### PR TITLE
Restructure library, bugfixes and extension of various functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,13 @@ find_package(OpenSSL REQUIRED)
 add_subdirectory(lib)
 
 # executable code
-add_subdirectory(src)
+option(BUILD_EXAMPLES "Build charge_point and central_system binaries." OFF)
+if(BUILD_EXAMPLES)
+    message("Building libocpp example binaries.")
+    add_subdirectory(src)
+else()
+    message("Not building libocpp example binaries.")
+endif()
 
 # auxillary files
 add_subdirectory(aux)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(OCPP VERSION 0.1
              DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
              LANGUAGES CXX)
 
+# enable compiler warnings
+add_compile_options(-Wall -Wextra -pedantic)
+# unused functions in a library should not be problematic
+add_compile_options(-Wno-unused)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,8 +61,8 @@ find_package(OpenSSL REQUIRED)
 add_subdirectory(lib)
 
 # executable code
-option(BUILD_EXAMPLES "Build charge_point and central_system binaries." OFF)
-if(BUILD_EXAMPLES)
+option(LIBOCPP_BUILD_EXAMPLES "Build charge_point and central_system binaries." OFF)
+if(LIBOCPP_BUILD_EXAMPLES)
     message("Building libocpp example binaries.")
     add_subdirectory(src)
 else()

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This is a C++ library implementation of OCPP, currently in Version 1.6 (https://www.openchargealliance.org/protocols/ocpp-16/) for utilization within the EVerest framework. It enables local chargepoints to communicate with cloud backends for remote management and to allow for payed charging.
 
+The following table shows the current support for the listed feature profiles and application notes. The aim is to fully support all of these in the future.
+
+| Feature-Profile | Supported |
+| --- | --- |
+| Core | :heavy_check_mark: yes |
+| Firmware Management | :x: |
+| Local Auth List Management | :x: |
+| Reservation | :x: |
+| Smart Charging | :yellow_circle: partially |
+| Remote Trigger | :heavy_check_mark: yes |
+
+| Application Note | Supported |
+| --- | --- |
+| OCPP 1.6 Security Whitepaper (3rd edition) | :yellow_circle: partially<br>Supported: Security Profiles 1 & 2 (TLS with HTTP Basic Authentication)<br>No support yet for Profile 3 (TLS with Client Side Certificates)|
+| Using ISO 15118 Plug & Charge with OCPP 1.6 | :x: |
+
+
 All documentation and the issue tracking can be found in our main repository here: https://github.com/EVerest/everest
 
 ## Build instructions

--- a/aux/config-docker-tls.json
+++ b/aux/config-docker-tls.json
@@ -24,7 +24,7 @@
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",
-        "SupportedFeatureProfiles": "Core",
+        "SupportedFeatureProfiles": "Core,RemoteTrigger",
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true

--- a/aux/config-docker.json
+++ b/aux/config-docker.json
@@ -24,7 +24,7 @@
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",
-        "SupportedFeatureProfiles": "Core",
+        "SupportedFeatureProfiles": "Core,RemoteTrigger",
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true

--- a/aux/config.json
+++ b/aux/config.json
@@ -24,7 +24,7 @@
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",
-        "SupportedFeatureProfiles": "Core",
+        "SupportedFeatureProfiles": "Core,RemoteTrigger",
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true

--- a/aux/profile_schemas/ocpp1_6/Config.json
+++ b/aux/profile_schemas/ocpp1_6/Config.json
@@ -14,6 +14,10 @@
         "Core": {
             "type": "object",
             "$ref": "Core.json"
+        },
+        "SmartCharging": {
+            "type": "object",
+            "$ref": "SmartCharging.json"
         }
     },
     "additionalProperties": false

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -53,9 +53,6 @@ private:
     std::shared_ptr<ChargePointConfiguration> configuration;
     std::unique_ptr<Everest::SteadyTimer> heartbeat_timer;
     std::unique_ptr<Everest::SteadyTimer> boot_notification_timer;
-    // Everest::SteadyTimer* meter_values_sample_timer; // TODO(kai): decide if we need a continuous sampling of meter
-    // values independent of transactions - maybe on connector 0, but that could be done in the chargingsession as
-    // well...
     std::unique_ptr<Everest::SystemTimer> clock_aligned_meter_values_timer;
     std::chrono::time_point<std::chrono::system_clock> clock_aligned_meter_values_time_point;
     std::map<int32_t, std::vector<MeterValue>> meter_values;

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -33,7 +33,7 @@
 #include <ocpp1_6/messages/StopTransaction.hpp>
 #include <ocpp1_6/messages/UnlockConnector.hpp>
 #include <ocpp1_6/types.hpp>
-#include <ocpp1_6/websocket.hpp>
+#include <ocpp1_6/websocket/websocket.hpp>
 
 namespace ocpp1_6 {
 

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -205,8 +205,10 @@ public:
     /// \returns true if this state change was possible
     bool resume_charging(int32_t connector);
 
-    // /// EV/EVSE indicates that charging has finished
-    // bool stop_charging(int32_t connector);
+    /// \brief EV was disconnected
+    /// \returns true if this state change was possible
+    bool plug_disconnected(int32_t connector);
+
     /// EV/EVSE indicates that an error with the given \p error_code occured
     /// \returns true if this state change was possible
     bool error(int32_t connector, ChargePointErrorCode error_code);
@@ -251,8 +253,6 @@ public:
     // FIXME: rework the following API functions, do we want to expose them?
     // insert plug
     // bool plug_connected(int32_t connector);
-    // remove plug
-    // bool plug_disconnected(int32_t connector);
 };
 
 } // namespace ocpp1_6

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -158,7 +158,7 @@ public:
     /// \brief Allows the exchange of arbitrary \p data identified by a \p vendorId and \p messageId with a central
     /// system \returns the DataTransferResponse
     DataTransferResponse data_transfer(const CiString255Type& vendorId, const CiString50Type& messageId,
-                                       const std::string data);
+                                       const std::string& data);
 
     /// registers a \p callback function that can be used to receive a arbitrary data transfer for the given \p vendorId
     /// and \p messageId

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -87,10 +87,13 @@ private:
     std::thread reset_thread;
 
     // callbacks
-    std::function<void(int32_t connector)> start_charging_callback;
-    std::function<void(int32_t connector)> stop_charging_callback;
+    std::function<bool(int32_t connector)> enable_evse_callback;
+    std::function<bool(int32_t connector)> disable_evse_callback;
+    std::function<bool(int32_t connector)> pause_charging_callback;
+    std::function<bool(int32_t connector)> resume_charging_callback;
+    std::function<bool(int32_t connector)> cancel_charging_callback;
     std::function<bool(int32_t connector)> unlock_connector_callback;
-    std::function<void(int32_t connector, double max_current)> set_max_current_callback;
+    std::function<bool(int32_t connector, double max_current)> set_max_current_callback;
 
     /// \brief This function is called after a successful connection to the Websocket
     void connected_callback();
@@ -214,6 +217,12 @@ public:
     /// \returns true if this state change was possible
     bool permanent_fault(int32_t connector);
 
+    /// \brief registers a \p callback function that can be used to enable the evse
+    void register_enable_evse_callback(const std::function<bool(int32_t connector)>& callback);
+
+    /// \brief registers a \p callback function that can be used to disable the evse
+    void register_disable_evse_callback(const std::function<bool(int32_t connector)>& callback);
+
     /// \brief registers a \p callback function that can be used to pause charging
     void register_pause_charging_callback(const std::function<bool(int32_t connector)>& callback);
 
@@ -235,7 +244,7 @@ public:
     void register_unlock_connector_callback(const std::function<bool(int32_t connector)>& callback);
 
     /// registers a \p callback function that can be used to set a max_current on a given connector
-    void register_set_max_current_callback(const std::function<void(int32_t connector, double max_current)>& callback);
+    void register_set_max_current_callback(const std::function<bool(int32_t connector, double max_current)>& callback);
 
     // FIXME: rework the following API functions, do we want to expose them?
     // insert plug

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -10,6 +10,7 @@
 
 #include <everest/timer.hpp>
 
+#include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/charge_point_state_machine.hpp>
 #include <ocpp1_6/charging_session.hpp>
 #include <ocpp1_6/message_queue.hpp>
@@ -36,8 +37,6 @@
 #include <ocpp1_6/websocket/websocket.hpp>
 
 namespace ocpp1_6 {
-
-class ChargePointConfiguration;
 
 /// \brief Contains a ChargePoint implementation compatible with OCPP-J 1.6
 class ChargePoint {

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -32,6 +32,7 @@
 #include <ocpp1_6/messages/StartTransaction.hpp>
 #include <ocpp1_6/messages/StatusNotification.hpp>
 #include <ocpp1_6/messages/StopTransaction.hpp>
+#include <ocpp1_6/messages/TriggerMessage.hpp>
 #include <ocpp1_6/messages/UnlockConnector.hpp>
 #include <ocpp1_6/types.hpp>
 #include <ocpp1_6/websocket/websocket.hpp>
@@ -138,6 +139,9 @@ private:
     void handleSetChargingProfileRequest(Call<SetChargingProfileRequest> call);
     void handleGetCompositeScheduleRequest(Call<GetCompositeScheduleRequest> call);
     void handleClearChargingProfileRequest(Call<ClearChargingProfileRequest> call);
+
+    // RemoteTrigger profile
+    void handleTriggerMessageRequest(Call<TriggerMessageRequest> call);
 
 public:
     /// \brief Creates a ChargePoint object with the provided \p configuration

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -81,6 +81,9 @@ private:
     std::map<MessageId, std::thread> remote_stop_transaction;  // FIXME: this should be done differently
     std::mutex remote_stop_transaction_mutex;                  // FIXME: this should be done differently
 
+    std::map<std::string, std::map<std::string, std::function<void(const std::string data)>>> data_transfer_callbacks;
+    std::mutex data_transfer_callbacks_mutex;
+
     std::thread reset_thread;
 
     // callbacks
@@ -156,6 +159,11 @@ public:
     /// system \returns the DataTransferResponse
     DataTransferResponse data_transfer(const CiString255Type& vendorId, const CiString50Type& messageId,
                                        const std::string data);
+
+    /// registers a \p callback function that can be used to receive a arbitrary data transfer for the given \p vendorId
+    /// and \p messageId
+    void register_data_transfer_callback(const CiString255Type& vendorId, const CiString50Type& messageId,
+                                         const std::function<void(const std::string data)>& callback);
 
     /// \brief Stores the given \p powermeter values for the given \p connector
     void receive_power_meter(int32_t connector, json powermeter);

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -10,7 +10,6 @@
 
 #include <everest/timer.hpp>
 
-#include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/charge_point_state_machine.hpp>
 #include <ocpp1_6/charging_session.hpp>
 #include <ocpp1_6/message_queue.hpp>
@@ -37,6 +36,8 @@
 #include <ocpp1_6/websocket.hpp>
 
 namespace ocpp1_6 {
+
+class ChargePointConfiguration;
 
 /// \brief Contains a ChargePoint implementation compatible with OCPP-J 1.6
 class ChargePoint {

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -96,6 +96,7 @@ private:
     /// \brief This function is called after a successful connection to the Websocket
     void connected_callback();
     void message_callback(const std::string& message);
+    void handle_message(const json& json_message, MessageType message_type);
     bool allowed_to_send_message(json::array_t message_type);
     template <class T> bool send(Call<T> call);
     template <class T> std::future<EnhancedMessage> send_async(Call<T> call);

--- a/include/ocpp1_6/charge_point_configuration.hpp
+++ b/include/ocpp1_6/charge_point_configuration.hpp
@@ -230,20 +230,28 @@ public:
 
     // Core Profile end
 
+    // SmartCharging Profile
     int32_t getChargeProfileMaxStackLevel();
     KeyValue getChargeProfileMaxStackLevelKeyValue();
 
+    // SmartCharging Profile
     std::string getChargingScheduleAllowedChargingRateUnit();
     KeyValue getChargingScheduleAllowedChargingRateUnitKeyValue();
+    std::vector<ChargingRateUnit> getChargingScheduleAllowedChargingRateUnitVector();
 
+    // SmartCharging Profile
     int32_t getChargingScheduleMaxPeriods();
     KeyValue getChargingScheduleMaxPeriodsKeyValue();
 
-    bool getConnectorSwitch3to1PhaseSupported();
-    KeyValue getConnectorSwitch3to1PhaseSupportedKeyValue();
+    // SmartCharging Profile - optional
+    boost::optional<bool> getConnectorSwitch3to1PhaseSupported();
+    boost::optional<KeyValue> getConnectorSwitch3to1PhaseSupportedKeyValue();
 
+    // SmartCharging Profile
     int32_t getMaxChargingProfilesInstalled();
     KeyValue getMaxChargingProfilesInstalledKeyValue();
+
+    // SmartCharging Profile end
 
     boost::optional<KeyValue> get(CiString50Type key);
 

--- a/include/ocpp1_6/charge_point_configuration.hpp
+++ b/include/ocpp1_6/charge_point_configuration.hpp
@@ -34,15 +34,15 @@ public:
     // Internal config options
     std::string getChargePointId();
     std::string getCentralSystemURI();
-    boost::optional<std::string> getChargeBoxSerialNumber();
-    std::string getChargePointModel();
-    boost::optional<std::string> getChargePointSerialNumber();
-    std::string getChargePointVendor();
-    std::string getFirmwareVersion();
-    boost::optional<std::string> getICCID();
-    boost::optional<std::string> getIMSI();
-    boost::optional<std::string> getMeterSerialNumber();
-    boost::optional<std::string> getMeterType();
+    boost::optional<CiString25Type> getChargeBoxSerialNumber();
+    CiString20Type getChargePointModel();
+    boost::optional<CiString25Type> getChargePointSerialNumber();
+    CiString20Type getChargePointVendor();
+    CiString50Type getFirmwareVersion();
+    boost::optional<CiString20Type> getICCID();
+    boost::optional<CiString20Type> getIMSI();
+    boost::optional<CiString25Type> getMeterSerialNumber();
+    boost::optional<CiString25Type> getMeterType();
     int32_t getWebsocketReconnectInterval();
 
     std::string getSupportedCiphers();

--- a/include/ocpp1_6/charge_point_state_machine.hpp
+++ b/include/ocpp1_6/charge_point_state_machine.hpp
@@ -95,9 +95,14 @@ struct ChargePointStateMachine {
     StateHandleType sd_unavailable{{State::Unavailable, "Unavailable"}};
     StateHandleType sd_faulted{{State::Faulted, "Faulted"}};
 
+    // track current state
+    ChargePointStatus state;
+
     std::function<void(ChargePointStatus status)> status_notification_callback;
 
     explicit ChargePointStateMachine(const std::function<void(ChargePointStatus status)>& status_notification_callback);
+
+    ChargePointStatus get_state();
 };
 
 using ChargePointStateMachineController = fsm::async::PThreadController<ChargePointStateMachine::StateHandleType>;
@@ -127,6 +132,8 @@ public:
     void run(std::map<int32_t, ocpp1_6::AvailabilityType> connector_availability);
 
     void submit_event(int32_t connector, EventBaseType event);
+
+    ChargePointStatus get_state(int32_t connector);
 };
 
 } // namespace ocpp1_6

--- a/include/ocpp1_6/charge_point_state_machine.hpp
+++ b/include/ocpp1_6/charge_point_state_machine.hpp
@@ -12,53 +12,16 @@
 
 namespace ocpp1_6 {
 
-enum class ChargePointStatusTransition
-{
-    A2_UsageInitiated,
-    A3_UsageInitiatedWithoutAuthorization,
-    A4_UsageInitiatedEVDoesNotStartCharging,
-    A5_UsageInitiatedEVSEDoesNotAllowCharging,
-    A7_ReserveNowReservesConnector,
-    A8_ChangeAvailabilityToUnavailable,
-    A9_FaultDetected,
-    B1_IntendedUsageIsEnded,
-    B3_PrerequisitesForChargingMetAndChargingStarts,
-    B4_PrerequisitesForChargingMetEVDoesNotStartCharging,
-    B5_PrerequisitesForChargingMetEVSEDoesNotAllowCharging,
-    B6_TimedOut, // Usage was initiated but ID Tag was not presented within timeout
-    B9_FaultDetected,
-    C1_ChargingSessionEndsNoUserActionRequired, // e.g. fixed cable removed on EV side
-    C4_ChargingStopsUponEVRequest,
-    C5_ChargingStopsUponEVSERequest,
-    C6_TransactionStoppedAndUserActionRequired, // e.g. remove cable leave parking bay
-    C8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable,
-    C9_FaultDetected,
-    D1_ChargingSessionEndsNoUserActionRequired,
-    D3_ChargingResumesUponEVRequest,
-    D5_ChargingSuspendedByEVSE,
-    D6_TransactionStoppedNoUserActionRequired,
-    D8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable,
-    D9_FaultDetected,
-    E1_ChargingSessionEndsNoUserActionRequired,
-    E3_ChargingResumesEVSERestrictionLifted,
-    E4_EVSERestrictionLiftedEVDoesNotStartCharging,
-    E6_TransactionStoppedAndUserActionRequired,
-    E8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable,
-    E9_FaultDetected,
-    F1_AllUserActionsCompleted,
-    F2_UsersRestartChargingSession, // cable reconnect, ID Tag presented again -> creates new transaction
-    F8_AllUserActionsCompletedConnectorScheduledToBecomeUnavailable,
-    F9_FaultDetected,
-    G1_ReservationExpiresOrCancelReservationReceived,
-    G2_ReservationIdentityPresented,
-    G8_ReservationExpiresOrCancelReservationReceivedConnectorScheduledToBecomeUnavailable,
-    G9_FaultDetected,
-    H1_ConnectorSetAvailableByChangeAvailability,
-    H2_ConnectorSetAvailableAfterUserInteractedWithChargePoint,
-    H3_ConnectorSetAvailableNoUserActionRequiredToStartCharging,
-    H4_ConnectorSetAvailableNoUserActionRequiredEVDoesNotStartCharging,
-    H5_ConnectorSetAvailableNoUserActionRequiredEVSEDoesNotAllowCharging,
-    H9_FaultDetected,
+enum class ChargePointStatusTransition {
+    BecomeAvailable,
+    UsageInitiated,
+    StartCharging,
+    PauseChargingEV,
+    PauseChargingEVSE,
+    ReserveConnector,
+    TransactionStoppedAndUserActionRequired,
+    ChangeAvailabilityToUnavailable,
+    FaultDetected,
     I1_ReturnToAvailable,
     I2_ReturnToPreparing,
     I3_ReturnToCharging,
@@ -71,87 +34,21 @@ enum class ChargePointStatusTransition
 
 using EventTypeFactory = fsm::utils::IdentifiableTypeFactory<ChargePointStatusTransition>;
 
-using Event_A2_UsageInitiated = EventTypeFactory::Derived<ChargePointStatusTransition::A2_UsageInitiated>;
-using Event_A3_UsageInitiatedWithoutAuthorization =
-    EventTypeFactory::Derived<ChargePointStatusTransition::A3_UsageInitiatedWithoutAuthorization>;
-using Event_A4_UsageInitiatedEVDoesNotStartCharging =
-    EventTypeFactory::Derived<ChargePointStatusTransition::A4_UsageInitiatedEVDoesNotStartCharging>;
-using Event_A5_UsageInitiatedEVSEDoesNotAllowCharging =
-    EventTypeFactory::Derived<ChargePointStatusTransition::A5_UsageInitiatedEVSEDoesNotAllowCharging>;
-using Event_A7_ReserveNowReservesConnector =
-    EventTypeFactory::Derived<ChargePointStatusTransition::A7_ReserveNowReservesConnector>;
-using Event_A8_ChangeAvailabilityToUnavailable =
-    EventTypeFactory::Derived<ChargePointStatusTransition::A8_ChangeAvailabilityToUnavailable>;
-using Event_A9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::A9_FaultDetected>;
-using Event_B1_IntendedUsageIsEnded = EventTypeFactory::Derived<ChargePointStatusTransition::B1_IntendedUsageIsEnded>;
-using Event_B3_PrerequisitesForChargingMetAndChargingStarts =
-    EventTypeFactory::Derived<ChargePointStatusTransition::B3_PrerequisitesForChargingMetAndChargingStarts>;
-using Event_B4_PrerequisitesForChargingMetEVDoesNotStartCharging =
-    EventTypeFactory::Derived<ChargePointStatusTransition::B4_PrerequisitesForChargingMetEVDoesNotStartCharging>;
-using Event_B5_PrerequisitesForChargingMetEVSEDoesNotAllowCharging =
-    EventTypeFactory::Derived<ChargePointStatusTransition::B5_PrerequisitesForChargingMetEVSEDoesNotAllowCharging>;
-using Event_B6_TimedOut = EventTypeFactory::Derived<ChargePointStatusTransition::B6_TimedOut>;
-using Event_B9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::B9_FaultDetected>;
-using Event_C1_ChargingSessionEndsNoUserActionRequired =
-    EventTypeFactory::Derived<ChargePointStatusTransition::C1_ChargingSessionEndsNoUserActionRequired>;
-using Event_C4_ChargingStopsUponEVRequest =
-    EventTypeFactory::Derived<ChargePointStatusTransition::C4_ChargingStopsUponEVRequest>;
-using Event_C5_ChargingStopsUponEVSERequest =
-    EventTypeFactory::Derived<ChargePointStatusTransition::C5_ChargingStopsUponEVSERequest>;
-using Event_C6_TransactionStoppedAndUserActionRequired =
-    EventTypeFactory::Derived<ChargePointStatusTransition::C6_TransactionStoppedAndUserActionRequired>;
-using Event_C8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable = EventTypeFactory::Derived<
-    ChargePointStatusTransition::C8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable>;
-using Event_C9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::C9_FaultDetected>;
-using Event_D1_ChargingSessionEndsNoUserActionRequired =
-    EventTypeFactory::Derived<ChargePointStatusTransition::D1_ChargingSessionEndsNoUserActionRequired>;
-using Event_D3_ChargingResumesUponEVRequest =
-    EventTypeFactory::Derived<ChargePointStatusTransition::D3_ChargingResumesUponEVRequest>;
-using Event_D5_ChargingSuspendedByEVSE =
-    EventTypeFactory::Derived<ChargePointStatusTransition::D5_ChargingSuspendedByEVSE>;
-using Event_D6_TransactionStoppedNoUserActionRequired =
-    EventTypeFactory::Derived<ChargePointStatusTransition::D6_TransactionStoppedNoUserActionRequired>;
-using Event_D8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable = EventTypeFactory::Derived<
-    ChargePointStatusTransition::D8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable>;
-using Event_D9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::D9_FaultDetected>;
-using Event_E1_ChargingSessionEndsNoUserActionRequired =
-    EventTypeFactory::Derived<ChargePointStatusTransition::E1_ChargingSessionEndsNoUserActionRequired>;
-using Event_E3_ChargingResumesEVSERestrictionLifted =
-    EventTypeFactory::Derived<ChargePointStatusTransition::E3_ChargingResumesEVSERestrictionLifted>;
-using Event_E4_EVSERestrictionLiftedEVDoesNotStartCharging =
-    EventTypeFactory::Derived<ChargePointStatusTransition::E4_EVSERestrictionLiftedEVDoesNotStartCharging>;
-using Event_E6_TransactionStoppedAndUserActionRequired =
-    EventTypeFactory::Derived<ChargePointStatusTransition::E6_TransactionStoppedAndUserActionRequired>;
-using Event_E8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable = EventTypeFactory::Derived<
-    ChargePointStatusTransition::E8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable>;
-using Event_E9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::E9_FaultDetected>;
-using Event_F1_AllUserActionsCompleted =
-    EventTypeFactory::Derived<ChargePointStatusTransition::F1_AllUserActionsCompleted>;
-using Event_F2_UsersRestartChargingSession =
-    EventTypeFactory::Derived<ChargePointStatusTransition::F2_UsersRestartChargingSession>;
-using Event_F8_AllUserActionsCompletedConnectorScheduledToBecomeUnavailable = EventTypeFactory::Derived<
-    ChargePointStatusTransition::F8_AllUserActionsCompletedConnectorScheduledToBecomeUnavailable>;
-using Event_F9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::F9_FaultDetected>;
-using Event_G1_ReservationExpiresOrCancelReservationReceived =
-    EventTypeFactory::Derived<ChargePointStatusTransition::G1_ReservationExpiresOrCancelReservationReceived>;
-using Event_G2_ReservationIdentityPresented =
-    EventTypeFactory::Derived<ChargePointStatusTransition::G2_ReservationIdentityPresented>;
-using Event_G8_ReservationExpiresOrCancelReservationReceivedConnectorScheduledToBecomeUnavailable =
-    EventTypeFactory::Derived<
-        ChargePointStatusTransition::
-            G8_ReservationExpiresOrCancelReservationReceivedConnectorScheduledToBecomeUnavailable>;
-using Event_G9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::G9_FaultDetected>;
-using Event_H1_ConnectorSetAvailableByChangeAvailability =
-    EventTypeFactory::Derived<ChargePointStatusTransition::H1_ConnectorSetAvailableByChangeAvailability>;
-using Event_H2_ConnectorSetAvailableAfterUserInteractedWithChargePoint =
-    EventTypeFactory::Derived<ChargePointStatusTransition::H2_ConnectorSetAvailableAfterUserInteractedWithChargePoint>;
-using Event_H3_ConnectorSetAvailableNoUserActionRequiredToStartCharging =
-    EventTypeFactory::Derived<ChargePointStatusTransition::H3_ConnectorSetAvailableNoUserActionRequiredToStartCharging>;
-using Event_H4_ConnectorSetAvailableNoUserActionRequiredEVDoesNotStartCharging = EventTypeFactory::Derived<
-    ChargePointStatusTransition::H4_ConnectorSetAvailableNoUserActionRequiredEVDoesNotStartCharging>;
-using Event_H5_ConnectorSetAvailableNoUserActionRequiredEVSEDoesNotAllowCharging = EventTypeFactory::Derived<
-    ChargePointStatusTransition::H5_ConnectorSetAvailableNoUserActionRequiredEVSEDoesNotAllowCharging>;
-using Event_H9_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::H9_FaultDetected>;
+using Event_UsageInitiated = EventTypeFactory::Derived<ChargePointStatusTransition::UsageInitiated>;
+using Event_StartCharging =
+    EventTypeFactory::Derived<ChargePointStatusTransition::StartCharging>;
+using Event_PauseChargingEV =
+    EventTypeFactory::Derived<ChargePointStatusTransition::PauseChargingEV>;
+using Event_PauseChargingEVSE =
+    EventTypeFactory::Derived<ChargePointStatusTransition::PauseChargingEVSE>;
+using Event_ReserveConnector =
+    EventTypeFactory::Derived<ChargePointStatusTransition::ReserveConnector>;
+using Event_ChangeAvailabilityToUnavailable =
+    EventTypeFactory::Derived<ChargePointStatusTransition::ChangeAvailabilityToUnavailable>;
+using Event_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::FaultDetected>;
+using Event_BecomeAvailable = EventTypeFactory::Derived<ChargePointStatusTransition::BecomeAvailable>;
+using Event_TransactionStoppedAndUserActionRequired =
+    EventTypeFactory::Derived<ChargePointStatusTransition::TransactionStoppedAndUserActionRequired>;
 using Event_I1_ReturnToAvailable = EventTypeFactory::Derived<ChargePointStatusTransition::I1_ReturnToAvailable>;
 using Event_I2_ReturnToPreparing = EventTypeFactory::Derived<ChargePointStatusTransition::I2_ReturnToPreparing>;
 using Event_I3_ReturnToCharging = EventTypeFactory::Derived<ChargePointStatusTransition::I3_ReturnToCharging>;
@@ -161,11 +58,10 @@ using Event_I6_ReturnToFinishing = EventTypeFactory::Derived<ChargePointStatusTr
 using Event_I7_ReturnToReserved = EventTypeFactory::Derived<ChargePointStatusTransition::I7_ReturnToReserved>;
 using Event_I8_ReturnToUnavailable = EventTypeFactory::Derived<ChargePointStatusTransition::I8_ReturnToUnavailable>;
 
-using EventBufferType = std::aligned_union_t<0, Event_A2_UsageInitiated>;
+using EventBufferType = std::aligned_union_t<0, Event_UsageInitiated>;
 using EventBaseType = EventTypeFactory::Base;
 
-enum class State
-{
+enum class State {
     Available,
     Preparing,
     Charging,

--- a/include/ocpp1_6/charging_session.hpp
+++ b/include/ocpp1_6/charging_session.hpp
@@ -5,7 +5,6 @@
 
 #include <memory>
 
-#include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/ocpp_types.hpp>
 #include <ocpp1_6/types.hpp>
 

--- a/include/ocpp1_6/enums.hpp
+++ b/include/ocpp1_6/enums.hpp
@@ -24,7 +24,7 @@ std::string authorization_status_to_string(AuthorizationStatus e);
 
 /// \brief Converts the given std::string \p s to AuthorizationStatus
 /// \returns a AuthorizationStatus from a string representation
-AuthorizationStatus string_to_authorization_status(std::string s);
+AuthorizationStatus string_to_authorization_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AuthorizationStatus \p authorization_status to the given output
@@ -46,7 +46,7 @@ std::string registration_status_to_string(RegistrationStatus e);
 
 /// \brief Converts the given std::string \p s to RegistrationStatus
 /// \returns a RegistrationStatus from a string representation
-RegistrationStatus string_to_registration_status(std::string s);
+RegistrationStatus string_to_registration_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RegistrationStatus \p registration_status to the given output
@@ -67,7 +67,7 @@ std::string cancel_reservation_status_to_string(CancelReservationStatus e);
 
 /// \brief Converts the given std::string \p s to CancelReservationStatus
 /// \returns a CancelReservationStatus from a string representation
-CancelReservationStatus string_to_cancel_reservation_status(std::string s);
+CancelReservationStatus string_to_cancel_reservation_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given CancelReservationStatus \p cancel_reservation_status to the
@@ -88,7 +88,7 @@ std::string availability_type_to_string(AvailabilityType e);
 
 /// \brief Converts the given std::string \p s to AvailabilityType
 /// \returns a AvailabilityType from a string representation
-AvailabilityType string_to_availability_type(std::string s);
+AvailabilityType string_to_availability_type(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AvailabilityType \p availability_type to the given output
@@ -110,7 +110,7 @@ std::string availability_status_to_string(AvailabilityStatus e);
 
 /// \brief Converts the given std::string \p s to AvailabilityStatus
 /// \returns a AvailabilityStatus from a string representation
-AvailabilityStatus string_to_availability_status(std::string s);
+AvailabilityStatus string_to_availability_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AvailabilityStatus \p availability_status to the given output
@@ -133,7 +133,7 @@ std::string configuration_status_to_string(ConfigurationStatus e);
 
 /// \brief Converts the given std::string \p s to ConfigurationStatus
 /// \returns a ConfigurationStatus from a string representation
-ConfigurationStatus string_to_configuration_status(std::string s);
+ConfigurationStatus string_to_configuration_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ConfigurationStatus \p configuration_status to the given output
@@ -154,7 +154,7 @@ std::string clear_cache_status_to_string(ClearCacheStatus e);
 
 /// \brief Converts the given std::string \p s to ClearCacheStatus
 /// \returns a ClearCacheStatus from a string representation
-ClearCacheStatus string_to_clear_cache_status(std::string s);
+ClearCacheStatus string_to_clear_cache_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ClearCacheStatus \p clear_cache_status to the given output
@@ -176,7 +176,7 @@ std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e
 
 /// \brief Converts the given std::string \p s to ChargingProfilePurposeType
 /// \returns a ChargingProfilePurposeType from a string representation
-ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s);
+ChargingProfilePurposeType string_to_charging_profile_purpose_type(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfilePurposeType \p charging_profile_purpose_type to
@@ -197,7 +197,7 @@ std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e
 
 /// \brief Converts the given std::string \p s to ClearChargingProfileStatus
 /// \returns a ClearChargingProfileStatus from a string representation
-ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s);
+ClearChargingProfileStatus string_to_clear_charging_profile_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ClearChargingProfileStatus \p clear_charging_profile_status to
@@ -220,7 +220,7 @@ std::string data_transfer_status_to_string(DataTransferStatus e);
 
 /// \brief Converts the given std::string \p s to DataTransferStatus
 /// \returns a DataTransferStatus from a string representation
-DataTransferStatus string_to_data_transfer_status(std::string s);
+DataTransferStatus string_to_data_transfer_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given DataTransferStatus \p data_transfer_status to the given output
@@ -243,7 +243,7 @@ std::string diagnostics_status_to_string(DiagnosticsStatus e);
 
 /// \brief Converts the given std::string \p s to DiagnosticsStatus
 /// \returns a DiagnosticsStatus from a string representation
-DiagnosticsStatus string_to_diagnostics_status(std::string s);
+DiagnosticsStatus string_to_diagnostics_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given DiagnosticsStatus \p diagnostics_status to the given output
@@ -269,7 +269,7 @@ std::string firmware_status_to_string(FirmwareStatus e);
 
 /// \brief Converts the given std::string \p s to FirmwareStatus
 /// \returns a FirmwareStatus from a string representation
-FirmwareStatus string_to_firmware_status(std::string s);
+FirmwareStatus string_to_firmware_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given FirmwareStatus \p firmware_status to the given output stream \p
@@ -290,7 +290,7 @@ std::string charging_rate_unit_to_string(ChargingRateUnit e);
 
 /// \brief Converts the given std::string \p s to ChargingRateUnit
 /// \returns a ChargingRateUnit from a string representation
-ChargingRateUnit string_to_charging_rate_unit(std::string s);
+ChargingRateUnit string_to_charging_rate_unit(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingRateUnit \p charging_rate_unit to the given output
@@ -311,7 +311,7 @@ std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e
 
 /// \brief Converts the given std::string \p s to GetCompositeScheduleStatus
 /// \returns a GetCompositeScheduleStatus from a string representation
-GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s);
+GetCompositeScheduleStatus string_to_get_composite_schedule_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given GetCompositeScheduleStatus \p get_composite_schedule_status to
@@ -338,7 +338,7 @@ std::string reading_context_to_string(ReadingContext e);
 
 /// \brief Converts the given std::string \p s to ReadingContext
 /// \returns a ReadingContext from a string representation
-ReadingContext string_to_reading_context(std::string s);
+ReadingContext string_to_reading_context(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ReadingContext \p reading_context to the given output stream \p
@@ -359,7 +359,7 @@ std::string value_format_to_string(ValueFormat e);
 
 /// \brief Converts the given std::string \p s to ValueFormat
 /// \returns a ValueFormat from a string representation
-ValueFormat string_to_value_format(std::string s);
+ValueFormat string_to_value_format(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ValueFormat \p value_format to the given output stream \p os
@@ -400,7 +400,7 @@ std::string measurand_to_string(Measurand e);
 
 /// \brief Converts the given std::string \p s to Measurand
 /// \returns a Measurand from a string representation
-Measurand string_to_measurand(std::string s);
+Measurand string_to_measurand(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Measurand \p measurand to the given output stream \p os
@@ -429,7 +429,7 @@ std::string phase_to_string(Phase e);
 
 /// \brief Converts the given std::string \p s to Phase
 /// \returns a Phase from a string representation
-Phase string_to_phase(std::string s);
+Phase string_to_phase(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Phase \p phase to the given output stream \p os
@@ -453,7 +453,7 @@ std::string location_to_string(Location e);
 
 /// \brief Converts the given std::string \p s to Location
 /// \returns a Location from a string representation
-Location string_to_location(std::string s);
+Location string_to_location(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Location \p location to the given output stream \p os
@@ -489,7 +489,7 @@ std::string unit_of_measure_to_string(UnitOfMeasure e);
 
 /// \brief Converts the given std::string \p s to UnitOfMeasure
 /// \returns a UnitOfMeasure from a string representation
-UnitOfMeasure string_to_unit_of_measure(std::string s);
+UnitOfMeasure string_to_unit_of_measure(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UnitOfMeasure \p unit_of_measure to the given output stream \p
@@ -511,7 +511,7 @@ std::string charging_profile_kind_type_to_string(ChargingProfileKindType e);
 
 /// \brief Converts the given std::string \p s to ChargingProfileKindType
 /// \returns a ChargingProfileKindType from a string representation
-ChargingProfileKindType string_to_charging_profile_kind_type(std::string s);
+ChargingProfileKindType string_to_charging_profile_kind_type(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfileKindType \p charging_profile_kind_type to the
@@ -532,7 +532,7 @@ std::string recurrency_kind_type_to_string(RecurrencyKindType e);
 
 /// \brief Converts the given std::string \p s to RecurrencyKindType
 /// \returns a RecurrencyKindType from a string representation
-RecurrencyKindType string_to_recurrency_kind_type(std::string s);
+RecurrencyKindType string_to_recurrency_kind_type(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RecurrencyKindType \p recurrency_kind_type to the given output
@@ -553,7 +553,7 @@ std::string remote_start_stop_status_to_string(RemoteStartStopStatus e);
 
 /// \brief Converts the given std::string \p s to RemoteStartStopStatus
 /// \returns a RemoteStartStopStatus from a string representation
-RemoteStartStopStatus string_to_remote_start_stop_status(std::string s);
+RemoteStartStopStatus string_to_remote_start_stop_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RemoteStartStopStatus \p remote_start_stop_status to the given
@@ -577,7 +577,7 @@ std::string reservation_status_to_string(ReservationStatus e);
 
 /// \brief Converts the given std::string \p s to ReservationStatus
 /// \returns a ReservationStatus from a string representation
-ReservationStatus string_to_reservation_status(std::string s);
+ReservationStatus string_to_reservation_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ReservationStatus \p reservation_status to the given output
@@ -598,7 +598,7 @@ std::string reset_type_to_string(ResetType e);
 
 /// \brief Converts the given std::string \p s to ResetType
 /// \returns a ResetType from a string representation
-ResetType string_to_reset_type(std::string s);
+ResetType string_to_reset_type(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ResetType \p reset_type to the given output stream \p os
@@ -619,7 +619,7 @@ std::string reset_status_to_string(ResetStatus e);
 
 /// \brief Converts the given std::string \p s to ResetStatus
 /// \returns a ResetStatus from a string representation
-ResetStatus string_to_reset_status(std::string s);
+ResetStatus string_to_reset_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ResetStatus \p reset_status to the given output stream \p os
@@ -640,7 +640,7 @@ std::string update_type_to_string(UpdateType e);
 
 /// \brief Converts the given std::string \p s to UpdateType
 /// \returns a UpdateType from a string representation
-UpdateType string_to_update_type(std::string s);
+UpdateType string_to_update_type(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UpdateType \p update_type to the given output stream \p os
@@ -663,7 +663,7 @@ std::string update_status_to_string(UpdateStatus e);
 
 /// \brief Converts the given std::string \p s to UpdateStatus
 /// \returns a UpdateStatus from a string representation
-UpdateStatus string_to_update_status(std::string s);
+UpdateStatus string_to_update_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UpdateStatus \p update_status to the given output stream \p os
@@ -685,7 +685,7 @@ std::string charging_profile_status_to_string(ChargingProfileStatus e);
 
 /// \brief Converts the given std::string \p s to ChargingProfileStatus
 /// \returns a ChargingProfileStatus from a string representation
-ChargingProfileStatus string_to_charging_profile_status(std::string s);
+ChargingProfileStatus string_to_charging_profile_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfileStatus \p charging_profile_status to the given
@@ -720,7 +720,7 @@ std::string charge_point_error_code_to_string(ChargePointErrorCode e);
 
 /// \brief Converts the given std::string \p s to ChargePointErrorCode
 /// \returns a ChargePointErrorCode from a string representation
-ChargePointErrorCode string_to_charge_point_error_code(std::string s);
+ChargePointErrorCode string_to_charge_point_error_code(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargePointErrorCode \p charge_point_error_code to the given
@@ -748,7 +748,7 @@ std::string charge_point_status_to_string(ChargePointStatus e);
 
 /// \brief Converts the given std::string \p s to ChargePointStatus
 /// \returns a ChargePointStatus from a string representation
-ChargePointStatus string_to_charge_point_status(std::string s);
+ChargePointStatus string_to_charge_point_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargePointStatus \p charge_point_status to the given output
@@ -778,7 +778,7 @@ std::string reason_to_string(Reason e);
 
 /// \brief Converts the given std::string \p s to Reason
 /// \returns a Reason from a string representation
-Reason string_to_reason(std::string s);
+Reason string_to_reason(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Reason \p reason to the given output stream \p os
@@ -803,7 +803,7 @@ std::string message_trigger_to_string(MessageTrigger e);
 
 /// \brief Converts the given std::string \p s to MessageTrigger
 /// \returns a MessageTrigger from a string representation
-MessageTrigger string_to_message_trigger(std::string s);
+MessageTrigger string_to_message_trigger(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given MessageTrigger \p message_trigger to the given output stream \p
@@ -825,7 +825,7 @@ std::string trigger_message_status_to_string(TriggerMessageStatus e);
 
 /// \brief Converts the given std::string \p s to TriggerMessageStatus
 /// \returns a TriggerMessageStatus from a string representation
-TriggerMessageStatus string_to_trigger_message_status(std::string s);
+TriggerMessageStatus string_to_trigger_message_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given TriggerMessageStatus \p trigger_message_status to the given
@@ -847,7 +847,7 @@ std::string unlock_status_to_string(UnlockStatus e);
 
 /// \brief Converts the given std::string \p s to UnlockStatus
 /// \returns a UnlockStatus from a string representation
-UnlockStatus string_to_unlock_status(std::string s);
+UnlockStatus string_to_unlock_status(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UnlockStatus \p unlock_status to the given output stream \p os

--- a/include/ocpp1_6/enums.hpp
+++ b/include/ocpp1_6/enums.hpp
@@ -20,11 +20,11 @@ enum class AuthorizationStatus
 namespace conversions {
 /// \brief Converts the given AuthorizationStatus \p e to human readable string
 /// \returns a string representation of the AuthorizationStatus
-const std::string authorization_status_to_string(AuthorizationStatus e);
+std::string authorization_status_to_string(AuthorizationStatus e);
 
 /// \brief Converts the given std::string \p s to AuthorizationStatus
 /// \returns a AuthorizationStatus from a string representation
-const AuthorizationStatus string_to_authorization_status(std::string s);
+AuthorizationStatus string_to_authorization_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AuthorizationStatus \p authorization_status to the given output
@@ -42,11 +42,11 @@ enum class RegistrationStatus
 namespace conversions {
 /// \brief Converts the given RegistrationStatus \p e to human readable string
 /// \returns a string representation of the RegistrationStatus
-const std::string registration_status_to_string(RegistrationStatus e);
+std::string registration_status_to_string(RegistrationStatus e);
 
 /// \brief Converts the given std::string \p s to RegistrationStatus
 /// \returns a RegistrationStatus from a string representation
-const RegistrationStatus string_to_registration_status(std::string s);
+RegistrationStatus string_to_registration_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RegistrationStatus \p registration_status to the given output
@@ -63,11 +63,11 @@ enum class CancelReservationStatus
 namespace conversions {
 /// \brief Converts the given CancelReservationStatus \p e to human readable string
 /// \returns a string representation of the CancelReservationStatus
-const std::string cancel_reservation_status_to_string(CancelReservationStatus e);
+std::string cancel_reservation_status_to_string(CancelReservationStatus e);
 
 /// \brief Converts the given std::string \p s to CancelReservationStatus
 /// \returns a CancelReservationStatus from a string representation
-const CancelReservationStatus string_to_cancel_reservation_status(std::string s);
+CancelReservationStatus string_to_cancel_reservation_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given CancelReservationStatus \p cancel_reservation_status to the
@@ -84,11 +84,11 @@ enum class AvailabilityType
 namespace conversions {
 /// \brief Converts the given AvailabilityType \p e to human readable string
 /// \returns a string representation of the AvailabilityType
-const std::string availability_type_to_string(AvailabilityType e);
+std::string availability_type_to_string(AvailabilityType e);
 
 /// \brief Converts the given std::string \p s to AvailabilityType
 /// \returns a AvailabilityType from a string representation
-const AvailabilityType string_to_availability_type(std::string s);
+AvailabilityType string_to_availability_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AvailabilityType \p availability_type to the given output
@@ -106,11 +106,11 @@ enum class AvailabilityStatus
 namespace conversions {
 /// \brief Converts the given AvailabilityStatus \p e to human readable string
 /// \returns a string representation of the AvailabilityStatus
-const std::string availability_status_to_string(AvailabilityStatus e);
+std::string availability_status_to_string(AvailabilityStatus e);
 
 /// \brief Converts the given std::string \p s to AvailabilityStatus
 /// \returns a AvailabilityStatus from a string representation
-const AvailabilityStatus string_to_availability_status(std::string s);
+AvailabilityStatus string_to_availability_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AvailabilityStatus \p availability_status to the given output
@@ -129,11 +129,11 @@ enum class ConfigurationStatus
 namespace conversions {
 /// \brief Converts the given ConfigurationStatus \p e to human readable string
 /// \returns a string representation of the ConfigurationStatus
-const std::string configuration_status_to_string(ConfigurationStatus e);
+std::string configuration_status_to_string(ConfigurationStatus e);
 
 /// \brief Converts the given std::string \p s to ConfigurationStatus
 /// \returns a ConfigurationStatus from a string representation
-const ConfigurationStatus string_to_configuration_status(std::string s);
+ConfigurationStatus string_to_configuration_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ConfigurationStatus \p configuration_status to the given output
@@ -150,11 +150,11 @@ enum class ClearCacheStatus
 namespace conversions {
 /// \brief Converts the given ClearCacheStatus \p e to human readable string
 /// \returns a string representation of the ClearCacheStatus
-const std::string clear_cache_status_to_string(ClearCacheStatus e);
+std::string clear_cache_status_to_string(ClearCacheStatus e);
 
 /// \brief Converts the given std::string \p s to ClearCacheStatus
 /// \returns a ClearCacheStatus from a string representation
-const ClearCacheStatus string_to_clear_cache_status(std::string s);
+ClearCacheStatus string_to_clear_cache_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ClearCacheStatus \p clear_cache_status to the given output
@@ -172,11 +172,11 @@ enum class ChargingProfilePurposeType
 namespace conversions {
 /// \brief Converts the given ChargingProfilePurposeType \p e to human readable string
 /// \returns a string representation of the ChargingProfilePurposeType
-const std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e);
+std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e);
 
 /// \brief Converts the given std::string \p s to ChargingProfilePurposeType
 /// \returns a ChargingProfilePurposeType from a string representation
-const ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s);
+ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfilePurposeType \p charging_profile_purpose_type to
@@ -193,11 +193,11 @@ enum class ClearChargingProfileStatus
 namespace conversions {
 /// \brief Converts the given ClearChargingProfileStatus \p e to human readable string
 /// \returns a string representation of the ClearChargingProfileStatus
-const std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e);
+std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e);
 
 /// \brief Converts the given std::string \p s to ClearChargingProfileStatus
 /// \returns a ClearChargingProfileStatus from a string representation
-const ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s);
+ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ClearChargingProfileStatus \p clear_charging_profile_status to
@@ -216,11 +216,11 @@ enum class DataTransferStatus
 namespace conversions {
 /// \brief Converts the given DataTransferStatus \p e to human readable string
 /// \returns a string representation of the DataTransferStatus
-const std::string data_transfer_status_to_string(DataTransferStatus e);
+std::string data_transfer_status_to_string(DataTransferStatus e);
 
 /// \brief Converts the given std::string \p s to DataTransferStatus
 /// \returns a DataTransferStatus from a string representation
-const DataTransferStatus string_to_data_transfer_status(std::string s);
+DataTransferStatus string_to_data_transfer_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given DataTransferStatus \p data_transfer_status to the given output
@@ -239,11 +239,11 @@ enum class DiagnosticsStatus
 namespace conversions {
 /// \brief Converts the given DiagnosticsStatus \p e to human readable string
 /// \returns a string representation of the DiagnosticsStatus
-const std::string diagnostics_status_to_string(DiagnosticsStatus e);
+std::string diagnostics_status_to_string(DiagnosticsStatus e);
 
 /// \brief Converts the given std::string \p s to DiagnosticsStatus
 /// \returns a DiagnosticsStatus from a string representation
-const DiagnosticsStatus string_to_diagnostics_status(std::string s);
+DiagnosticsStatus string_to_diagnostics_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given DiagnosticsStatus \p diagnostics_status to the given output
@@ -265,11 +265,11 @@ enum class FirmwareStatus
 namespace conversions {
 /// \brief Converts the given FirmwareStatus \p e to human readable string
 /// \returns a string representation of the FirmwareStatus
-const std::string firmware_status_to_string(FirmwareStatus e);
+std::string firmware_status_to_string(FirmwareStatus e);
 
 /// \brief Converts the given std::string \p s to FirmwareStatus
 /// \returns a FirmwareStatus from a string representation
-const FirmwareStatus string_to_firmware_status(std::string s);
+FirmwareStatus string_to_firmware_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given FirmwareStatus \p firmware_status to the given output stream \p
@@ -286,11 +286,11 @@ enum class ChargingRateUnit
 namespace conversions {
 /// \brief Converts the given ChargingRateUnit \p e to human readable string
 /// \returns a string representation of the ChargingRateUnit
-const std::string charging_rate_unit_to_string(ChargingRateUnit e);
+std::string charging_rate_unit_to_string(ChargingRateUnit e);
 
 /// \brief Converts the given std::string \p s to ChargingRateUnit
 /// \returns a ChargingRateUnit from a string representation
-const ChargingRateUnit string_to_charging_rate_unit(std::string s);
+ChargingRateUnit string_to_charging_rate_unit(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingRateUnit \p charging_rate_unit to the given output
@@ -307,11 +307,11 @@ enum class GetCompositeScheduleStatus
 namespace conversions {
 /// \brief Converts the given GetCompositeScheduleStatus \p e to human readable string
 /// \returns a string representation of the GetCompositeScheduleStatus
-const std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e);
+std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e);
 
 /// \brief Converts the given std::string \p s to GetCompositeScheduleStatus
 /// \returns a GetCompositeScheduleStatus from a string representation
-const GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s);
+GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given GetCompositeScheduleStatus \p get_composite_schedule_status to
@@ -334,11 +334,11 @@ enum class ReadingContext
 namespace conversions {
 /// \brief Converts the given ReadingContext \p e to human readable string
 /// \returns a string representation of the ReadingContext
-const std::string reading_context_to_string(ReadingContext e);
+std::string reading_context_to_string(ReadingContext e);
 
 /// \brief Converts the given std::string \p s to ReadingContext
 /// \returns a ReadingContext from a string representation
-const ReadingContext string_to_reading_context(std::string s);
+ReadingContext string_to_reading_context(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ReadingContext \p reading_context to the given output stream \p
@@ -355,11 +355,11 @@ enum class ValueFormat
 namespace conversions {
 /// \brief Converts the given ValueFormat \p e to human readable string
 /// \returns a string representation of the ValueFormat
-const std::string value_format_to_string(ValueFormat e);
+std::string value_format_to_string(ValueFormat e);
 
 /// \brief Converts the given std::string \p s to ValueFormat
 /// \returns a ValueFormat from a string representation
-const ValueFormat string_to_value_format(std::string s);
+ValueFormat string_to_value_format(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ValueFormat \p value_format to the given output stream \p os
@@ -396,11 +396,11 @@ enum class Measurand
 namespace conversions {
 /// \brief Converts the given Measurand \p e to human readable string
 /// \returns a string representation of the Measurand
-const std::string measurand_to_string(Measurand e);
+std::string measurand_to_string(Measurand e);
 
 /// \brief Converts the given std::string \p s to Measurand
 /// \returns a Measurand from a string representation
-const Measurand string_to_measurand(std::string s);
+Measurand string_to_measurand(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Measurand \p measurand to the given output stream \p os
@@ -425,11 +425,11 @@ enum class Phase
 namespace conversions {
 /// \brief Converts the given Phase \p e to human readable string
 /// \returns a string representation of the Phase
-const std::string phase_to_string(Phase e);
+std::string phase_to_string(Phase e);
 
 /// \brief Converts the given std::string \p s to Phase
 /// \returns a Phase from a string representation
-const Phase string_to_phase(std::string s);
+Phase string_to_phase(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Phase \p phase to the given output stream \p os
@@ -449,11 +449,11 @@ enum class Location
 namespace conversions {
 /// \brief Converts the given Location \p e to human readable string
 /// \returns a string representation of the Location
-const std::string location_to_string(Location e);
+std::string location_to_string(Location e);
 
 /// \brief Converts the given std::string \p s to Location
 /// \returns a Location from a string representation
-const Location string_to_location(std::string s);
+Location string_to_location(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Location \p location to the given output stream \p os
@@ -485,11 +485,11 @@ enum class UnitOfMeasure
 namespace conversions {
 /// \brief Converts the given UnitOfMeasure \p e to human readable string
 /// \returns a string representation of the UnitOfMeasure
-const std::string unit_of_measure_to_string(UnitOfMeasure e);
+std::string unit_of_measure_to_string(UnitOfMeasure e);
 
 /// \brief Converts the given std::string \p s to UnitOfMeasure
 /// \returns a UnitOfMeasure from a string representation
-const UnitOfMeasure string_to_unit_of_measure(std::string s);
+UnitOfMeasure string_to_unit_of_measure(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UnitOfMeasure \p unit_of_measure to the given output stream \p
@@ -507,11 +507,11 @@ enum class ChargingProfileKindType
 namespace conversions {
 /// \brief Converts the given ChargingProfileKindType \p e to human readable string
 /// \returns a string representation of the ChargingProfileKindType
-const std::string charging_profile_kind_type_to_string(ChargingProfileKindType e);
+std::string charging_profile_kind_type_to_string(ChargingProfileKindType e);
 
 /// \brief Converts the given std::string \p s to ChargingProfileKindType
 /// \returns a ChargingProfileKindType from a string representation
-const ChargingProfileKindType string_to_charging_profile_kind_type(std::string s);
+ChargingProfileKindType string_to_charging_profile_kind_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfileKindType \p charging_profile_kind_type to the
@@ -528,11 +528,11 @@ enum class RecurrencyKindType
 namespace conversions {
 /// \brief Converts the given RecurrencyKindType \p e to human readable string
 /// \returns a string representation of the RecurrencyKindType
-const std::string recurrency_kind_type_to_string(RecurrencyKindType e);
+std::string recurrency_kind_type_to_string(RecurrencyKindType e);
 
 /// \brief Converts the given std::string \p s to RecurrencyKindType
 /// \returns a RecurrencyKindType from a string representation
-const RecurrencyKindType string_to_recurrency_kind_type(std::string s);
+RecurrencyKindType string_to_recurrency_kind_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RecurrencyKindType \p recurrency_kind_type to the given output
@@ -549,11 +549,11 @@ enum class RemoteStartStopStatus
 namespace conversions {
 /// \brief Converts the given RemoteStartStopStatus \p e to human readable string
 /// \returns a string representation of the RemoteStartStopStatus
-const std::string remote_start_stop_status_to_string(RemoteStartStopStatus e);
+std::string remote_start_stop_status_to_string(RemoteStartStopStatus e);
 
 /// \brief Converts the given std::string \p s to RemoteStartStopStatus
 /// \returns a RemoteStartStopStatus from a string representation
-const RemoteStartStopStatus string_to_remote_start_stop_status(std::string s);
+RemoteStartStopStatus string_to_remote_start_stop_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RemoteStartStopStatus \p remote_start_stop_status to the given
@@ -573,11 +573,11 @@ enum class ReservationStatus
 namespace conversions {
 /// \brief Converts the given ReservationStatus \p e to human readable string
 /// \returns a string representation of the ReservationStatus
-const std::string reservation_status_to_string(ReservationStatus e);
+std::string reservation_status_to_string(ReservationStatus e);
 
 /// \brief Converts the given std::string \p s to ReservationStatus
 /// \returns a ReservationStatus from a string representation
-const ReservationStatus string_to_reservation_status(std::string s);
+ReservationStatus string_to_reservation_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ReservationStatus \p reservation_status to the given output
@@ -594,11 +594,11 @@ enum class ResetType
 namespace conversions {
 /// \brief Converts the given ResetType \p e to human readable string
 /// \returns a string representation of the ResetType
-const std::string reset_type_to_string(ResetType e);
+std::string reset_type_to_string(ResetType e);
 
 /// \brief Converts the given std::string \p s to ResetType
 /// \returns a ResetType from a string representation
-const ResetType string_to_reset_type(std::string s);
+ResetType string_to_reset_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ResetType \p reset_type to the given output stream \p os
@@ -615,11 +615,11 @@ enum class ResetStatus
 namespace conversions {
 /// \brief Converts the given ResetStatus \p e to human readable string
 /// \returns a string representation of the ResetStatus
-const std::string reset_status_to_string(ResetStatus e);
+std::string reset_status_to_string(ResetStatus e);
 
 /// \brief Converts the given std::string \p s to ResetStatus
 /// \returns a ResetStatus from a string representation
-const ResetStatus string_to_reset_status(std::string s);
+ResetStatus string_to_reset_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ResetStatus \p reset_status to the given output stream \p os
@@ -636,11 +636,11 @@ enum class UpdateType
 namespace conversions {
 /// \brief Converts the given UpdateType \p e to human readable string
 /// \returns a string representation of the UpdateType
-const std::string update_type_to_string(UpdateType e);
+std::string update_type_to_string(UpdateType e);
 
 /// \brief Converts the given std::string \p s to UpdateType
 /// \returns a UpdateType from a string representation
-const UpdateType string_to_update_type(std::string s);
+UpdateType string_to_update_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UpdateType \p update_type to the given output stream \p os
@@ -659,11 +659,11 @@ enum class UpdateStatus
 namespace conversions {
 /// \brief Converts the given UpdateStatus \p e to human readable string
 /// \returns a string representation of the UpdateStatus
-const std::string update_status_to_string(UpdateStatus e);
+std::string update_status_to_string(UpdateStatus e);
 
 /// \brief Converts the given std::string \p s to UpdateStatus
 /// \returns a UpdateStatus from a string representation
-const UpdateStatus string_to_update_status(std::string s);
+UpdateStatus string_to_update_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UpdateStatus \p update_status to the given output stream \p os
@@ -681,11 +681,11 @@ enum class ChargingProfileStatus
 namespace conversions {
 /// \brief Converts the given ChargingProfileStatus \p e to human readable string
 /// \returns a string representation of the ChargingProfileStatus
-const std::string charging_profile_status_to_string(ChargingProfileStatus e);
+std::string charging_profile_status_to_string(ChargingProfileStatus e);
 
 /// \brief Converts the given std::string \p s to ChargingProfileStatus
 /// \returns a ChargingProfileStatus from a string representation
-const ChargingProfileStatus string_to_charging_profile_status(std::string s);
+ChargingProfileStatus string_to_charging_profile_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfileStatus \p charging_profile_status to the given
@@ -716,11 +716,11 @@ enum class ChargePointErrorCode
 namespace conversions {
 /// \brief Converts the given ChargePointErrorCode \p e to human readable string
 /// \returns a string representation of the ChargePointErrorCode
-const std::string charge_point_error_code_to_string(ChargePointErrorCode e);
+std::string charge_point_error_code_to_string(ChargePointErrorCode e);
 
 /// \brief Converts the given std::string \p s to ChargePointErrorCode
 /// \returns a ChargePointErrorCode from a string representation
-const ChargePointErrorCode string_to_charge_point_error_code(std::string s);
+ChargePointErrorCode string_to_charge_point_error_code(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargePointErrorCode \p charge_point_error_code to the given
@@ -744,11 +744,11 @@ enum class ChargePointStatus
 namespace conversions {
 /// \brief Converts the given ChargePointStatus \p e to human readable string
 /// \returns a string representation of the ChargePointStatus
-const std::string charge_point_status_to_string(ChargePointStatus e);
+std::string charge_point_status_to_string(ChargePointStatus e);
 
 /// \brief Converts the given std::string \p s to ChargePointStatus
 /// \returns a ChargePointStatus from a string representation
-const ChargePointStatus string_to_charge_point_status(std::string s);
+ChargePointStatus string_to_charge_point_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargePointStatus \p charge_point_status to the given output
@@ -774,11 +774,11 @@ enum class Reason
 namespace conversions {
 /// \brief Converts the given Reason \p e to human readable string
 /// \returns a string representation of the Reason
-const std::string reason_to_string(Reason e);
+std::string reason_to_string(Reason e);
 
 /// \brief Converts the given std::string \p s to Reason
 /// \returns a Reason from a string representation
-const Reason string_to_reason(std::string s);
+Reason string_to_reason(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Reason \p reason to the given output stream \p os
@@ -799,11 +799,11 @@ enum class MessageTrigger
 namespace conversions {
 /// \brief Converts the given MessageTrigger \p e to human readable string
 /// \returns a string representation of the MessageTrigger
-const std::string message_trigger_to_string(MessageTrigger e);
+std::string message_trigger_to_string(MessageTrigger e);
 
 /// \brief Converts the given std::string \p s to MessageTrigger
 /// \returns a MessageTrigger from a string representation
-const MessageTrigger string_to_message_trigger(std::string s);
+MessageTrigger string_to_message_trigger(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given MessageTrigger \p message_trigger to the given output stream \p
@@ -821,11 +821,11 @@ enum class TriggerMessageStatus
 namespace conversions {
 /// \brief Converts the given TriggerMessageStatus \p e to human readable string
 /// \returns a string representation of the TriggerMessageStatus
-const std::string trigger_message_status_to_string(TriggerMessageStatus e);
+std::string trigger_message_status_to_string(TriggerMessageStatus e);
 
 /// \brief Converts the given std::string \p s to TriggerMessageStatus
 /// \returns a TriggerMessageStatus from a string representation
-const TriggerMessageStatus string_to_trigger_message_status(std::string s);
+TriggerMessageStatus string_to_trigger_message_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given TriggerMessageStatus \p trigger_message_status to the given
@@ -843,11 +843,11 @@ enum class UnlockStatus
 namespace conversions {
 /// \brief Converts the given UnlockStatus \p e to human readable string
 /// \returns a string representation of the UnlockStatus
-const std::string unlock_status_to_string(UnlockStatus e);
+std::string unlock_status_to_string(UnlockStatus e);
 
 /// \brief Converts the given std::string \p s to UnlockStatus
 /// \returns a UnlockStatus from a string representation
-const UnlockStatus string_to_unlock_status(std::string s);
+UnlockStatus string_to_unlock_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UnlockStatus \p unlock_status to the given output stream \p os

--- a/include/ocpp1_6/enums.hpp
+++ b/include/ocpp1_6/enums.hpp
@@ -3,7 +3,6 @@
 #ifndef OCPP1_6_ENUMS_HPP
 #define OCPP1_6_ENUMS_HPP
 
-#include <map>
 #include <string>
 
 namespace ocpp1_6 {
@@ -17,37 +16,20 @@ enum class AuthorizationStatus
     Invalid,
     ConcurrentTx,
 };
-namespace conversions {
-static const std::map<AuthorizationStatus, std::string> AuthorizationStatusStrings{
-    {AuthorizationStatus::Accepted, "Accepted"},         {AuthorizationStatus::Blocked, "Blocked"},
-    {AuthorizationStatus::Expired, "Expired"},           {AuthorizationStatus::Invalid, "Invalid"},
-    {AuthorizationStatus::ConcurrentTx, "ConcurrentTx"},
-};
-static const std::map<std::string, AuthorizationStatus> AuthorizationStatusValues{
-    {"Accepted", AuthorizationStatus::Accepted},         {"Blocked", AuthorizationStatus::Blocked},
-    {"Expired", AuthorizationStatus::Expired},           {"Invalid", AuthorizationStatus::Invalid},
-    {"ConcurrentTx", AuthorizationStatus::ConcurrentTx},
-};
 
+namespace conversions {
 /// \brief Converts the given AuthorizationStatus \p e to human readable string
 /// \returns a string representation of the AuthorizationStatus
-static const std::string authorization_status_to_string(AuthorizationStatus e) {
-    return AuthorizationStatusStrings.at(e);
-}
+const std::string authorization_status_to_string(AuthorizationStatus e);
 
 /// \brief Converts the given std::string \p s to AuthorizationStatus
 /// \returns a AuthorizationStatus from a string representation
-static const AuthorizationStatus string_to_authorization_status(std::string s) {
-    return AuthorizationStatusValues.at(s);
-}
+const AuthorizationStatus string_to_authorization_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AuthorizationStatus \p authorization_status to the given output
 /// stream \p os \returns an output stream with the AuthorizationStatus written to
-inline std::ostream& operator<<(std::ostream& os, const AuthorizationStatus& authorization_status) {
-    os << conversions::authorization_status_to_string(authorization_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const AuthorizationStatus& authorization_status);
 
 // from: BootNotificationResponse
 enum class RegistrationStatus
@@ -56,37 +38,20 @@ enum class RegistrationStatus
     Pending,
     Rejected,
 };
-namespace conversions {
-static const std::map<RegistrationStatus, std::string> RegistrationStatusStrings{
-    {RegistrationStatus::Accepted, "Accepted"},
-    {RegistrationStatus::Pending, "Pending"},
-    {RegistrationStatus::Rejected, "Rejected"},
-};
-static const std::map<std::string, RegistrationStatus> RegistrationStatusValues{
-    {"Accepted", RegistrationStatus::Accepted},
-    {"Pending", RegistrationStatus::Pending},
-    {"Rejected", RegistrationStatus::Rejected},
-};
 
+namespace conversions {
 /// \brief Converts the given RegistrationStatus \p e to human readable string
 /// \returns a string representation of the RegistrationStatus
-static const std::string registration_status_to_string(RegistrationStatus e) {
-    return RegistrationStatusStrings.at(e);
-}
+const std::string registration_status_to_string(RegistrationStatus e);
 
 /// \brief Converts the given std::string \p s to RegistrationStatus
 /// \returns a RegistrationStatus from a string representation
-static const RegistrationStatus string_to_registration_status(std::string s) {
-    return RegistrationStatusValues.at(s);
-}
+const RegistrationStatus string_to_registration_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RegistrationStatus \p registration_status to the given output
 /// stream \p os \returns an output stream with the RegistrationStatus written to
-inline std::ostream& operator<<(std::ostream& os, const RegistrationStatus& registration_status) {
-    os << conversions::registration_status_to_string(registration_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const RegistrationStatus& registration_status);
 
 // from: CancelReservationResponse
 enum class CancelReservationStatus
@@ -94,35 +59,20 @@ enum class CancelReservationStatus
     Accepted,
     Rejected,
 };
-namespace conversions {
-static const std::map<CancelReservationStatus, std::string> CancelReservationStatusStrings{
-    {CancelReservationStatus::Accepted, "Accepted"},
-    {CancelReservationStatus::Rejected, "Rejected"},
-};
-static const std::map<std::string, CancelReservationStatus> CancelReservationStatusValues{
-    {"Accepted", CancelReservationStatus::Accepted},
-    {"Rejected", CancelReservationStatus::Rejected},
-};
 
+namespace conversions {
 /// \brief Converts the given CancelReservationStatus \p e to human readable string
 /// \returns a string representation of the CancelReservationStatus
-static const std::string cancel_reservation_status_to_string(CancelReservationStatus e) {
-    return CancelReservationStatusStrings.at(e);
-}
+const std::string cancel_reservation_status_to_string(CancelReservationStatus e);
 
 /// \brief Converts the given std::string \p s to CancelReservationStatus
 /// \returns a CancelReservationStatus from a string representation
-static const CancelReservationStatus string_to_cancel_reservation_status(std::string s) {
-    return CancelReservationStatusValues.at(s);
-}
+const CancelReservationStatus string_to_cancel_reservation_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given CancelReservationStatus \p cancel_reservation_status to the
 /// given output stream \p os \returns an output stream with the CancelReservationStatus written to
-inline std::ostream& operator<<(std::ostream& os, const CancelReservationStatus& cancel_reservation_status) {
-    os << conversions::cancel_reservation_status_to_string(cancel_reservation_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const CancelReservationStatus& cancel_reservation_status);
 
 // from: ChangeAvailabilityRequest
 enum class AvailabilityType
@@ -130,35 +80,20 @@ enum class AvailabilityType
     Inoperative,
     Operative,
 };
-namespace conversions {
-static const std::map<AvailabilityType, std::string> AvailabilityTypeStrings{
-    {AvailabilityType::Inoperative, "Inoperative"},
-    {AvailabilityType::Operative, "Operative"},
-};
-static const std::map<std::string, AvailabilityType> AvailabilityTypeValues{
-    {"Inoperative", AvailabilityType::Inoperative},
-    {"Operative", AvailabilityType::Operative},
-};
 
+namespace conversions {
 /// \brief Converts the given AvailabilityType \p e to human readable string
 /// \returns a string representation of the AvailabilityType
-static const std::string availability_type_to_string(AvailabilityType e) {
-    return AvailabilityTypeStrings.at(e);
-}
+const std::string availability_type_to_string(AvailabilityType e);
 
 /// \brief Converts the given std::string \p s to AvailabilityType
 /// \returns a AvailabilityType from a string representation
-static const AvailabilityType string_to_availability_type(std::string s) {
-    return AvailabilityTypeValues.at(s);
-}
+const AvailabilityType string_to_availability_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AvailabilityType \p availability_type to the given output
 /// stream \p os \returns an output stream with the AvailabilityType written to
-inline std::ostream& operator<<(std::ostream& os, const AvailabilityType& availability_type) {
-    os << conversions::availability_type_to_string(availability_type);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const AvailabilityType& availability_type);
 
 // from: ChangeAvailabilityResponse
 enum class AvailabilityStatus
@@ -167,37 +102,20 @@ enum class AvailabilityStatus
     Rejected,
     Scheduled,
 };
-namespace conversions {
-static const std::map<AvailabilityStatus, std::string> AvailabilityStatusStrings{
-    {AvailabilityStatus::Accepted, "Accepted"},
-    {AvailabilityStatus::Rejected, "Rejected"},
-    {AvailabilityStatus::Scheduled, "Scheduled"},
-};
-static const std::map<std::string, AvailabilityStatus> AvailabilityStatusValues{
-    {"Accepted", AvailabilityStatus::Accepted},
-    {"Rejected", AvailabilityStatus::Rejected},
-    {"Scheduled", AvailabilityStatus::Scheduled},
-};
 
+namespace conversions {
 /// \brief Converts the given AvailabilityStatus \p e to human readable string
 /// \returns a string representation of the AvailabilityStatus
-static const std::string availability_status_to_string(AvailabilityStatus e) {
-    return AvailabilityStatusStrings.at(e);
-}
+const std::string availability_status_to_string(AvailabilityStatus e);
 
 /// \brief Converts the given std::string \p s to AvailabilityStatus
 /// \returns a AvailabilityStatus from a string representation
-static const AvailabilityStatus string_to_availability_status(std::string s) {
-    return AvailabilityStatusValues.at(s);
-}
+const AvailabilityStatus string_to_availability_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given AvailabilityStatus \p availability_status to the given output
 /// stream \p os \returns an output stream with the AvailabilityStatus written to
-inline std::ostream& operator<<(std::ostream& os, const AvailabilityStatus& availability_status) {
-    os << conversions::availability_status_to_string(availability_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const AvailabilityStatus& availability_status);
 
 // from: ChangeConfigurationResponse
 enum class ConfigurationStatus
@@ -207,39 +125,20 @@ enum class ConfigurationStatus
     RebootRequired,
     NotSupported,
 };
-namespace conversions {
-static const std::map<ConfigurationStatus, std::string> ConfigurationStatusStrings{
-    {ConfigurationStatus::Accepted, "Accepted"},
-    {ConfigurationStatus::Rejected, "Rejected"},
-    {ConfigurationStatus::RebootRequired, "RebootRequired"},
-    {ConfigurationStatus::NotSupported, "NotSupported"},
-};
-static const std::map<std::string, ConfigurationStatus> ConfigurationStatusValues{
-    {"Accepted", ConfigurationStatus::Accepted},
-    {"Rejected", ConfigurationStatus::Rejected},
-    {"RebootRequired", ConfigurationStatus::RebootRequired},
-    {"NotSupported", ConfigurationStatus::NotSupported},
-};
 
+namespace conversions {
 /// \brief Converts the given ConfigurationStatus \p e to human readable string
 /// \returns a string representation of the ConfigurationStatus
-static const std::string configuration_status_to_string(ConfigurationStatus e) {
-    return ConfigurationStatusStrings.at(e);
-}
+const std::string configuration_status_to_string(ConfigurationStatus e);
 
 /// \brief Converts the given std::string \p s to ConfigurationStatus
 /// \returns a ConfigurationStatus from a string representation
-static const ConfigurationStatus string_to_configuration_status(std::string s) {
-    return ConfigurationStatusValues.at(s);
-}
+const ConfigurationStatus string_to_configuration_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ConfigurationStatus \p configuration_status to the given output
 /// stream \p os \returns an output stream with the ConfigurationStatus written to
-inline std::ostream& operator<<(std::ostream& os, const ConfigurationStatus& configuration_status) {
-    os << conversions::configuration_status_to_string(configuration_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ConfigurationStatus& configuration_status);
 
 // from: ClearCacheResponse
 enum class ClearCacheStatus
@@ -247,35 +146,20 @@ enum class ClearCacheStatus
     Accepted,
     Rejected,
 };
-namespace conversions {
-static const std::map<ClearCacheStatus, std::string> ClearCacheStatusStrings{
-    {ClearCacheStatus::Accepted, "Accepted"},
-    {ClearCacheStatus::Rejected, "Rejected"},
-};
-static const std::map<std::string, ClearCacheStatus> ClearCacheStatusValues{
-    {"Accepted", ClearCacheStatus::Accepted},
-    {"Rejected", ClearCacheStatus::Rejected},
-};
 
+namespace conversions {
 /// \brief Converts the given ClearCacheStatus \p e to human readable string
 /// \returns a string representation of the ClearCacheStatus
-static const std::string clear_cache_status_to_string(ClearCacheStatus e) {
-    return ClearCacheStatusStrings.at(e);
-}
+const std::string clear_cache_status_to_string(ClearCacheStatus e);
 
 /// \brief Converts the given std::string \p s to ClearCacheStatus
 /// \returns a ClearCacheStatus from a string representation
-static const ClearCacheStatus string_to_clear_cache_status(std::string s) {
-    return ClearCacheStatusValues.at(s);
-}
+const ClearCacheStatus string_to_clear_cache_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ClearCacheStatus \p clear_cache_status to the given output
 /// stream \p os \returns an output stream with the ClearCacheStatus written to
-inline std::ostream& operator<<(std::ostream& os, const ClearCacheStatus& clear_cache_status) {
-    os << conversions::clear_cache_status_to_string(clear_cache_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ClearCacheStatus& clear_cache_status);
 
 // from: ClearChargingProfileRequest
 enum class ChargingProfilePurposeType
@@ -284,37 +168,20 @@ enum class ChargingProfilePurposeType
     TxDefaultProfile,
     TxProfile,
 };
-namespace conversions {
-static const std::map<ChargingProfilePurposeType, std::string> ChargingProfilePurposeTypeStrings{
-    {ChargingProfilePurposeType::ChargePointMaxProfile, "ChargePointMaxProfile"},
-    {ChargingProfilePurposeType::TxDefaultProfile, "TxDefaultProfile"},
-    {ChargingProfilePurposeType::TxProfile, "TxProfile"},
-};
-static const std::map<std::string, ChargingProfilePurposeType> ChargingProfilePurposeTypeValues{
-    {"ChargePointMaxProfile", ChargingProfilePurposeType::ChargePointMaxProfile},
-    {"TxDefaultProfile", ChargingProfilePurposeType::TxDefaultProfile},
-    {"TxProfile", ChargingProfilePurposeType::TxProfile},
-};
 
+namespace conversions {
 /// \brief Converts the given ChargingProfilePurposeType \p e to human readable string
 /// \returns a string representation of the ChargingProfilePurposeType
-static const std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e) {
-    return ChargingProfilePurposeTypeStrings.at(e);
-}
+const std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e);
 
 /// \brief Converts the given std::string \p s to ChargingProfilePurposeType
 /// \returns a ChargingProfilePurposeType from a string representation
-static const ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s) {
-    return ChargingProfilePurposeTypeValues.at(s);
-}
+const ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfilePurposeType \p charging_profile_purpose_type to
 /// the given output stream \p os \returns an output stream with the ChargingProfilePurposeType written to
-inline std::ostream& operator<<(std::ostream& os, const ChargingProfilePurposeType& charging_profile_purpose_type) {
-    os << conversions::charging_profile_purpose_type_to_string(charging_profile_purpose_type);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ChargingProfilePurposeType& charging_profile_purpose_type);
 
 // from: ClearChargingProfileResponse
 enum class ClearChargingProfileStatus
@@ -322,35 +189,20 @@ enum class ClearChargingProfileStatus
     Accepted,
     Unknown,
 };
-namespace conversions {
-static const std::map<ClearChargingProfileStatus, std::string> ClearChargingProfileStatusStrings{
-    {ClearChargingProfileStatus::Accepted, "Accepted"},
-    {ClearChargingProfileStatus::Unknown, "Unknown"},
-};
-static const std::map<std::string, ClearChargingProfileStatus> ClearChargingProfileStatusValues{
-    {"Accepted", ClearChargingProfileStatus::Accepted},
-    {"Unknown", ClearChargingProfileStatus::Unknown},
-};
 
+namespace conversions {
 /// \brief Converts the given ClearChargingProfileStatus \p e to human readable string
 /// \returns a string representation of the ClearChargingProfileStatus
-static const std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e) {
-    return ClearChargingProfileStatusStrings.at(e);
-}
+const std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e);
 
 /// \brief Converts the given std::string \p s to ClearChargingProfileStatus
 /// \returns a ClearChargingProfileStatus from a string representation
-static const ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s) {
-    return ClearChargingProfileStatusValues.at(s);
-}
+const ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ClearChargingProfileStatus \p clear_charging_profile_status to
 /// the given output stream \p os \returns an output stream with the ClearChargingProfileStatus written to
-inline std::ostream& operator<<(std::ostream& os, const ClearChargingProfileStatus& clear_charging_profile_status) {
-    os << conversions::clear_charging_profile_status_to_string(clear_charging_profile_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ClearChargingProfileStatus& clear_charging_profile_status);
 
 // from: DataTransferResponse
 enum class DataTransferStatus
@@ -360,39 +212,20 @@ enum class DataTransferStatus
     UnknownMessageId,
     UnknownVendorId,
 };
-namespace conversions {
-static const std::map<DataTransferStatus, std::string> DataTransferStatusStrings{
-    {DataTransferStatus::Accepted, "Accepted"},
-    {DataTransferStatus::Rejected, "Rejected"},
-    {DataTransferStatus::UnknownMessageId, "UnknownMessageId"},
-    {DataTransferStatus::UnknownVendorId, "UnknownVendorId"},
-};
-static const std::map<std::string, DataTransferStatus> DataTransferStatusValues{
-    {"Accepted", DataTransferStatus::Accepted},
-    {"Rejected", DataTransferStatus::Rejected},
-    {"UnknownMessageId", DataTransferStatus::UnknownMessageId},
-    {"UnknownVendorId", DataTransferStatus::UnknownVendorId},
-};
 
+namespace conversions {
 /// \brief Converts the given DataTransferStatus \p e to human readable string
 /// \returns a string representation of the DataTransferStatus
-static const std::string data_transfer_status_to_string(DataTransferStatus e) {
-    return DataTransferStatusStrings.at(e);
-}
+const std::string data_transfer_status_to_string(DataTransferStatus e);
 
 /// \brief Converts the given std::string \p s to DataTransferStatus
 /// \returns a DataTransferStatus from a string representation
-static const DataTransferStatus string_to_data_transfer_status(std::string s) {
-    return DataTransferStatusValues.at(s);
-}
+const DataTransferStatus string_to_data_transfer_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given DataTransferStatus \p data_transfer_status to the given output
 /// stream \p os \returns an output stream with the DataTransferStatus written to
-inline std::ostream& operator<<(std::ostream& os, const DataTransferStatus& data_transfer_status) {
-    os << conversions::data_transfer_status_to_string(data_transfer_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const DataTransferStatus& data_transfer_status);
 
 // from: DiagnosticsStatusNotificationRequest
 enum class DiagnosticsStatus
@@ -402,39 +235,20 @@ enum class DiagnosticsStatus
     UploadFailed,
     Uploading,
 };
-namespace conversions {
-static const std::map<DiagnosticsStatus, std::string> DiagnosticsStatusStrings{
-    {DiagnosticsStatus::Idle, "Idle"},
-    {DiagnosticsStatus::Uploaded, "Uploaded"},
-    {DiagnosticsStatus::UploadFailed, "UploadFailed"},
-    {DiagnosticsStatus::Uploading, "Uploading"},
-};
-static const std::map<std::string, DiagnosticsStatus> DiagnosticsStatusValues{
-    {"Idle", DiagnosticsStatus::Idle},
-    {"Uploaded", DiagnosticsStatus::Uploaded},
-    {"UploadFailed", DiagnosticsStatus::UploadFailed},
-    {"Uploading", DiagnosticsStatus::Uploading},
-};
 
+namespace conversions {
 /// \brief Converts the given DiagnosticsStatus \p e to human readable string
 /// \returns a string representation of the DiagnosticsStatus
-static const std::string diagnostics_status_to_string(DiagnosticsStatus e) {
-    return DiagnosticsStatusStrings.at(e);
-}
+const std::string diagnostics_status_to_string(DiagnosticsStatus e);
 
 /// \brief Converts the given std::string \p s to DiagnosticsStatus
 /// \returns a DiagnosticsStatus from a string representation
-static const DiagnosticsStatus string_to_diagnostics_status(std::string s) {
-    return DiagnosticsStatusValues.at(s);
-}
+const DiagnosticsStatus string_to_diagnostics_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given DiagnosticsStatus \p diagnostics_status to the given output
 /// stream \p os \returns an output stream with the DiagnosticsStatus written to
-inline std::ostream& operator<<(std::ostream& os, const DiagnosticsStatus& diagnostics_status) {
-    os << conversions::diagnostics_status_to_string(diagnostics_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const DiagnosticsStatus& diagnostics_status);
 
 // from: FirmwareStatusNotificationRequest
 enum class FirmwareStatus
@@ -447,45 +261,20 @@ enum class FirmwareStatus
     Installing,
     Installed,
 };
-namespace conversions {
-static const std::map<FirmwareStatus, std::string> FirmwareStatusStrings{
-    {FirmwareStatus::Downloaded, "Downloaded"},
-    {FirmwareStatus::DownloadFailed, "DownloadFailed"},
-    {FirmwareStatus::Downloading, "Downloading"},
-    {FirmwareStatus::Idle, "Idle"},
-    {FirmwareStatus::InstallationFailed, "InstallationFailed"},
-    {FirmwareStatus::Installing, "Installing"},
-    {FirmwareStatus::Installed, "Installed"},
-};
-static const std::map<std::string, FirmwareStatus> FirmwareStatusValues{
-    {"Downloaded", FirmwareStatus::Downloaded},
-    {"DownloadFailed", FirmwareStatus::DownloadFailed},
-    {"Downloading", FirmwareStatus::Downloading},
-    {"Idle", FirmwareStatus::Idle},
-    {"InstallationFailed", FirmwareStatus::InstallationFailed},
-    {"Installing", FirmwareStatus::Installing},
-    {"Installed", FirmwareStatus::Installed},
-};
 
+namespace conversions {
 /// \brief Converts the given FirmwareStatus \p e to human readable string
 /// \returns a string representation of the FirmwareStatus
-static const std::string firmware_status_to_string(FirmwareStatus e) {
-    return FirmwareStatusStrings.at(e);
-}
+const std::string firmware_status_to_string(FirmwareStatus e);
 
 /// \brief Converts the given std::string \p s to FirmwareStatus
 /// \returns a FirmwareStatus from a string representation
-static const FirmwareStatus string_to_firmware_status(std::string s) {
-    return FirmwareStatusValues.at(s);
-}
+const FirmwareStatus string_to_firmware_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given FirmwareStatus \p firmware_status to the given output stream \p
 /// os \returns an output stream with the FirmwareStatus written to
-inline std::ostream& operator<<(std::ostream& os, const FirmwareStatus& firmware_status) {
-    os << conversions::firmware_status_to_string(firmware_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const FirmwareStatus& firmware_status);
 
 // from: GetCompositeScheduleRequest
 enum class ChargingRateUnit
@@ -493,35 +282,20 @@ enum class ChargingRateUnit
     A,
     W,
 };
-namespace conversions {
-static const std::map<ChargingRateUnit, std::string> ChargingRateUnitStrings{
-    {ChargingRateUnit::A, "A"},
-    {ChargingRateUnit::W, "W"},
-};
-static const std::map<std::string, ChargingRateUnit> ChargingRateUnitValues{
-    {"A", ChargingRateUnit::A},
-    {"W", ChargingRateUnit::W},
-};
 
+namespace conversions {
 /// \brief Converts the given ChargingRateUnit \p e to human readable string
 /// \returns a string representation of the ChargingRateUnit
-static const std::string charging_rate_unit_to_string(ChargingRateUnit e) {
-    return ChargingRateUnitStrings.at(e);
-}
+const std::string charging_rate_unit_to_string(ChargingRateUnit e);
 
 /// \brief Converts the given std::string \p s to ChargingRateUnit
 /// \returns a ChargingRateUnit from a string representation
-static const ChargingRateUnit string_to_charging_rate_unit(std::string s) {
-    return ChargingRateUnitValues.at(s);
-}
+const ChargingRateUnit string_to_charging_rate_unit(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingRateUnit \p charging_rate_unit to the given output
 /// stream \p os \returns an output stream with the ChargingRateUnit written to
-inline std::ostream& operator<<(std::ostream& os, const ChargingRateUnit& charging_rate_unit) {
-    os << conversions::charging_rate_unit_to_string(charging_rate_unit);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ChargingRateUnit& charging_rate_unit);
 
 // from: GetCompositeScheduleResponse
 enum class GetCompositeScheduleStatus
@@ -529,35 +303,20 @@ enum class GetCompositeScheduleStatus
     Accepted,
     Rejected,
 };
-namespace conversions {
-static const std::map<GetCompositeScheduleStatus, std::string> GetCompositeScheduleStatusStrings{
-    {GetCompositeScheduleStatus::Accepted, "Accepted"},
-    {GetCompositeScheduleStatus::Rejected, "Rejected"},
-};
-static const std::map<std::string, GetCompositeScheduleStatus> GetCompositeScheduleStatusValues{
-    {"Accepted", GetCompositeScheduleStatus::Accepted},
-    {"Rejected", GetCompositeScheduleStatus::Rejected},
-};
 
+namespace conversions {
 /// \brief Converts the given GetCompositeScheduleStatus \p e to human readable string
 /// \returns a string representation of the GetCompositeScheduleStatus
-static const std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e) {
-    return GetCompositeScheduleStatusStrings.at(e);
-}
+const std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e);
 
 /// \brief Converts the given std::string \p s to GetCompositeScheduleStatus
 /// \returns a GetCompositeScheduleStatus from a string representation
-static const GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s) {
-    return GetCompositeScheduleStatusValues.at(s);
-}
+const GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given GetCompositeScheduleStatus \p get_composite_schedule_status to
 /// the given output stream \p os \returns an output stream with the GetCompositeScheduleStatus written to
-inline std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleStatus& get_composite_schedule_status) {
-    os << conversions::get_composite_schedule_status_to_string(get_composite_schedule_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleStatus& get_composite_schedule_status);
 
 // from: MeterValuesRequest
 enum class ReadingContext
@@ -571,47 +330,20 @@ enum class ReadingContext
     Trigger,
     Other,
 };
-namespace conversions {
-static const std::map<ReadingContext, std::string> ReadingContextStrings{
-    {ReadingContext::Interruption_Begin, "Interruption.Begin"},
-    {ReadingContext::Interruption_End, "Interruption.End"},
-    {ReadingContext::Sample_Clock, "Sample.Clock"},
-    {ReadingContext::Sample_Periodic, "Sample.Periodic"},
-    {ReadingContext::Transaction_Begin, "Transaction.Begin"},
-    {ReadingContext::Transaction_End, "Transaction.End"},
-    {ReadingContext::Trigger, "Trigger"},
-    {ReadingContext::Other, "Other"},
-};
-static const std::map<std::string, ReadingContext> ReadingContextValues{
-    {"Interruption.Begin", ReadingContext::Interruption_Begin},
-    {"Interruption.End", ReadingContext::Interruption_End},
-    {"Sample.Clock", ReadingContext::Sample_Clock},
-    {"Sample.Periodic", ReadingContext::Sample_Periodic},
-    {"Transaction.Begin", ReadingContext::Transaction_Begin},
-    {"Transaction.End", ReadingContext::Transaction_End},
-    {"Trigger", ReadingContext::Trigger},
-    {"Other", ReadingContext::Other},
-};
 
+namespace conversions {
 /// \brief Converts the given ReadingContext \p e to human readable string
 /// \returns a string representation of the ReadingContext
-static const std::string reading_context_to_string(ReadingContext e) {
-    return ReadingContextStrings.at(e);
-}
+const std::string reading_context_to_string(ReadingContext e);
 
 /// \brief Converts the given std::string \p s to ReadingContext
 /// \returns a ReadingContext from a string representation
-static const ReadingContext string_to_reading_context(std::string s) {
-    return ReadingContextValues.at(s);
-}
+const ReadingContext string_to_reading_context(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ReadingContext \p reading_context to the given output stream \p
 /// os \returns an output stream with the ReadingContext written to
-inline std::ostream& operator<<(std::ostream& os, const ReadingContext& reading_context) {
-    os << conversions::reading_context_to_string(reading_context);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ReadingContext& reading_context);
 
 // from: MeterValuesRequest
 enum class ValueFormat
@@ -619,35 +351,20 @@ enum class ValueFormat
     Raw,
     SignedData,
 };
-namespace conversions {
-static const std::map<ValueFormat, std::string> ValueFormatStrings{
-    {ValueFormat::Raw, "Raw"},
-    {ValueFormat::SignedData, "SignedData"},
-};
-static const std::map<std::string, ValueFormat> ValueFormatValues{
-    {"Raw", ValueFormat::Raw},
-    {"SignedData", ValueFormat::SignedData},
-};
 
+namespace conversions {
 /// \brief Converts the given ValueFormat \p e to human readable string
 /// \returns a string representation of the ValueFormat
-static const std::string value_format_to_string(ValueFormat e) {
-    return ValueFormatStrings.at(e);
-}
+const std::string value_format_to_string(ValueFormat e);
 
 /// \brief Converts the given std::string \p s to ValueFormat
 /// \returns a ValueFormat from a string representation
-static const ValueFormat string_to_value_format(std::string s) {
-    return ValueFormatValues.at(s);
-}
+const ValueFormat string_to_value_format(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ValueFormat \p value_format to the given output stream \p os
 /// \returns an output stream with the ValueFormat written to
-inline std::ostream& operator<<(std::ostream& os, const ValueFormat& value_format) {
-    os << conversions::value_format_to_string(value_format);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ValueFormat& value_format);
 
 // from: MeterValuesRequest
 enum class Measurand
@@ -675,75 +392,20 @@ enum class Measurand
     SoC,
     RPM,
 };
-namespace conversions {
-static const std::map<Measurand, std::string> MeasurandStrings{
-    {Measurand::Energy_Active_Export_Register, "Energy.Active.Export.Register"},
-    {Measurand::Energy_Active_Import_Register, "Energy.Active.Import.Register"},
-    {Measurand::Energy_Reactive_Export_Register, "Energy.Reactive.Export.Register"},
-    {Measurand::Energy_Reactive_Import_Register, "Energy.Reactive.Import.Register"},
-    {Measurand::Energy_Active_Export_Interval, "Energy.Active.Export.Interval"},
-    {Measurand::Energy_Active_Import_Interval, "Energy.Active.Import.Interval"},
-    {Measurand::Energy_Reactive_Export_Interval, "Energy.Reactive.Export.Interval"},
-    {Measurand::Energy_Reactive_Import_Interval, "Energy.Reactive.Import.Interval"},
-    {Measurand::Power_Active_Export, "Power.Active.Export"},
-    {Measurand::Power_Active_Import, "Power.Active.Import"},
-    {Measurand::Power_Offered, "Power.Offered"},
-    {Measurand::Power_Reactive_Export, "Power.Reactive.Export"},
-    {Measurand::Power_Reactive_Import, "Power.Reactive.Import"},
-    {Measurand::Power_Factor, "Power.Factor"},
-    {Measurand::Current_Import, "Current.Import"},
-    {Measurand::Current_Export, "Current.Export"},
-    {Measurand::Current_Offered, "Current.Offered"},
-    {Measurand::Voltage, "Voltage"},
-    {Measurand::Frequency, "Frequency"},
-    {Measurand::Temperature, "Temperature"},
-    {Measurand::SoC, "SoC"},
-    {Measurand::RPM, "RPM"},
-};
-static const std::map<std::string, Measurand> MeasurandValues{
-    {"Energy.Active.Export.Register", Measurand::Energy_Active_Export_Register},
-    {"Energy.Active.Import.Register", Measurand::Energy_Active_Import_Register},
-    {"Energy.Reactive.Export.Register", Measurand::Energy_Reactive_Export_Register},
-    {"Energy.Reactive.Import.Register", Measurand::Energy_Reactive_Import_Register},
-    {"Energy.Active.Export.Interval", Measurand::Energy_Active_Export_Interval},
-    {"Energy.Active.Import.Interval", Measurand::Energy_Active_Import_Interval},
-    {"Energy.Reactive.Export.Interval", Measurand::Energy_Reactive_Export_Interval},
-    {"Energy.Reactive.Import.Interval", Measurand::Energy_Reactive_Import_Interval},
-    {"Power.Active.Export", Measurand::Power_Active_Export},
-    {"Power.Active.Import", Measurand::Power_Active_Import},
-    {"Power.Offered", Measurand::Power_Offered},
-    {"Power.Reactive.Export", Measurand::Power_Reactive_Export},
-    {"Power.Reactive.Import", Measurand::Power_Reactive_Import},
-    {"Power.Factor", Measurand::Power_Factor},
-    {"Current.Import", Measurand::Current_Import},
-    {"Current.Export", Measurand::Current_Export},
-    {"Current.Offered", Measurand::Current_Offered},
-    {"Voltage", Measurand::Voltage},
-    {"Frequency", Measurand::Frequency},
-    {"Temperature", Measurand::Temperature},
-    {"SoC", Measurand::SoC},
-    {"RPM", Measurand::RPM},
-};
 
+namespace conversions {
 /// \brief Converts the given Measurand \p e to human readable string
 /// \returns a string representation of the Measurand
-static const std::string measurand_to_string(Measurand e) {
-    return MeasurandStrings.at(e);
-}
+const std::string measurand_to_string(Measurand e);
 
 /// \brief Converts the given std::string \p s to Measurand
 /// \returns a Measurand from a string representation
-static const Measurand string_to_measurand(std::string s) {
-    return MeasurandValues.at(s);
-}
+const Measurand string_to_measurand(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Measurand \p measurand to the given output stream \p os
 /// \returns an output stream with the Measurand written to
-inline std::ostream& operator<<(std::ostream& os, const Measurand& measurand) {
-    os << conversions::measurand_to_string(measurand);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const Measurand& measurand);
 
 // from: MeterValuesRequest
 enum class Phase
@@ -759,37 +421,20 @@ enum class Phase
     L2_L3,
     L3_L1,
 };
-namespace conversions {
-static const std::map<Phase, std::string> PhaseStrings{
-    {Phase::L1, "L1"},       {Phase::L2, "L2"},       {Phase::L3, "L3"},     {Phase::N, "N"},
-    {Phase::L1_N, "L1-N"},   {Phase::L2_N, "L2-N"},   {Phase::L3_N, "L3-N"}, {Phase::L1_L2, "L1-L2"},
-    {Phase::L2_L3, "L2-L3"}, {Phase::L3_L1, "L3-L1"},
-};
-static const std::map<std::string, Phase> PhaseValues{
-    {"L1", Phase::L1},       {"L2", Phase::L2},       {"L3", Phase::L3},     {"N", Phase::N},
-    {"L1-N", Phase::L1_N},   {"L2-N", Phase::L2_N},   {"L3-N", Phase::L3_N}, {"L1-L2", Phase::L1_L2},
-    {"L2-L3", Phase::L2_L3}, {"L3-L1", Phase::L3_L1},
-};
 
+namespace conversions {
 /// \brief Converts the given Phase \p e to human readable string
 /// \returns a string representation of the Phase
-static const std::string phase_to_string(Phase e) {
-    return PhaseStrings.at(e);
-}
+const std::string phase_to_string(Phase e);
 
 /// \brief Converts the given std::string \p s to Phase
 /// \returns a Phase from a string representation
-static const Phase string_to_phase(std::string s) {
-    return PhaseValues.at(s);
-}
+const Phase string_to_phase(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Phase \p phase to the given output stream \p os
 /// \returns an output stream with the Phase written to
-inline std::ostream& operator<<(std::ostream& os, const Phase& phase) {
-    os << conversions::phase_to_string(phase);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const Phase& phase);
 
 // from: MeterValuesRequest
 enum class Location
@@ -800,35 +445,20 @@ enum class Location
     Outlet,
     Body,
 };
-namespace conversions {
-static const std::map<Location, std::string> LocationStrings{
-    {Location::Cable, "Cable"},   {Location::EV, "EV"},     {Location::Inlet, "Inlet"},
-    {Location::Outlet, "Outlet"}, {Location::Body, "Body"},
-};
-static const std::map<std::string, Location> LocationValues{
-    {"Cable", Location::Cable},   {"EV", Location::EV},     {"Inlet", Location::Inlet},
-    {"Outlet", Location::Outlet}, {"Body", Location::Body},
-};
 
+namespace conversions {
 /// \brief Converts the given Location \p e to human readable string
 /// \returns a string representation of the Location
-static const std::string location_to_string(Location e) {
-    return LocationStrings.at(e);
-}
+const std::string location_to_string(Location e);
 
 /// \brief Converts the given std::string \p s to Location
 /// \returns a Location from a string representation
-static const Location string_to_location(std::string s) {
-    return LocationValues.at(s);
-}
+const Location string_to_location(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Location \p location to the given output stream \p os
 /// \returns an output stream with the Location written to
-inline std::ostream& operator<<(std::ostream& os, const Location& location) {
-    os << conversions::location_to_string(location);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const Location& location);
 
 // from: MeterValuesRequest
 enum class UnitOfMeasure
@@ -851,65 +481,20 @@ enum class UnitOfMeasure
     Fahrenheit,
     Percent,
 };
-namespace conversions {
-static const std::map<UnitOfMeasure, std::string> UnitOfMeasureStrings{
-    {UnitOfMeasure::Wh, "Wh"},
-    {UnitOfMeasure::kWh, "kWh"},
-    {UnitOfMeasure::varh, "varh"},
-    {UnitOfMeasure::kvarh, "kvarh"},
-    {UnitOfMeasure::W, "W"},
-    {UnitOfMeasure::kW, "kW"},
-    {UnitOfMeasure::VA, "VA"},
-    {UnitOfMeasure::kVA, "kVA"},
-    {UnitOfMeasure::var, "var"},
-    {UnitOfMeasure::kvar, "kvar"},
-    {UnitOfMeasure::A, "A"},
-    {UnitOfMeasure::V, "V"},
-    {UnitOfMeasure::K, "K"},
-    {UnitOfMeasure::Celcius, "Celcius"},
-    {UnitOfMeasure::Celsius, "Celsius"},
-    {UnitOfMeasure::Fahrenheit, "Fahrenheit"},
-    {UnitOfMeasure::Percent, "Percent"},
-};
-static const std::map<std::string, UnitOfMeasure> UnitOfMeasureValues{
-    {"Wh", UnitOfMeasure::Wh},
-    {"kWh", UnitOfMeasure::kWh},
-    {"varh", UnitOfMeasure::varh},
-    {"kvarh", UnitOfMeasure::kvarh},
-    {"W", UnitOfMeasure::W},
-    {"kW", UnitOfMeasure::kW},
-    {"VA", UnitOfMeasure::VA},
-    {"kVA", UnitOfMeasure::kVA},
-    {"var", UnitOfMeasure::var},
-    {"kvar", UnitOfMeasure::kvar},
-    {"A", UnitOfMeasure::A},
-    {"V", UnitOfMeasure::V},
-    {"K", UnitOfMeasure::K},
-    {"Celcius", UnitOfMeasure::Celcius},
-    {"Celsius", UnitOfMeasure::Celsius},
-    {"Fahrenheit", UnitOfMeasure::Fahrenheit},
-    {"Percent", UnitOfMeasure::Percent},
-};
 
+namespace conversions {
 /// \brief Converts the given UnitOfMeasure \p e to human readable string
 /// \returns a string representation of the UnitOfMeasure
-static const std::string unit_of_measure_to_string(UnitOfMeasure e) {
-    return UnitOfMeasureStrings.at(e);
-}
+const std::string unit_of_measure_to_string(UnitOfMeasure e);
 
 /// \brief Converts the given std::string \p s to UnitOfMeasure
 /// \returns a UnitOfMeasure from a string representation
-static const UnitOfMeasure string_to_unit_of_measure(std::string s) {
-    return UnitOfMeasureValues.at(s);
-}
+const UnitOfMeasure string_to_unit_of_measure(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UnitOfMeasure \p unit_of_measure to the given output stream \p
 /// os \returns an output stream with the UnitOfMeasure written to
-inline std::ostream& operator<<(std::ostream& os, const UnitOfMeasure& unit_of_measure) {
-    os << conversions::unit_of_measure_to_string(unit_of_measure);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const UnitOfMeasure& unit_of_measure);
 
 // from: RemoteStartTransactionRequest
 enum class ChargingProfileKindType
@@ -918,37 +503,20 @@ enum class ChargingProfileKindType
     Recurring,
     Relative,
 };
-namespace conversions {
-static const std::map<ChargingProfileKindType, std::string> ChargingProfileKindTypeStrings{
-    {ChargingProfileKindType::Absolute, "Absolute"},
-    {ChargingProfileKindType::Recurring, "Recurring"},
-    {ChargingProfileKindType::Relative, "Relative"},
-};
-static const std::map<std::string, ChargingProfileKindType> ChargingProfileKindTypeValues{
-    {"Absolute", ChargingProfileKindType::Absolute},
-    {"Recurring", ChargingProfileKindType::Recurring},
-    {"Relative", ChargingProfileKindType::Relative},
-};
 
+namespace conversions {
 /// \brief Converts the given ChargingProfileKindType \p e to human readable string
 /// \returns a string representation of the ChargingProfileKindType
-static const std::string charging_profile_kind_type_to_string(ChargingProfileKindType e) {
-    return ChargingProfileKindTypeStrings.at(e);
-}
+const std::string charging_profile_kind_type_to_string(ChargingProfileKindType e);
 
 /// \brief Converts the given std::string \p s to ChargingProfileKindType
 /// \returns a ChargingProfileKindType from a string representation
-static const ChargingProfileKindType string_to_charging_profile_kind_type(std::string s) {
-    return ChargingProfileKindTypeValues.at(s);
-}
+const ChargingProfileKindType string_to_charging_profile_kind_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfileKindType \p charging_profile_kind_type to the
 /// given output stream \p os \returns an output stream with the ChargingProfileKindType written to
-inline std::ostream& operator<<(std::ostream& os, const ChargingProfileKindType& charging_profile_kind_type) {
-    os << conversions::charging_profile_kind_type_to_string(charging_profile_kind_type);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ChargingProfileKindType& charging_profile_kind_type);
 
 // from: RemoteStartTransactionRequest
 enum class RecurrencyKindType
@@ -956,35 +524,20 @@ enum class RecurrencyKindType
     Daily,
     Weekly,
 };
-namespace conversions {
-static const std::map<RecurrencyKindType, std::string> RecurrencyKindTypeStrings{
-    {RecurrencyKindType::Daily, "Daily"},
-    {RecurrencyKindType::Weekly, "Weekly"},
-};
-static const std::map<std::string, RecurrencyKindType> RecurrencyKindTypeValues{
-    {"Daily", RecurrencyKindType::Daily},
-    {"Weekly", RecurrencyKindType::Weekly},
-};
 
+namespace conversions {
 /// \brief Converts the given RecurrencyKindType \p e to human readable string
 /// \returns a string representation of the RecurrencyKindType
-static const std::string recurrency_kind_type_to_string(RecurrencyKindType e) {
-    return RecurrencyKindTypeStrings.at(e);
-}
+const std::string recurrency_kind_type_to_string(RecurrencyKindType e);
 
 /// \brief Converts the given std::string \p s to RecurrencyKindType
 /// \returns a RecurrencyKindType from a string representation
-static const RecurrencyKindType string_to_recurrency_kind_type(std::string s) {
-    return RecurrencyKindTypeValues.at(s);
-}
+const RecurrencyKindType string_to_recurrency_kind_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RecurrencyKindType \p recurrency_kind_type to the given output
 /// stream \p os \returns an output stream with the RecurrencyKindType written to
-inline std::ostream& operator<<(std::ostream& os, const RecurrencyKindType& recurrency_kind_type) {
-    os << conversions::recurrency_kind_type_to_string(recurrency_kind_type);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const RecurrencyKindType& recurrency_kind_type);
 
 // from: RemoteStartTransactionResponse
 enum class RemoteStartStopStatus
@@ -992,35 +545,20 @@ enum class RemoteStartStopStatus
     Accepted,
     Rejected,
 };
-namespace conversions {
-static const std::map<RemoteStartStopStatus, std::string> RemoteStartStopStatusStrings{
-    {RemoteStartStopStatus::Accepted, "Accepted"},
-    {RemoteStartStopStatus::Rejected, "Rejected"},
-};
-static const std::map<std::string, RemoteStartStopStatus> RemoteStartStopStatusValues{
-    {"Accepted", RemoteStartStopStatus::Accepted},
-    {"Rejected", RemoteStartStopStatus::Rejected},
-};
 
+namespace conversions {
 /// \brief Converts the given RemoteStartStopStatus \p e to human readable string
 /// \returns a string representation of the RemoteStartStopStatus
-static const std::string remote_start_stop_status_to_string(RemoteStartStopStatus e) {
-    return RemoteStartStopStatusStrings.at(e);
-}
+const std::string remote_start_stop_status_to_string(RemoteStartStopStatus e);
 
 /// \brief Converts the given std::string \p s to RemoteStartStopStatus
 /// \returns a RemoteStartStopStatus from a string representation
-static const RemoteStartStopStatus string_to_remote_start_stop_status(std::string s) {
-    return RemoteStartStopStatusValues.at(s);
-}
+const RemoteStartStopStatus string_to_remote_start_stop_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given RemoteStartStopStatus \p remote_start_stop_status to the given
 /// output stream \p os \returns an output stream with the RemoteStartStopStatus written to
-inline std::ostream& operator<<(std::ostream& os, const RemoteStartStopStatus& remote_start_stop_status) {
-    os << conversions::remote_start_stop_status_to_string(remote_start_stop_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const RemoteStartStopStatus& remote_start_stop_status);
 
 // from: ReserveNowResponse
 enum class ReservationStatus
@@ -1031,37 +569,20 @@ enum class ReservationStatus
     Rejected,
     Unavailable,
 };
-namespace conversions {
-static const std::map<ReservationStatus, std::string> ReservationStatusStrings{
-    {ReservationStatus::Accepted, "Accepted"},       {ReservationStatus::Faulted, "Faulted"},
-    {ReservationStatus::Occupied, "Occupied"},       {ReservationStatus::Rejected, "Rejected"},
-    {ReservationStatus::Unavailable, "Unavailable"},
-};
-static const std::map<std::string, ReservationStatus> ReservationStatusValues{
-    {"Accepted", ReservationStatus::Accepted},       {"Faulted", ReservationStatus::Faulted},
-    {"Occupied", ReservationStatus::Occupied},       {"Rejected", ReservationStatus::Rejected},
-    {"Unavailable", ReservationStatus::Unavailable},
-};
 
+namespace conversions {
 /// \brief Converts the given ReservationStatus \p e to human readable string
 /// \returns a string representation of the ReservationStatus
-static const std::string reservation_status_to_string(ReservationStatus e) {
-    return ReservationStatusStrings.at(e);
-}
+const std::string reservation_status_to_string(ReservationStatus e);
 
 /// \brief Converts the given std::string \p s to ReservationStatus
 /// \returns a ReservationStatus from a string representation
-static const ReservationStatus string_to_reservation_status(std::string s) {
-    return ReservationStatusValues.at(s);
-}
+const ReservationStatus string_to_reservation_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ReservationStatus \p reservation_status to the given output
 /// stream \p os \returns an output stream with the ReservationStatus written to
-inline std::ostream& operator<<(std::ostream& os, const ReservationStatus& reservation_status) {
-    os << conversions::reservation_status_to_string(reservation_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ReservationStatus& reservation_status);
 
 // from: ResetRequest
 enum class ResetType
@@ -1069,35 +590,20 @@ enum class ResetType
     Hard,
     Soft,
 };
-namespace conversions {
-static const std::map<ResetType, std::string> ResetTypeStrings{
-    {ResetType::Hard, "Hard"},
-    {ResetType::Soft, "Soft"},
-};
-static const std::map<std::string, ResetType> ResetTypeValues{
-    {"Hard", ResetType::Hard},
-    {"Soft", ResetType::Soft},
-};
 
+namespace conversions {
 /// \brief Converts the given ResetType \p e to human readable string
 /// \returns a string representation of the ResetType
-static const std::string reset_type_to_string(ResetType e) {
-    return ResetTypeStrings.at(e);
-}
+const std::string reset_type_to_string(ResetType e);
 
 /// \brief Converts the given std::string \p s to ResetType
 /// \returns a ResetType from a string representation
-static const ResetType string_to_reset_type(std::string s) {
-    return ResetTypeValues.at(s);
-}
+const ResetType string_to_reset_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ResetType \p reset_type to the given output stream \p os
 /// \returns an output stream with the ResetType written to
-inline std::ostream& operator<<(std::ostream& os, const ResetType& reset_type) {
-    os << conversions::reset_type_to_string(reset_type);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ResetType& reset_type);
 
 // from: ResetResponse
 enum class ResetStatus
@@ -1105,35 +611,20 @@ enum class ResetStatus
     Accepted,
     Rejected,
 };
-namespace conversions {
-static const std::map<ResetStatus, std::string> ResetStatusStrings{
-    {ResetStatus::Accepted, "Accepted"},
-    {ResetStatus::Rejected, "Rejected"},
-};
-static const std::map<std::string, ResetStatus> ResetStatusValues{
-    {"Accepted", ResetStatus::Accepted},
-    {"Rejected", ResetStatus::Rejected},
-};
 
+namespace conversions {
 /// \brief Converts the given ResetStatus \p e to human readable string
 /// \returns a string representation of the ResetStatus
-static const std::string reset_status_to_string(ResetStatus e) {
-    return ResetStatusStrings.at(e);
-}
+const std::string reset_status_to_string(ResetStatus e);
 
 /// \brief Converts the given std::string \p s to ResetStatus
 /// \returns a ResetStatus from a string representation
-static const ResetStatus string_to_reset_status(std::string s) {
-    return ResetStatusValues.at(s);
-}
+const ResetStatus string_to_reset_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ResetStatus \p reset_status to the given output stream \p os
 /// \returns an output stream with the ResetStatus written to
-inline std::ostream& operator<<(std::ostream& os, const ResetStatus& reset_status) {
-    os << conversions::reset_status_to_string(reset_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ResetStatus& reset_status);
 
 // from: SendLocalListRequest
 enum class UpdateType
@@ -1141,35 +632,20 @@ enum class UpdateType
     Differential,
     Full,
 };
-namespace conversions {
-static const std::map<UpdateType, std::string> UpdateTypeStrings{
-    {UpdateType::Differential, "Differential"},
-    {UpdateType::Full, "Full"},
-};
-static const std::map<std::string, UpdateType> UpdateTypeValues{
-    {"Differential", UpdateType::Differential},
-    {"Full", UpdateType::Full},
-};
 
+namespace conversions {
 /// \brief Converts the given UpdateType \p e to human readable string
 /// \returns a string representation of the UpdateType
-static const std::string update_type_to_string(UpdateType e) {
-    return UpdateTypeStrings.at(e);
-}
+const std::string update_type_to_string(UpdateType e);
 
 /// \brief Converts the given std::string \p s to UpdateType
 /// \returns a UpdateType from a string representation
-static const UpdateType string_to_update_type(std::string s) {
-    return UpdateTypeValues.at(s);
-}
+const UpdateType string_to_update_type(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UpdateType \p update_type to the given output stream \p os
 /// \returns an output stream with the UpdateType written to
-inline std::ostream& operator<<(std::ostream& os, const UpdateType& update_type) {
-    os << conversions::update_type_to_string(update_type);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const UpdateType& update_type);
 
 // from: SendLocalListResponse
 enum class UpdateStatus
@@ -1179,39 +655,20 @@ enum class UpdateStatus
     NotSupported,
     VersionMismatch,
 };
-namespace conversions {
-static const std::map<UpdateStatus, std::string> UpdateStatusStrings{
-    {UpdateStatus::Accepted, "Accepted"},
-    {UpdateStatus::Failed, "Failed"},
-    {UpdateStatus::NotSupported, "NotSupported"},
-    {UpdateStatus::VersionMismatch, "VersionMismatch"},
-};
-static const std::map<std::string, UpdateStatus> UpdateStatusValues{
-    {"Accepted", UpdateStatus::Accepted},
-    {"Failed", UpdateStatus::Failed},
-    {"NotSupported", UpdateStatus::NotSupported},
-    {"VersionMismatch", UpdateStatus::VersionMismatch},
-};
 
+namespace conversions {
 /// \brief Converts the given UpdateStatus \p e to human readable string
 /// \returns a string representation of the UpdateStatus
-static const std::string update_status_to_string(UpdateStatus e) {
-    return UpdateStatusStrings.at(e);
-}
+const std::string update_status_to_string(UpdateStatus e);
 
 /// \brief Converts the given std::string \p s to UpdateStatus
 /// \returns a UpdateStatus from a string representation
-static const UpdateStatus string_to_update_status(std::string s) {
-    return UpdateStatusValues.at(s);
-}
+const UpdateStatus string_to_update_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UpdateStatus \p update_status to the given output stream \p os
 /// \returns an output stream with the UpdateStatus written to
-inline std::ostream& operator<<(std::ostream& os, const UpdateStatus& update_status) {
-    os << conversions::update_status_to_string(update_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const UpdateStatus& update_status);
 
 // from: SetChargingProfileResponse
 enum class ChargingProfileStatus
@@ -1220,37 +677,20 @@ enum class ChargingProfileStatus
     Rejected,
     NotSupported,
 };
-namespace conversions {
-static const std::map<ChargingProfileStatus, std::string> ChargingProfileStatusStrings{
-    {ChargingProfileStatus::Accepted, "Accepted"},
-    {ChargingProfileStatus::Rejected, "Rejected"},
-    {ChargingProfileStatus::NotSupported, "NotSupported"},
-};
-static const std::map<std::string, ChargingProfileStatus> ChargingProfileStatusValues{
-    {"Accepted", ChargingProfileStatus::Accepted},
-    {"Rejected", ChargingProfileStatus::Rejected},
-    {"NotSupported", ChargingProfileStatus::NotSupported},
-};
 
+namespace conversions {
 /// \brief Converts the given ChargingProfileStatus \p e to human readable string
 /// \returns a string representation of the ChargingProfileStatus
-static const std::string charging_profile_status_to_string(ChargingProfileStatus e) {
-    return ChargingProfileStatusStrings.at(e);
-}
+const std::string charging_profile_status_to_string(ChargingProfileStatus e);
 
 /// \brief Converts the given std::string \p s to ChargingProfileStatus
 /// \returns a ChargingProfileStatus from a string representation
-static const ChargingProfileStatus string_to_charging_profile_status(std::string s) {
-    return ChargingProfileStatusValues.at(s);
-}
+const ChargingProfileStatus string_to_charging_profile_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargingProfileStatus \p charging_profile_status to the given
 /// output stream \p os \returns an output stream with the ChargingProfileStatus written to
-inline std::ostream& operator<<(std::ostream& os, const ChargingProfileStatus& charging_profile_status) {
-    os << conversions::charging_profile_status_to_string(charging_profile_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ChargingProfileStatus& charging_profile_status);
 
 // from: StatusNotificationRequest
 enum class ChargePointErrorCode
@@ -1272,63 +712,20 @@ enum class ChargePointErrorCode
     OverVoltage,
     WeakSignal,
 };
-namespace conversions {
-static const std::map<ChargePointErrorCode, std::string> ChargePointErrorCodeStrings{
-    {ChargePointErrorCode::ConnectorLockFailure, "ConnectorLockFailure"},
-    {ChargePointErrorCode::EVCommunicationError, "EVCommunicationError"},
-    {ChargePointErrorCode::GroundFailure, "GroundFailure"},
-    {ChargePointErrorCode::HighTemperature, "HighTemperature"},
-    {ChargePointErrorCode::InternalError, "InternalError"},
-    {ChargePointErrorCode::LocalListConflict, "LocalListConflict"},
-    {ChargePointErrorCode::NoError, "NoError"},
-    {ChargePointErrorCode::OtherError, "OtherError"},
-    {ChargePointErrorCode::OverCurrentFailure, "OverCurrentFailure"},
-    {ChargePointErrorCode::PowerMeterFailure, "PowerMeterFailure"},
-    {ChargePointErrorCode::PowerSwitchFailure, "PowerSwitchFailure"},
-    {ChargePointErrorCode::ReaderFailure, "ReaderFailure"},
-    {ChargePointErrorCode::ResetFailure, "ResetFailure"},
-    {ChargePointErrorCode::UnderVoltage, "UnderVoltage"},
-    {ChargePointErrorCode::OverVoltage, "OverVoltage"},
-    {ChargePointErrorCode::WeakSignal, "WeakSignal"},
-};
-static const std::map<std::string, ChargePointErrorCode> ChargePointErrorCodeValues{
-    {"ConnectorLockFailure", ChargePointErrorCode::ConnectorLockFailure},
-    {"EVCommunicationError", ChargePointErrorCode::EVCommunicationError},
-    {"GroundFailure", ChargePointErrorCode::GroundFailure},
-    {"HighTemperature", ChargePointErrorCode::HighTemperature},
-    {"InternalError", ChargePointErrorCode::InternalError},
-    {"LocalListConflict", ChargePointErrorCode::LocalListConflict},
-    {"NoError", ChargePointErrorCode::NoError},
-    {"OtherError", ChargePointErrorCode::OtherError},
-    {"OverCurrentFailure", ChargePointErrorCode::OverCurrentFailure},
-    {"PowerMeterFailure", ChargePointErrorCode::PowerMeterFailure},
-    {"PowerSwitchFailure", ChargePointErrorCode::PowerSwitchFailure},
-    {"ReaderFailure", ChargePointErrorCode::ReaderFailure},
-    {"ResetFailure", ChargePointErrorCode::ResetFailure},
-    {"UnderVoltage", ChargePointErrorCode::UnderVoltage},
-    {"OverVoltage", ChargePointErrorCode::OverVoltage},
-    {"WeakSignal", ChargePointErrorCode::WeakSignal},
-};
 
+namespace conversions {
 /// \brief Converts the given ChargePointErrorCode \p e to human readable string
 /// \returns a string representation of the ChargePointErrorCode
-static const std::string charge_point_error_code_to_string(ChargePointErrorCode e) {
-    return ChargePointErrorCodeStrings.at(e);
-}
+const std::string charge_point_error_code_to_string(ChargePointErrorCode e);
 
 /// \brief Converts the given std::string \p s to ChargePointErrorCode
 /// \returns a ChargePointErrorCode from a string representation
-static const ChargePointErrorCode string_to_charge_point_error_code(std::string s) {
-    return ChargePointErrorCodeValues.at(s);
-}
+const ChargePointErrorCode string_to_charge_point_error_code(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargePointErrorCode \p charge_point_error_code to the given
 /// output stream \p os \returns an output stream with the ChargePointErrorCode written to
-inline std::ostream& operator<<(std::ostream& os, const ChargePointErrorCode& charge_point_error_code) {
-    os << conversions::charge_point_error_code_to_string(charge_point_error_code);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ChargePointErrorCode& charge_point_error_code);
 
 // from: StatusNotificationRequest
 enum class ChargePointStatus
@@ -1343,41 +740,20 @@ enum class ChargePointStatus
     Unavailable,
     Faulted,
 };
-namespace conversions {
-static const std::map<ChargePointStatus, std::string> ChargePointStatusStrings{
-    {ChargePointStatus::Available, "Available"},     {ChargePointStatus::Preparing, "Preparing"},
-    {ChargePointStatus::Charging, "Charging"},       {ChargePointStatus::SuspendedEVSE, "SuspendedEVSE"},
-    {ChargePointStatus::SuspendedEV, "SuspendedEV"}, {ChargePointStatus::Finishing, "Finishing"},
-    {ChargePointStatus::Reserved, "Reserved"},       {ChargePointStatus::Unavailable, "Unavailable"},
-    {ChargePointStatus::Faulted, "Faulted"},
-};
-static const std::map<std::string, ChargePointStatus> ChargePointStatusValues{
-    {"Available", ChargePointStatus::Available},     {"Preparing", ChargePointStatus::Preparing},
-    {"Charging", ChargePointStatus::Charging},       {"SuspendedEVSE", ChargePointStatus::SuspendedEVSE},
-    {"SuspendedEV", ChargePointStatus::SuspendedEV}, {"Finishing", ChargePointStatus::Finishing},
-    {"Reserved", ChargePointStatus::Reserved},       {"Unavailable", ChargePointStatus::Unavailable},
-    {"Faulted", ChargePointStatus::Faulted},
-};
 
+namespace conversions {
 /// \brief Converts the given ChargePointStatus \p e to human readable string
 /// \returns a string representation of the ChargePointStatus
-static const std::string charge_point_status_to_string(ChargePointStatus e) {
-    return ChargePointStatusStrings.at(e);
-}
+const std::string charge_point_status_to_string(ChargePointStatus e);
 
 /// \brief Converts the given std::string \p s to ChargePointStatus
 /// \returns a ChargePointStatus from a string representation
-static const ChargePointStatus string_to_charge_point_status(std::string s) {
-    return ChargePointStatusValues.at(s);
-}
+const ChargePointStatus string_to_charge_point_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given ChargePointStatus \p charge_point_status to the given output
 /// stream \p os \returns an output stream with the ChargePointStatus written to
-inline std::ostream& operator<<(std::ostream& os, const ChargePointStatus& charge_point_status) {
-    os << conversions::charge_point_status_to_string(charge_point_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ChargePointStatus& charge_point_status);
 
 // from: StopTransactionRequest
 enum class Reason
@@ -1394,53 +770,20 @@ enum class Reason
     UnlockCommand,
     DeAuthorized,
 };
-namespace conversions {
-static const std::map<Reason, std::string> ReasonStrings{
-    {Reason::EmergencyStop, "EmergencyStop"},
-    {Reason::EVDisconnected, "EVDisconnected"},
-    {Reason::HardReset, "HardReset"},
-    {Reason::Local, "Local"},
-    {Reason::Other, "Other"},
-    {Reason::PowerLoss, "PowerLoss"},
-    {Reason::Reboot, "Reboot"},
-    {Reason::Remote, "Remote"},
-    {Reason::SoftReset, "SoftReset"},
-    {Reason::UnlockCommand, "UnlockCommand"},
-    {Reason::DeAuthorized, "DeAuthorized"},
-};
-static const std::map<std::string, Reason> ReasonValues{
-    {"EmergencyStop", Reason::EmergencyStop},
-    {"EVDisconnected", Reason::EVDisconnected},
-    {"HardReset", Reason::HardReset},
-    {"Local", Reason::Local},
-    {"Other", Reason::Other},
-    {"PowerLoss", Reason::PowerLoss},
-    {"Reboot", Reason::Reboot},
-    {"Remote", Reason::Remote},
-    {"SoftReset", Reason::SoftReset},
-    {"UnlockCommand", Reason::UnlockCommand},
-    {"DeAuthorized", Reason::DeAuthorized},
-};
 
+namespace conversions {
 /// \brief Converts the given Reason \p e to human readable string
 /// \returns a string representation of the Reason
-static const std::string reason_to_string(Reason e) {
-    return ReasonStrings.at(e);
-}
+const std::string reason_to_string(Reason e);
 
 /// \brief Converts the given std::string \p s to Reason
 /// \returns a Reason from a string representation
-static const Reason string_to_reason(std::string s) {
-    return ReasonValues.at(s);
-}
+const Reason string_to_reason(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given Reason \p reason to the given output stream \p os
 /// \returns an output stream with the Reason written to
-inline std::ostream& operator<<(std::ostream& os, const Reason& reason) {
-    os << conversions::reason_to_string(reason);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const Reason& reason);
 
 // from: TriggerMessageRequest
 enum class MessageTrigger
@@ -1452,43 +795,20 @@ enum class MessageTrigger
     MeterValues,
     StatusNotification,
 };
-namespace conversions {
-static const std::map<MessageTrigger, std::string> MessageTriggerStrings{
-    {MessageTrigger::BootNotification, "BootNotification"},
-    {MessageTrigger::DiagnosticsStatusNotification, "DiagnosticsStatusNotification"},
-    {MessageTrigger::FirmwareStatusNotification, "FirmwareStatusNotification"},
-    {MessageTrigger::Heartbeat, "Heartbeat"},
-    {MessageTrigger::MeterValues, "MeterValues"},
-    {MessageTrigger::StatusNotification, "StatusNotification"},
-};
-static const std::map<std::string, MessageTrigger> MessageTriggerValues{
-    {"BootNotification", MessageTrigger::BootNotification},
-    {"DiagnosticsStatusNotification", MessageTrigger::DiagnosticsStatusNotification},
-    {"FirmwareStatusNotification", MessageTrigger::FirmwareStatusNotification},
-    {"Heartbeat", MessageTrigger::Heartbeat},
-    {"MeterValues", MessageTrigger::MeterValues},
-    {"StatusNotification", MessageTrigger::StatusNotification},
-};
 
+namespace conversions {
 /// \brief Converts the given MessageTrigger \p e to human readable string
 /// \returns a string representation of the MessageTrigger
-static const std::string message_trigger_to_string(MessageTrigger e) {
-    return MessageTriggerStrings.at(e);
-}
+const std::string message_trigger_to_string(MessageTrigger e);
 
 /// \brief Converts the given std::string \p s to MessageTrigger
 /// \returns a MessageTrigger from a string representation
-static const MessageTrigger string_to_message_trigger(std::string s) {
-    return MessageTriggerValues.at(s);
-}
+const MessageTrigger string_to_message_trigger(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given MessageTrigger \p message_trigger to the given output stream \p
 /// os \returns an output stream with the MessageTrigger written to
-inline std::ostream& operator<<(std::ostream& os, const MessageTrigger& message_trigger) {
-    os << conversions::message_trigger_to_string(message_trigger);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const MessageTrigger& message_trigger);
 
 // from: TriggerMessageResponse
 enum class TriggerMessageStatus
@@ -1497,37 +817,20 @@ enum class TriggerMessageStatus
     Rejected,
     NotImplemented,
 };
-namespace conversions {
-static const std::map<TriggerMessageStatus, std::string> TriggerMessageStatusStrings{
-    {TriggerMessageStatus::Accepted, "Accepted"},
-    {TriggerMessageStatus::Rejected, "Rejected"},
-    {TriggerMessageStatus::NotImplemented, "NotImplemented"},
-};
-static const std::map<std::string, TriggerMessageStatus> TriggerMessageStatusValues{
-    {"Accepted", TriggerMessageStatus::Accepted},
-    {"Rejected", TriggerMessageStatus::Rejected},
-    {"NotImplemented", TriggerMessageStatus::NotImplemented},
-};
 
+namespace conversions {
 /// \brief Converts the given TriggerMessageStatus \p e to human readable string
 /// \returns a string representation of the TriggerMessageStatus
-static const std::string trigger_message_status_to_string(TriggerMessageStatus e) {
-    return TriggerMessageStatusStrings.at(e);
-}
+const std::string trigger_message_status_to_string(TriggerMessageStatus e);
 
 /// \brief Converts the given std::string \p s to TriggerMessageStatus
 /// \returns a TriggerMessageStatus from a string representation
-static const TriggerMessageStatus string_to_trigger_message_status(std::string s) {
-    return TriggerMessageStatusValues.at(s);
-}
+const TriggerMessageStatus string_to_trigger_message_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given TriggerMessageStatus \p trigger_message_status to the given
 /// output stream \p os \returns an output stream with the TriggerMessageStatus written to
-inline std::ostream& operator<<(std::ostream& os, const TriggerMessageStatus& trigger_message_status) {
-    os << conversions::trigger_message_status_to_string(trigger_message_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const TriggerMessageStatus& trigger_message_status);
 
 // from: UnlockConnectorResponse
 enum class UnlockStatus
@@ -1536,37 +839,20 @@ enum class UnlockStatus
     UnlockFailed,
     NotSupported,
 };
-namespace conversions {
-static const std::map<UnlockStatus, std::string> UnlockStatusStrings{
-    {UnlockStatus::Unlocked, "Unlocked"},
-    {UnlockStatus::UnlockFailed, "UnlockFailed"},
-    {UnlockStatus::NotSupported, "NotSupported"},
-};
-static const std::map<std::string, UnlockStatus> UnlockStatusValues{
-    {"Unlocked", UnlockStatus::Unlocked},
-    {"UnlockFailed", UnlockStatus::UnlockFailed},
-    {"NotSupported", UnlockStatus::NotSupported},
-};
 
+namespace conversions {
 /// \brief Converts the given UnlockStatus \p e to human readable string
 /// \returns a string representation of the UnlockStatus
-static const std::string unlock_status_to_string(UnlockStatus e) {
-    return UnlockStatusStrings.at(e);
-}
+const std::string unlock_status_to_string(UnlockStatus e);
 
 /// \brief Converts the given std::string \p s to UnlockStatus
 /// \returns a UnlockStatus from a string representation
-static const UnlockStatus string_to_unlock_status(std::string s) {
-    return UnlockStatusValues.at(s);
-}
+const UnlockStatus string_to_unlock_status(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given UnlockStatus \p unlock_status to the given output stream \p os
 /// \returns an output stream with the UnlockStatus written to
-inline std::ostream& operator<<(std::ostream& os, const UnlockStatus& unlock_status) {
-    os << conversions::unlock_status_to_string(unlock_status);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const UnlockStatus& unlock_status);
 } // namespace ocpp1_6
 
 #endif // OCPP1_6_ENUMS_HPP

--- a/include/ocpp1_6/message_queue.hpp
+++ b/include/ocpp1_6/message_queue.hpp
@@ -48,7 +48,7 @@ struct ControlMessage {
     DateTime timestamp;                    ///< A timestamp that shows when this message can be sent
 
     /// \brief Creates a new ControlMessage object from the provided \p message
-    ControlMessage(json message) {
+    explicit ControlMessage(json message) {
         this->message = message.get<json::array_t>();
         this->messageType = conversions::string_to_messagetype(message.at(CALL_ACTION));
         this->message_attempts = 0;

--- a/include/ocpp1_6/message_queue.hpp
+++ b/include/ocpp1_6/message_queue.hpp
@@ -15,10 +15,11 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
-#include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/types.hpp>
 
 namespace ocpp1_6 {
+
+class ChargePointConfiguration;
 
 /// \brief Contains a OCPP message in json form with additional information
 struct EnhancedMessage {

--- a/include/ocpp1_6/message_queue.hpp
+++ b/include/ocpp1_6/message_queue.hpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <deque>
+#include <future>
 #include <mutex>
 #include <queue>
 #include <thread>
@@ -13,8 +14,6 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-
-#include <everest/timer.hpp>
 
 #include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/types.hpp>
@@ -94,7 +93,6 @@ public:
     /// \brief pushes a new \p call message onto the message queue
     template <class T> void push(Call<T> call) {
         auto* message = new ControlMessage(call);
-        EVLOG(debug) << "Adding Call message " << message->messageType << " with uid " << call.uniqueId << " to queue";
         if (this->isTransactionMessage(message)) {
             // according to the spec the "transaction related messages" StartTransaction, StopTransaction and
             // MeterValues have to be delivered in chronological order
@@ -114,7 +112,6 @@ public:
     /// \returns a future from which the CallResult can be extracted
     template <class T> std::future<EnhancedMessage> push_async(Call<T> call) {
         auto* message = new ControlMessage(call);
-        EVLOG(debug) << "Adding Call message " << message->messageType << " with uid " << call.uniqueId << " to queue";
         if (this->isTransactionMessage(message)) {
             // according to the spec the "transaction related messages" StartTransaction, StopTransaction and
             // MeterValues have to be delivered in chronological order

--- a/include/ocpp1_6/messages/Authorize.hpp
+++ b/include/ocpp1_6/messages/Authorize.hpp
@@ -13,34 +13,18 @@ struct AuthorizeRequest : public Message {
 
     /// \brief Provides the type of this Authorize message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "Authorize";
-    }
-
-    /// \brief Conversion from a given AuthorizeRequest \p k to a given json object \p j
-    friend void to_json(json& j, const AuthorizeRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"idTag", k.idTag},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given AuthorizeRequest \p k
-    friend void from_json(const json& j, AuthorizeRequest& k) {
-        // the required parts of the message
-        k.idTag = j.at("idTag");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given AuthorizeRequest \p k to the given output stream \p os
-    /// \returns an output stream with the AuthorizeRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const AuthorizeRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given AuthorizeRequest \p k to a given json object \p j
+void to_json(json& j, const AuthorizeRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given AuthorizeRequest \p k
+void from_json(const json& j, AuthorizeRequest& k);
+
+/// \brief Writes the string representation of the given AuthorizeRequest \p k to the given output stream \p os
+/// \returns an output stream with the AuthorizeRequest written to
+std::ostream& operator<<(std::ostream& os, const AuthorizeRequest& k);
 
 /// \brief Contains a OCPP 1.6 AuthorizeResponse message
 struct AuthorizeResponse : public Message {
@@ -48,34 +32,18 @@ struct AuthorizeResponse : public Message {
 
     /// \brief Provides the type of this AuthorizeResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "AuthorizeResponse";
-    }
-
-    /// \brief Conversion from a given AuthorizeResponse \p k to a given json object \p j
-    friend void to_json(json& j, const AuthorizeResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"idTagInfo", k.idTagInfo},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given AuthorizeResponse \p k
-    friend void from_json(const json& j, AuthorizeResponse& k) {
-        // the required parts of the message
-        k.idTagInfo = j.at("idTagInfo");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given AuthorizeResponse \p k to the given output stream \p os
-    /// \returns an output stream with the AuthorizeResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const AuthorizeResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given AuthorizeResponse \p k to a given json object \p j
+void to_json(json& j, const AuthorizeResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given AuthorizeResponse \p k
+void from_json(const json& j, AuthorizeResponse& k);
+
+/// \brief Writes the string representation of the given AuthorizeResponse \p k to the given output stream \p os
+/// \returns an output stream with the AuthorizeResponse written to
+std::ostream& operator<<(std::ostream& os, const AuthorizeResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/BootNotification.hpp
+++ b/include/ocpp1_6/messages/BootNotification.hpp
@@ -21,78 +21,18 @@ struct BootNotificationRequest : public Message {
 
     /// \brief Provides the type of this BootNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "BootNotification";
-    }
-
-    /// \brief Conversion from a given BootNotificationRequest \p k to a given json object \p j
-    friend void to_json(json& j, const BootNotificationRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"chargePointVendor", k.chargePointVendor},
-            {"chargePointModel", k.chargePointModel},
-        };
-        // the optional parts of the message
-        if (k.chargePointSerialNumber) {
-            j["chargePointSerialNumber"] = k.chargePointSerialNumber.value();
-        }
-        if (k.chargeBoxSerialNumber) {
-            j["chargeBoxSerialNumber"] = k.chargeBoxSerialNumber.value();
-        }
-        if (k.firmwareVersion) {
-            j["firmwareVersion"] = k.firmwareVersion.value();
-        }
-        if (k.iccid) {
-            j["iccid"] = k.iccid.value();
-        }
-        if (k.imsi) {
-            j["imsi"] = k.imsi.value();
-        }
-        if (k.meterType) {
-            j["meterType"] = k.meterType.value();
-        }
-        if (k.meterSerialNumber) {
-            j["meterSerialNumber"] = k.meterSerialNumber.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given BootNotificationRequest \p k
-    friend void from_json(const json& j, BootNotificationRequest& k) {
-        // the required parts of the message
-        k.chargePointVendor = j.at("chargePointVendor");
-        k.chargePointModel = j.at("chargePointModel");
-
-        // the optional parts of the message
-        if (j.contains("chargePointSerialNumber")) {
-            k.chargePointSerialNumber.emplace(j.at("chargePointSerialNumber"));
-        }
-        if (j.contains("chargeBoxSerialNumber")) {
-            k.chargeBoxSerialNumber.emplace(j.at("chargeBoxSerialNumber"));
-        }
-        if (j.contains("firmwareVersion")) {
-            k.firmwareVersion.emplace(j.at("firmwareVersion"));
-        }
-        if (j.contains("iccid")) {
-            k.iccid.emplace(j.at("iccid"));
-        }
-        if (j.contains("imsi")) {
-            k.imsi.emplace(j.at("imsi"));
-        }
-        if (j.contains("meterType")) {
-            k.meterType.emplace(j.at("meterType"));
-        }
-        if (j.contains("meterSerialNumber")) {
-            k.meterSerialNumber.emplace(j.at("meterSerialNumber"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given BootNotificationRequest \p k to the given output stream \p
-    /// os \returns an output stream with the BootNotificationRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const BootNotificationRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given BootNotificationRequest \p k to a given json object \p j
+void to_json(json& j, const BootNotificationRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given BootNotificationRequest \p k
+void from_json(const json& j, BootNotificationRequest& k);
+
+/// \brief Writes the string representation of the given BootNotificationRequest \p k to the given output stream \p os
+/// \returns an output stream with the BootNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const BootNotificationRequest& k);
 
 /// \brief Contains a OCPP 1.6 BootNotificationResponse message
 struct BootNotificationResponse : public Message {
@@ -102,39 +42,18 @@ struct BootNotificationResponse : public Message {
 
     /// \brief Provides the type of this BootNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "BootNotificationResponse";
-    }
-
-    /// \brief Conversion from a given BootNotificationResponse \p k to a given json object \p j
-    friend void to_json(json& j, const BootNotificationResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::registration_status_to_string(k.status)},
-            {"currentTime", k.currentTime.to_rfc3339()},
-            {"interval", k.interval},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given BootNotificationResponse \p k
-    friend void from_json(const json& j, BootNotificationResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_registration_status(j.at("status"));
-        k.currentTime = DateTime(std::string(j.at("currentTime")));
-        ;
-        k.interval = j.at("interval");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given BootNotificationResponse \p k to the given output stream \p
-    /// os \returns an output stream with the BootNotificationResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const BootNotificationResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given BootNotificationResponse \p k to a given json object \p j
+void to_json(json& j, const BootNotificationResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given BootNotificationResponse \p k
+void from_json(const json& j, BootNotificationResponse& k);
+
+/// \brief Writes the string representation of the given BootNotificationResponse \p k to the given output stream \p os
+/// \returns an output stream with the BootNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const BootNotificationResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/CancelReservation.hpp
+++ b/include/ocpp1_6/messages/CancelReservation.hpp
@@ -13,34 +13,18 @@ struct CancelReservationRequest : public Message {
 
     /// \brief Provides the type of this CancelReservation message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "CancelReservation";
-    }
-
-    /// \brief Conversion from a given CancelReservationRequest \p k to a given json object \p j
-    friend void to_json(json& j, const CancelReservationRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"reservationId", k.reservationId},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CancelReservationRequest \p k
-    friend void from_json(const json& j, CancelReservationRequest& k) {
-        // the required parts of the message
-        k.reservationId = j.at("reservationId");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given CancelReservationRequest \p k to the given output stream \p
-    /// os \returns an output stream with the CancelReservationRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const CancelReservationRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given CancelReservationRequest \p k to a given json object \p j
+void to_json(json& j, const CancelReservationRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given CancelReservationRequest \p k
+void from_json(const json& j, CancelReservationRequest& k);
+
+/// \brief Writes the string representation of the given CancelReservationRequest \p k to the given output stream \p os
+/// \returns an output stream with the CancelReservationRequest written to
+std::ostream& operator<<(std::ostream& os, const CancelReservationRequest& k);
 
 /// \brief Contains a OCPP 1.6 CancelReservationResponse message
 struct CancelReservationResponse : public Message {
@@ -48,34 +32,18 @@ struct CancelReservationResponse : public Message {
 
     /// \brief Provides the type of this CancelReservationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "CancelReservationResponse";
-    }
-
-    /// \brief Conversion from a given CancelReservationResponse \p k to a given json object \p j
-    friend void to_json(json& j, const CancelReservationResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::cancel_reservation_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CancelReservationResponse \p k
-    friend void from_json(const json& j, CancelReservationResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_cancel_reservation_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given CancelReservationResponse \p k to the given output stream
-    /// \p os \returns an output stream with the CancelReservationResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const CancelReservationResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given CancelReservationResponse \p k to a given json object \p j
+void to_json(json& j, const CancelReservationResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given CancelReservationResponse \p k
+void from_json(const json& j, CancelReservationResponse& k);
+
+/// \brief Writes the string representation of the given CancelReservationResponse \p k to the given output stream \p os
+/// \returns an output stream with the CancelReservationResponse written to
+std::ostream& operator<<(std::ostream& os, const CancelReservationResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/ChangeAvailability.hpp
+++ b/include/ocpp1_6/messages/ChangeAvailability.hpp
@@ -14,36 +14,18 @@ struct ChangeAvailabilityRequest : public Message {
 
     /// \brief Provides the type of this ChangeAvailability message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ChangeAvailability";
-    }
-
-    /// \brief Conversion from a given ChangeAvailabilityRequest \p k to a given json object \p j
-    friend void to_json(json& j, const ChangeAvailabilityRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-            {"type", conversions::availability_type_to_string(k.type)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ChangeAvailabilityRequest \p k
-    friend void from_json(const json& j, ChangeAvailabilityRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-        k.type = conversions::string_to_availability_type(j.at("type"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ChangeAvailabilityRequest \p k to the given output stream
-    /// \p os \returns an output stream with the ChangeAvailabilityRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const ChangeAvailabilityRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ChangeAvailabilityRequest \p k to a given json object \p j
+void to_json(json& j, const ChangeAvailabilityRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given ChangeAvailabilityRequest \p k
+void from_json(const json& j, ChangeAvailabilityRequest& k);
+
+/// \brief Writes the string representation of the given ChangeAvailabilityRequest \p k to the given output stream \p os
+/// \returns an output stream with the ChangeAvailabilityRequest written to
+std::ostream& operator<<(std::ostream& os, const ChangeAvailabilityRequest& k);
 
 /// \brief Contains a OCPP 1.6 ChangeAvailabilityResponse message
 struct ChangeAvailabilityResponse : public Message {
@@ -51,34 +33,18 @@ struct ChangeAvailabilityResponse : public Message {
 
     /// \brief Provides the type of this ChangeAvailabilityResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ChangeAvailabilityResponse";
-    }
-
-    /// \brief Conversion from a given ChangeAvailabilityResponse \p k to a given json object \p j
-    friend void to_json(json& j, const ChangeAvailabilityResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::availability_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ChangeAvailabilityResponse \p k
-    friend void from_json(const json& j, ChangeAvailabilityResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_availability_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ChangeAvailabilityResponse \p k to the given output stream
-    /// \p os \returns an output stream with the ChangeAvailabilityResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const ChangeAvailabilityResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ChangeAvailabilityResponse \p k to a given json object \p j
+void to_json(json& j, const ChangeAvailabilityResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given ChangeAvailabilityResponse \p k
+void from_json(const json& j, ChangeAvailabilityResponse& k);
+
+/// \brief Writes the string representation of the given ChangeAvailabilityResponse \p k to the given output stream \p
+/// os \returns an output stream with the ChangeAvailabilityResponse written to
+std::ostream& operator<<(std::ostream& os, const ChangeAvailabilityResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/ChangeConfiguration.hpp
+++ b/include/ocpp1_6/messages/ChangeConfiguration.hpp
@@ -14,36 +14,18 @@ struct ChangeConfigurationRequest : public Message {
 
     /// \brief Provides the type of this ChangeConfiguration message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ChangeConfiguration";
-    }
-
-    /// \brief Conversion from a given ChangeConfigurationRequest \p k to a given json object \p j
-    friend void to_json(json& j, const ChangeConfigurationRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"key", k.key},
-            {"value", k.value},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ChangeConfigurationRequest \p k
-    friend void from_json(const json& j, ChangeConfigurationRequest& k) {
-        // the required parts of the message
-        k.key = j.at("key");
-        k.value = j.at("value");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ChangeConfigurationRequest \p k to the given output stream
-    /// \p os \returns an output stream with the ChangeConfigurationRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const ChangeConfigurationRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ChangeConfigurationRequest \p k to a given json object \p j
+void to_json(json& j, const ChangeConfigurationRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given ChangeConfigurationRequest \p k
+void from_json(const json& j, ChangeConfigurationRequest& k);
+
+/// \brief Writes the string representation of the given ChangeConfigurationRequest \p k to the given output stream \p
+/// os \returns an output stream with the ChangeConfigurationRequest written to
+std::ostream& operator<<(std::ostream& os, const ChangeConfigurationRequest& k);
 
 /// \brief Contains a OCPP 1.6 ChangeConfigurationResponse message
 struct ChangeConfigurationResponse : public Message {
@@ -51,34 +33,18 @@ struct ChangeConfigurationResponse : public Message {
 
     /// \brief Provides the type of this ChangeConfigurationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ChangeConfigurationResponse";
-    }
-
-    /// \brief Conversion from a given ChangeConfigurationResponse \p k to a given json object \p j
-    friend void to_json(json& j, const ChangeConfigurationResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::configuration_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ChangeConfigurationResponse \p k
-    friend void from_json(const json& j, ChangeConfigurationResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_configuration_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ChangeConfigurationResponse \p k to the given output stream
-    /// \p os \returns an output stream with the ChangeConfigurationResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const ChangeConfigurationResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ChangeConfigurationResponse \p k to a given json object \p j
+void to_json(json& j, const ChangeConfigurationResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given ChangeConfigurationResponse \p k
+void from_json(const json& j, ChangeConfigurationResponse& k);
+
+/// \brief Writes the string representation of the given ChangeConfigurationResponse \p k to the given output stream \p
+/// os \returns an output stream with the ChangeConfigurationResponse written to
+std::ostream& operator<<(std::ostream& os, const ChangeConfigurationResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/ClearCache.hpp
+++ b/include/ocpp1_6/messages/ClearCache.hpp
@@ -12,31 +12,18 @@ struct ClearCacheRequest : public Message {
 
     /// \brief Provides the type of this ClearCache message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ClearCache";
-    }
-
-    /// \brief Conversion from a given ClearCacheRequest \p k to a given json object \p j
-    friend void to_json(json& j, const ClearCacheRequest& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ClearCacheRequest \p k
-    friend void from_json(const json& j, ClearCacheRequest& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ClearCacheRequest \p k to the given output stream \p os
-    /// \returns an output stream with the ClearCacheRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const ClearCacheRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ClearCacheRequest \p k to a given json object \p j
+void to_json(json& j, const ClearCacheRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given ClearCacheRequest \p k
+void from_json(const json& j, ClearCacheRequest& k);
+
+/// \brief Writes the string representation of the given ClearCacheRequest \p k to the given output stream \p os
+/// \returns an output stream with the ClearCacheRequest written to
+std::ostream& operator<<(std::ostream& os, const ClearCacheRequest& k);
 
 /// \brief Contains a OCPP 1.6 ClearCacheResponse message
 struct ClearCacheResponse : public Message {
@@ -44,34 +31,18 @@ struct ClearCacheResponse : public Message {
 
     /// \brief Provides the type of this ClearCacheResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ClearCacheResponse";
-    }
-
-    /// \brief Conversion from a given ClearCacheResponse \p k to a given json object \p j
-    friend void to_json(json& j, const ClearCacheResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::clear_cache_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ClearCacheResponse \p k
-    friend void from_json(const json& j, ClearCacheResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_clear_cache_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ClearCacheResponse \p k to the given output stream \p os
-    /// \returns an output stream with the ClearCacheResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const ClearCacheResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ClearCacheResponse \p k to a given json object \p j
+void to_json(json& j, const ClearCacheResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given ClearCacheResponse \p k
+void from_json(const json& j, ClearCacheResponse& k);
+
+/// \brief Writes the string representation of the given ClearCacheResponse \p k to the given output stream \p os
+/// \returns an output stream with the ClearCacheResponse written to
+std::ostream& operator<<(std::ostream& os, const ClearCacheResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/ClearChargingProfile.hpp
+++ b/include/ocpp1_6/messages/ClearChargingProfile.hpp
@@ -16,57 +16,18 @@ struct ClearChargingProfileRequest : public Message {
 
     /// \brief Provides the type of this ClearChargingProfile message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ClearChargingProfile";
-    }
-
-    /// \brief Conversion from a given ClearChargingProfileRequest \p k to a given json object \p j
-    friend void to_json(json& j, const ClearChargingProfileRequest& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-        if (k.id) {
-            j["id"] = k.id.value();
-        }
-        if (k.connectorId) {
-            j["connectorId"] = k.connectorId.value();
-        }
-        if (k.chargingProfilePurpose) {
-            j["chargingProfilePurpose"] =
-                conversions::charging_profile_purpose_type_to_string(k.chargingProfilePurpose.value());
-        }
-        if (k.stackLevel) {
-            j["stackLevel"] = k.stackLevel.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ClearChargingProfileRequest \p k
-    friend void from_json(const json& j, ClearChargingProfileRequest& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-        if (j.contains("id")) {
-            k.id.emplace(j.at("id"));
-        }
-        if (j.contains("connectorId")) {
-            k.connectorId.emplace(j.at("connectorId"));
-        }
-        if (j.contains("chargingProfilePurpose")) {
-            k.chargingProfilePurpose.emplace(
-                conversions::string_to_charging_profile_purpose_type(j.at("chargingProfilePurpose")));
-        }
-        if (j.contains("stackLevel")) {
-            k.stackLevel.emplace(j.at("stackLevel"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given ClearChargingProfileRequest \p k to the given output stream
-    /// \p os \returns an output stream with the ClearChargingProfileRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const ClearChargingProfileRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ClearChargingProfileRequest \p k to a given json object \p j
+void to_json(json& j, const ClearChargingProfileRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given ClearChargingProfileRequest \p k
+void from_json(const json& j, ClearChargingProfileRequest& k);
+
+/// \brief Writes the string representation of the given ClearChargingProfileRequest \p k to the given output stream \p
+/// os \returns an output stream with the ClearChargingProfileRequest written to
+std::ostream& operator<<(std::ostream& os, const ClearChargingProfileRequest& k);
 
 /// \brief Contains a OCPP 1.6 ClearChargingProfileResponse message
 struct ClearChargingProfileResponse : public Message {
@@ -74,34 +35,18 @@ struct ClearChargingProfileResponse : public Message {
 
     /// \brief Provides the type of this ClearChargingProfileResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ClearChargingProfileResponse";
-    }
-
-    /// \brief Conversion from a given ClearChargingProfileResponse \p k to a given json object \p j
-    friend void to_json(json& j, const ClearChargingProfileResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::clear_charging_profile_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ClearChargingProfileResponse \p k
-    friend void from_json(const json& j, ClearChargingProfileResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_clear_charging_profile_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ClearChargingProfileResponse \p k to the given output
-    /// stream \p os \returns an output stream with the ClearChargingProfileResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const ClearChargingProfileResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ClearChargingProfileResponse \p k to a given json object \p j
+void to_json(json& j, const ClearChargingProfileResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given ClearChargingProfileResponse \p k
+void from_json(const json& j, ClearChargingProfileResponse& k);
+
+/// \brief Writes the string representation of the given ClearChargingProfileResponse \p k to the given output stream \p
+/// os \returns an output stream with the ClearChargingProfileResponse written to
+std::ostream& operator<<(std::ostream& os, const ClearChargingProfileResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/DataTransfer.hpp
+++ b/include/ocpp1_6/messages/DataTransfer.hpp
@@ -15,46 +15,18 @@ struct DataTransferRequest : public Message {
 
     /// \brief Provides the type of this DataTransfer message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "DataTransfer";
-    }
-
-    /// \brief Conversion from a given DataTransferRequest \p k to a given json object \p j
-    friend void to_json(json& j, const DataTransferRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"vendorId", k.vendorId},
-        };
-        // the optional parts of the message
-        if (k.messageId) {
-            j["messageId"] = k.messageId.value();
-        }
-        if (k.data) {
-            j["data"] = k.data.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given DataTransferRequest \p k
-    friend void from_json(const json& j, DataTransferRequest& k) {
-        // the required parts of the message
-        k.vendorId = j.at("vendorId");
-
-        // the optional parts of the message
-        if (j.contains("messageId")) {
-            k.messageId.emplace(j.at("messageId"));
-        }
-        if (j.contains("data")) {
-            k.data.emplace(j.at("data"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given DataTransferRequest \p k to the given output stream \p os
-    /// \returns an output stream with the DataTransferRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const DataTransferRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given DataTransferRequest \p k to a given json object \p j
+void to_json(json& j, const DataTransferRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given DataTransferRequest \p k
+void from_json(const json& j, DataTransferRequest& k);
+
+/// \brief Writes the string representation of the given DataTransferRequest \p k to the given output stream \p os
+/// \returns an output stream with the DataTransferRequest written to
+std::ostream& operator<<(std::ostream& os, const DataTransferRequest& k);
 
 /// \brief Contains a OCPP 1.6 DataTransferResponse message
 struct DataTransferResponse : public Message {
@@ -63,40 +35,18 @@ struct DataTransferResponse : public Message {
 
     /// \brief Provides the type of this DataTransferResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "DataTransferResponse";
-    }
-
-    /// \brief Conversion from a given DataTransferResponse \p k to a given json object \p j
-    friend void to_json(json& j, const DataTransferResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::data_transfer_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-        if (k.data) {
-            j["data"] = k.data.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given DataTransferResponse \p k
-    friend void from_json(const json& j, DataTransferResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_data_transfer_status(j.at("status"));
-
-        // the optional parts of the message
-        if (j.contains("data")) {
-            k.data.emplace(j.at("data"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given DataTransferResponse \p k to the given output stream \p os
-    /// \returns an output stream with the DataTransferResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const DataTransferResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given DataTransferResponse \p k to a given json object \p j
+void to_json(json& j, const DataTransferResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given DataTransferResponse \p k
+void from_json(const json& j, DataTransferResponse& k);
+
+/// \brief Writes the string representation of the given DataTransferResponse \p k to the given output stream \p os
+/// \returns an output stream with the DataTransferResponse written to
+std::ostream& operator<<(std::ostream& os, const DataTransferResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/DiagnosticsStatusNotification.hpp
+++ b/include/ocpp1_6/messages/DiagnosticsStatusNotification.hpp
@@ -13,65 +13,36 @@ struct DiagnosticsStatusNotificationRequest : public Message {
 
     /// \brief Provides the type of this DiagnosticsStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "DiagnosticsStatusNotification";
-    }
-
-    /// \brief Conversion from a given DiagnosticsStatusNotificationRequest \p k to a given json object \p j
-    friend void to_json(json& j, const DiagnosticsStatusNotificationRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::diagnostics_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given DiagnosticsStatusNotificationRequest \p k
-    friend void from_json(const json& j, DiagnosticsStatusNotificationRequest& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_diagnostics_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given DiagnosticsStatusNotificationRequest \p k to the given
-    /// output stream \p os \returns an output stream with the DiagnosticsStatusNotificationRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const DiagnosticsStatusNotificationRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given DiagnosticsStatusNotificationRequest \p k to a given json object \p j
+void to_json(json& j, const DiagnosticsStatusNotificationRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given DiagnosticsStatusNotificationRequest \p k
+void from_json(const json& j, DiagnosticsStatusNotificationRequest& k);
+
+/// \brief Writes the string representation of the given DiagnosticsStatusNotificationRequest \p k to the given output
+/// stream \p os \returns an output stream with the DiagnosticsStatusNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const DiagnosticsStatusNotificationRequest& k);
 
 /// \brief Contains a OCPP 1.6 DiagnosticsStatusNotificationResponse message
 struct DiagnosticsStatusNotificationResponse : public Message {
 
     /// \brief Provides the type of this DiagnosticsStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "DiagnosticsStatusNotificationResponse";
-    }
-
-    /// \brief Conversion from a given DiagnosticsStatusNotificationResponse \p k to a given json object \p j
-    friend void to_json(json& j, const DiagnosticsStatusNotificationResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given DiagnosticsStatusNotificationResponse \p k
-    friend void from_json(const json& j, DiagnosticsStatusNotificationResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given DiagnosticsStatusNotificationResponse \p k to the given
-    /// output stream \p os \returns an output stream with the DiagnosticsStatusNotificationResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const DiagnosticsStatusNotificationResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given DiagnosticsStatusNotificationResponse \p k to a given json object \p j
+void to_json(json& j, const DiagnosticsStatusNotificationResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given DiagnosticsStatusNotificationResponse \p k
+void from_json(const json& j, DiagnosticsStatusNotificationResponse& k);
+
+/// \brief Writes the string representation of the given DiagnosticsStatusNotificationResponse \p k to the given output
+/// stream \p os \returns an output stream with the DiagnosticsStatusNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const DiagnosticsStatusNotificationResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/FirmwareStatusNotification.hpp
+++ b/include/ocpp1_6/messages/FirmwareStatusNotification.hpp
@@ -13,65 +13,36 @@ struct FirmwareStatusNotificationRequest : public Message {
 
     /// \brief Provides the type of this FirmwareStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "FirmwareStatusNotification";
-    }
-
-    /// \brief Conversion from a given FirmwareStatusNotificationRequest \p k to a given json object \p j
-    friend void to_json(json& j, const FirmwareStatusNotificationRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::firmware_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given FirmwareStatusNotificationRequest \p k
-    friend void from_json(const json& j, FirmwareStatusNotificationRequest& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_firmware_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given FirmwareStatusNotificationRequest \p k to the given output
-    /// stream \p os \returns an output stream with the FirmwareStatusNotificationRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const FirmwareStatusNotificationRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given FirmwareStatusNotificationRequest \p k to a given json object \p j
+void to_json(json& j, const FirmwareStatusNotificationRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given FirmwareStatusNotificationRequest \p k
+void from_json(const json& j, FirmwareStatusNotificationRequest& k);
+
+/// \brief Writes the string representation of the given FirmwareStatusNotificationRequest \p k to the given output
+/// stream \p os \returns an output stream with the FirmwareStatusNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const FirmwareStatusNotificationRequest& k);
 
 /// \brief Contains a OCPP 1.6 FirmwareStatusNotificationResponse message
 struct FirmwareStatusNotificationResponse : public Message {
 
     /// \brief Provides the type of this FirmwareStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "FirmwareStatusNotificationResponse";
-    }
-
-    /// \brief Conversion from a given FirmwareStatusNotificationResponse \p k to a given json object \p j
-    friend void to_json(json& j, const FirmwareStatusNotificationResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given FirmwareStatusNotificationResponse \p k
-    friend void from_json(const json& j, FirmwareStatusNotificationResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given FirmwareStatusNotificationResponse \p k to the given output
-    /// stream \p os \returns an output stream with the FirmwareStatusNotificationResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const FirmwareStatusNotificationResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given FirmwareStatusNotificationResponse \p k to a given json object \p j
+void to_json(json& j, const FirmwareStatusNotificationResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given FirmwareStatusNotificationResponse \p k
+void from_json(const json& j, FirmwareStatusNotificationResponse& k);
+
+/// \brief Writes the string representation of the given FirmwareStatusNotificationResponse \p k to the given output
+/// stream \p os \returns an output stream with the FirmwareStatusNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const FirmwareStatusNotificationResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/GetCompositeSchedule.hpp
+++ b/include/ocpp1_6/messages/GetCompositeSchedule.hpp
@@ -15,42 +15,18 @@ struct GetCompositeScheduleRequest : public Message {
 
     /// \brief Provides the type of this GetCompositeSchedule message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetCompositeSchedule";
-    }
-
-    /// \brief Conversion from a given GetCompositeScheduleRequest \p k to a given json object \p j
-    friend void to_json(json& j, const GetCompositeScheduleRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-            {"duration", k.duration},
-        };
-        // the optional parts of the message
-        if (k.chargingRateUnit) {
-            j["chargingRateUnit"] = conversions::charging_rate_unit_to_string(k.chargingRateUnit.value());
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetCompositeScheduleRequest \p k
-    friend void from_json(const json& j, GetCompositeScheduleRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-        k.duration = j.at("duration");
-
-        // the optional parts of the message
-        if (j.contains("chargingRateUnit")) {
-            k.chargingRateUnit.emplace(conversions::string_to_charging_rate_unit(j.at("chargingRateUnit")));
-        }
-    }
-
-    /// \brief Writes the string representation of the given GetCompositeScheduleRequest \p k to the given output stream
-    /// \p os \returns an output stream with the GetCompositeScheduleRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetCompositeScheduleRequest \p k to a given json object \p j
+void to_json(json& j, const GetCompositeScheduleRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given GetCompositeScheduleRequest \p k
+void from_json(const json& j, GetCompositeScheduleRequest& k);
+
+/// \brief Writes the string representation of the given GetCompositeScheduleRequest \p k to the given output stream \p
+/// os \returns an output stream with the GetCompositeScheduleRequest written to
+std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleRequest& k);
 
 /// \brief Contains a OCPP 1.6 GetCompositeScheduleResponse message
 struct GetCompositeScheduleResponse : public Message {
@@ -61,52 +37,18 @@ struct GetCompositeScheduleResponse : public Message {
 
     /// \brief Provides the type of this GetCompositeScheduleResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetCompositeScheduleResponse";
-    }
-
-    /// \brief Conversion from a given GetCompositeScheduleResponse \p k to a given json object \p j
-    friend void to_json(json& j, const GetCompositeScheduleResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::get_composite_schedule_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-        if (k.connectorId) {
-            j["connectorId"] = k.connectorId.value();
-        }
-        if (k.scheduleStart) {
-            j["scheduleStart"] = k.scheduleStart.value().to_rfc3339();
-        }
-        if (k.chargingSchedule) {
-            j["chargingSchedule"] = k.chargingSchedule.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetCompositeScheduleResponse \p k
-    friend void from_json(const json& j, GetCompositeScheduleResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_get_composite_schedule_status(j.at("status"));
-
-        // the optional parts of the message
-        if (j.contains("connectorId")) {
-            k.connectorId.emplace(j.at("connectorId"));
-        }
-        if (j.contains("scheduleStart")) {
-            k.scheduleStart.emplace(DateTime(std::string(j.at("scheduleStart"))));
-        }
-        if (j.contains("chargingSchedule")) {
-            k.chargingSchedule.emplace(j.at("chargingSchedule"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given GetCompositeScheduleResponse \p k to the given output
-    /// stream \p os \returns an output stream with the GetCompositeScheduleResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetCompositeScheduleResponse \p k to a given json object \p j
+void to_json(json& j, const GetCompositeScheduleResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given GetCompositeScheduleResponse \p k
+void from_json(const json& j, GetCompositeScheduleResponse& k);
+
+/// \brief Writes the string representation of the given GetCompositeScheduleResponse \p k to the given output stream \p
+/// os \returns an output stream with the GetCompositeScheduleResponse written to
+std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/GetConfiguration.hpp
+++ b/include/ocpp1_6/messages/GetConfiguration.hpp
@@ -13,49 +13,18 @@ struct GetConfigurationRequest : public Message {
 
     /// \brief Provides the type of this GetConfiguration message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetConfiguration";
-    }
-
-    /// \brief Conversion from a given GetConfigurationRequest \p k to a given json object \p j
-    friend void to_json(json& j, const GetConfigurationRequest& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-        if (k.key) {
-            if (j.size() == 0) {
-                j = json{{"key", json::array()}};
-            } else {
-                j["key"] = json::array();
-            }
-            for (auto val : k.key.value()) {
-                j["key"].push_back(val);
-            }
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetConfigurationRequest \p k
-    friend void from_json(const json& j, GetConfigurationRequest& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-        if (j.contains("key")) {
-            json arr = j.at("key");
-            std::vector<CiString50Type> vec;
-            for (auto val : arr) {
-                vec.push_back(val);
-            }
-            k.key.emplace(vec);
-        }
-    }
-
-    /// \brief Writes the string representation of the given GetConfigurationRequest \p k to the given output stream \p
-    /// os \returns an output stream with the GetConfigurationRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const GetConfigurationRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetConfigurationRequest \p k to a given json object \p j
+void to_json(json& j, const GetConfigurationRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given GetConfigurationRequest \p k
+void from_json(const json& j, GetConfigurationRequest& k);
+
+/// \brief Writes the string representation of the given GetConfigurationRequest \p k to the given output stream \p os
+/// \returns an output stream with the GetConfigurationRequest written to
+std::ostream& operator<<(std::ostream& os, const GetConfigurationRequest& k);
 
 /// \brief Contains a OCPP 1.6 GetConfigurationResponse message
 struct GetConfigurationResponse : public Message {
@@ -64,67 +33,18 @@ struct GetConfigurationResponse : public Message {
 
     /// \brief Provides the type of this GetConfigurationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetConfigurationResponse";
-    }
-
-    /// \brief Conversion from a given GetConfigurationResponse \p k to a given json object \p j
-    friend void to_json(json& j, const GetConfigurationResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-        if (k.configurationKey) {
-            if (j.size() == 0) {
-                j = json{{"configurationKey", json::array()}};
-            } else {
-                j["configurationKey"] = json::array();
-            }
-            for (auto val : k.configurationKey.value()) {
-                j["configurationKey"].push_back(val);
-            }
-        }
-        if (k.unknownKey) {
-            if (j.size() == 0) {
-                j = json{{"unknownKey", json::array()}};
-            } else {
-                j["unknownKey"] = json::array();
-            }
-            for (auto val : k.unknownKey.value()) {
-                j["unknownKey"].push_back(val);
-            }
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetConfigurationResponse \p k
-    friend void from_json(const json& j, GetConfigurationResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-        if (j.contains("configurationKey")) {
-            json arr = j.at("configurationKey");
-            std::vector<KeyValue> vec;
-            for (auto val : arr) {
-                vec.push_back(val);
-            }
-            k.configurationKey.emplace(vec);
-        }
-        if (j.contains("unknownKey")) {
-            json arr = j.at("unknownKey");
-            std::vector<CiString50Type> vec;
-            for (auto val : arr) {
-                vec.push_back(val);
-            }
-            k.unknownKey.emplace(vec);
-        }
-    }
-
-    /// \brief Writes the string representation of the given GetConfigurationResponse \p k to the given output stream \p
-    /// os \returns an output stream with the GetConfigurationResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const GetConfigurationResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetConfigurationResponse \p k to a given json object \p j
+void to_json(json& j, const GetConfigurationResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given GetConfigurationResponse \p k
+void from_json(const json& j, GetConfigurationResponse& k);
+
+/// \brief Writes the string representation of the given GetConfigurationResponse \p k to the given output stream \p os
+/// \returns an output stream with the GetConfigurationResponse written to
+std::ostream& operator<<(std::ostream& os, const GetConfigurationResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/GetDiagnostics.hpp
+++ b/include/ocpp1_6/messages/GetDiagnostics.hpp
@@ -9,7 +9,7 @@ namespace ocpp1_6 {
 
 /// \brief Contains a OCPP 1.6 GetDiagnostics message
 struct GetDiagnosticsRequest : public Message {
-    TODO : std::string with format : uri location;
+    std::string location;
     boost::optional<int32_t> retries;
     boost::optional<int32_t> retryInterval;
     boost::optional<DateTime> startTime;
@@ -17,58 +17,18 @@ struct GetDiagnosticsRequest : public Message {
 
     /// \brief Provides the type of this GetDiagnostics message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetDiagnostics";
-    }
-
-    /// \brief Conversion from a given GetDiagnosticsRequest \p k to a given json object \p j
-    friend void to_json(json& j, const GetDiagnosticsRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"location", k.location},
-        };
-        // the optional parts of the message
-        if (k.retries) {
-            j["retries"] = k.retries.value();
-        }
-        if (k.retryInterval) {
-            j["retryInterval"] = k.retryInterval.value();
-        }
-        if (k.startTime) {
-            j["startTime"] = k.startTime.value().to_rfc3339();
-        }
-        if (k.stopTime) {
-            j["stopTime"] = k.stopTime.value().to_rfc3339();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetDiagnosticsRequest \p k
-    friend void from_json(const json& j, GetDiagnosticsRequest& k) {
-        // the required parts of the message
-        k.location = j.at("location");
-
-        // the optional parts of the message
-        if (j.contains("retries")) {
-            k.retries.emplace(j.at("retries"));
-        }
-        if (j.contains("retryInterval")) {
-            k.retryInterval.emplace(j.at("retryInterval"));
-        }
-        if (j.contains("startTime")) {
-            k.startTime.emplace(DateTime(std::string(j.at("startTime"))));
-        }
-        if (j.contains("stopTime")) {
-            k.stopTime.emplace(DateTime(std::string(j.at("stopTime"))));
-        }
-    }
-
-    /// \brief Writes the string representation of the given GetDiagnosticsRequest \p k to the given output stream \p os
-    /// \returns an output stream with the GetDiagnosticsRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const GetDiagnosticsRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetDiagnosticsRequest \p k to a given json object \p j
+void to_json(json& j, const GetDiagnosticsRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given GetDiagnosticsRequest \p k
+void from_json(const json& j, GetDiagnosticsRequest& k);
+
+/// \brief Writes the string representation of the given GetDiagnosticsRequest \p k to the given output stream \p os
+/// \returns an output stream with the GetDiagnosticsRequest written to
+std::ostream& operator<<(std::ostream& os, const GetDiagnosticsRequest& k);
 
 /// \brief Contains a OCPP 1.6 GetDiagnosticsResponse message
 struct GetDiagnosticsResponse : public Message {
@@ -76,37 +36,18 @@ struct GetDiagnosticsResponse : public Message {
 
     /// \brief Provides the type of this GetDiagnosticsResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetDiagnosticsResponse";
-    }
-
-    /// \brief Conversion from a given GetDiagnosticsResponse \p k to a given json object \p j
-    friend void to_json(json& j, const GetDiagnosticsResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-        if (k.fileName) {
-            j["fileName"] = k.fileName.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetDiagnosticsResponse \p k
-    friend void from_json(const json& j, GetDiagnosticsResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-        if (j.contains("fileName")) {
-            k.fileName.emplace(j.at("fileName"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given GetDiagnosticsResponse \p k to the given output stream \p
-    /// os \returns an output stream with the GetDiagnosticsResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const GetDiagnosticsResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetDiagnosticsResponse \p k to a given json object \p j
+void to_json(json& j, const GetDiagnosticsResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given GetDiagnosticsResponse \p k
+void from_json(const json& j, GetDiagnosticsResponse& k);
+
+/// \brief Writes the string representation of the given GetDiagnosticsResponse \p k to the given output stream \p os
+/// \returns an output stream with the GetDiagnosticsResponse written to
+std::ostream& operator<<(std::ostream& os, const GetDiagnosticsResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/GetLocalListVersion.hpp
+++ b/include/ocpp1_6/messages/GetLocalListVersion.hpp
@@ -12,31 +12,18 @@ struct GetLocalListVersionRequest : public Message {
 
     /// \brief Provides the type of this GetLocalListVersion message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetLocalListVersion";
-    }
-
-    /// \brief Conversion from a given GetLocalListVersionRequest \p k to a given json object \p j
-    friend void to_json(json& j, const GetLocalListVersionRequest& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetLocalListVersionRequest \p k
-    friend void from_json(const json& j, GetLocalListVersionRequest& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given GetLocalListVersionRequest \p k to the given output stream
-    /// \p os \returns an output stream with the GetLocalListVersionRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const GetLocalListVersionRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetLocalListVersionRequest \p k to a given json object \p j
+void to_json(json& j, const GetLocalListVersionRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given GetLocalListVersionRequest \p k
+void from_json(const json& j, GetLocalListVersionRequest& k);
+
+/// \brief Writes the string representation of the given GetLocalListVersionRequest \p k to the given output stream \p
+/// os \returns an output stream with the GetLocalListVersionRequest written to
+std::ostream& operator<<(std::ostream& os, const GetLocalListVersionRequest& k);
 
 /// \brief Contains a OCPP 1.6 GetLocalListVersionResponse message
 struct GetLocalListVersionResponse : public Message {
@@ -44,34 +31,18 @@ struct GetLocalListVersionResponse : public Message {
 
     /// \brief Provides the type of this GetLocalListVersionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "GetLocalListVersionResponse";
-    }
-
-    /// \brief Conversion from a given GetLocalListVersionResponse \p k to a given json object \p j
-    friend void to_json(json& j, const GetLocalListVersionResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"listVersion", k.listVersion},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given GetLocalListVersionResponse \p k
-    friend void from_json(const json& j, GetLocalListVersionResponse& k) {
-        // the required parts of the message
-        k.listVersion = j.at("listVersion");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given GetLocalListVersionResponse \p k to the given output stream
-    /// \p os \returns an output stream with the GetLocalListVersionResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const GetLocalListVersionResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given GetLocalListVersionResponse \p k to a given json object \p j
+void to_json(json& j, const GetLocalListVersionResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given GetLocalListVersionResponse \p k
+void from_json(const json& j, GetLocalListVersionResponse& k);
+
+/// \brief Writes the string representation of the given GetLocalListVersionResponse \p k to the given output stream \p
+/// os \returns an output stream with the GetLocalListVersionResponse written to
+std::ostream& operator<<(std::ostream& os, const GetLocalListVersionResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/Heartbeat.hpp
+++ b/include/ocpp1_6/messages/Heartbeat.hpp
@@ -12,31 +12,18 @@ struct HeartbeatRequest : public Message {
 
     /// \brief Provides the type of this Heartbeat message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "Heartbeat";
-    }
-
-    /// \brief Conversion from a given HeartbeatRequest \p k to a given json object \p j
-    friend void to_json(json& j, const HeartbeatRequest& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given HeartbeatRequest \p k
-    friend void from_json(const json& j, HeartbeatRequest& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given HeartbeatRequest \p k to the given output stream \p os
-    /// \returns an output stream with the HeartbeatRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const HeartbeatRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given HeartbeatRequest \p k to a given json object \p j
+void to_json(json& j, const HeartbeatRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given HeartbeatRequest \p k
+void from_json(const json& j, HeartbeatRequest& k);
+
+/// \brief Writes the string representation of the given HeartbeatRequest \p k to the given output stream \p os
+/// \returns an output stream with the HeartbeatRequest written to
+std::ostream& operator<<(std::ostream& os, const HeartbeatRequest& k);
 
 /// \brief Contains a OCPP 1.6 HeartbeatResponse message
 struct HeartbeatResponse : public Message {
@@ -44,35 +31,18 @@ struct HeartbeatResponse : public Message {
 
     /// \brief Provides the type of this HeartbeatResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "HeartbeatResponse";
-    }
-
-    /// \brief Conversion from a given HeartbeatResponse \p k to a given json object \p j
-    friend void to_json(json& j, const HeartbeatResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"currentTime", k.currentTime.to_rfc3339()},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given HeartbeatResponse \p k
-    friend void from_json(const json& j, HeartbeatResponse& k) {
-        // the required parts of the message
-        k.currentTime = DateTime(std::string(j.at("currentTime")));
-        ;
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given HeartbeatResponse \p k to the given output stream \p os
-    /// \returns an output stream with the HeartbeatResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const HeartbeatResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given HeartbeatResponse \p k to a given json object \p j
+void to_json(json& j, const HeartbeatResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given HeartbeatResponse \p k
+void from_json(const json& j, HeartbeatResponse& k);
+
+/// \brief Writes the string representation of the given HeartbeatResponse \p k to the given output stream \p os
+/// \returns an output stream with the HeartbeatResponse written to
+std::ostream& operator<<(std::ostream& os, const HeartbeatResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/MeterValues.hpp
+++ b/include/ocpp1_6/messages/MeterValues.hpp
@@ -15,75 +15,36 @@ struct MeterValuesRequest : public Message {
 
     /// \brief Provides the type of this MeterValues message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "MeterValues";
-    }
-
-    /// \brief Conversion from a given MeterValuesRequest \p k to a given json object \p j
-    friend void to_json(json& j, const MeterValuesRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-            {"meterValue", k.meterValue},
-        };
-        // the optional parts of the message
-        if (k.transactionId) {
-            j["transactionId"] = k.transactionId.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given MeterValuesRequest \p k
-    friend void from_json(const json& j, MeterValuesRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-        for (auto val : j.at("meterValue")) {
-            k.meterValue.push_back(val);
-        }
-
-        // the optional parts of the message
-        if (j.contains("transactionId")) {
-            k.transactionId.emplace(j.at("transactionId"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given MeterValuesRequest \p k to the given output stream \p os
-    /// \returns an output stream with the MeterValuesRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const MeterValuesRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given MeterValuesRequest \p k to a given json object \p j
+void to_json(json& j, const MeterValuesRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given MeterValuesRequest \p k
+void from_json(const json& j, MeterValuesRequest& k);
+
+/// \brief Writes the string representation of the given MeterValuesRequest \p k to the given output stream \p os
+/// \returns an output stream with the MeterValuesRequest written to
+std::ostream& operator<<(std::ostream& os, const MeterValuesRequest& k);
 
 /// \brief Contains a OCPP 1.6 MeterValuesResponse message
 struct MeterValuesResponse : public Message {
 
     /// \brief Provides the type of this MeterValuesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "MeterValuesResponse";
-    }
-
-    /// \brief Conversion from a given MeterValuesResponse \p k to a given json object \p j
-    friend void to_json(json& j, const MeterValuesResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given MeterValuesResponse \p k
-    friend void from_json(const json& j, MeterValuesResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given MeterValuesResponse \p k to the given output stream \p os
-    /// \returns an output stream with the MeterValuesResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const MeterValuesResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given MeterValuesResponse \p k to a given json object \p j
+void to_json(json& j, const MeterValuesResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given MeterValuesResponse \p k
+void from_json(const json& j, MeterValuesResponse& k);
+
+/// \brief Writes the string representation of the given MeterValuesResponse \p k to the given output stream \p os
+/// \returns an output stream with the MeterValuesResponse written to
+std::ostream& operator<<(std::ostream& os, const MeterValuesResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/RemoteStartTransaction.hpp
+++ b/include/ocpp1_6/messages/RemoteStartTransaction.hpp
@@ -15,46 +15,18 @@ struct RemoteStartTransactionRequest : public Message {
 
     /// \brief Provides the type of this RemoteStartTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "RemoteStartTransaction";
-    }
-
-    /// \brief Conversion from a given RemoteStartTransactionRequest \p k to a given json object \p j
-    friend void to_json(json& j, const RemoteStartTransactionRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"idTag", k.idTag},
-        };
-        // the optional parts of the message
-        if (k.connectorId) {
-            j["connectorId"] = k.connectorId.value();
-        }
-        if (k.chargingProfile) {
-            j["chargingProfile"] = k.chargingProfile.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given RemoteStartTransactionRequest \p k
-    friend void from_json(const json& j, RemoteStartTransactionRequest& k) {
-        // the required parts of the message
-        k.idTag = j.at("idTag");
-
-        // the optional parts of the message
-        if (j.contains("connectorId")) {
-            k.connectorId.emplace(j.at("connectorId"));
-        }
-        if (j.contains("chargingProfile")) {
-            k.chargingProfile.emplace(j.at("chargingProfile"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given RemoteStartTransactionRequest \p k to the given output
-    /// stream \p os \returns an output stream with the RemoteStartTransactionRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const RemoteStartTransactionRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given RemoteStartTransactionRequest \p k to a given json object \p j
+void to_json(json& j, const RemoteStartTransactionRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given RemoteStartTransactionRequest \p k
+void from_json(const json& j, RemoteStartTransactionRequest& k);
+
+/// \brief Writes the string representation of the given RemoteStartTransactionRequest \p k to the given output stream
+/// \p os \returns an output stream with the RemoteStartTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const RemoteStartTransactionRequest& k);
 
 /// \brief Contains a OCPP 1.6 RemoteStartTransactionResponse message
 struct RemoteStartTransactionResponse : public Message {
@@ -62,34 +34,18 @@ struct RemoteStartTransactionResponse : public Message {
 
     /// \brief Provides the type of this RemoteStartTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "RemoteStartTransactionResponse";
-    }
-
-    /// \brief Conversion from a given RemoteStartTransactionResponse \p k to a given json object \p j
-    friend void to_json(json& j, const RemoteStartTransactionResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::remote_start_stop_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given RemoteStartTransactionResponse \p k
-    friend void from_json(const json& j, RemoteStartTransactionResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_remote_start_stop_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given RemoteStartTransactionResponse \p k to the given output
-    /// stream \p os \returns an output stream with the RemoteStartTransactionResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const RemoteStartTransactionResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given RemoteStartTransactionResponse \p k to a given json object \p j
+void to_json(json& j, const RemoteStartTransactionResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given RemoteStartTransactionResponse \p k
+void from_json(const json& j, RemoteStartTransactionResponse& k);
+
+/// \brief Writes the string representation of the given RemoteStartTransactionResponse \p k to the given output stream
+/// \p os \returns an output stream with the RemoteStartTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const RemoteStartTransactionResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/RemoteStopTransaction.hpp
+++ b/include/ocpp1_6/messages/RemoteStopTransaction.hpp
@@ -13,34 +13,18 @@ struct RemoteStopTransactionRequest : public Message {
 
     /// \brief Provides the type of this RemoteStopTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "RemoteStopTransaction";
-    }
-
-    /// \brief Conversion from a given RemoteStopTransactionRequest \p k to a given json object \p j
-    friend void to_json(json& j, const RemoteStopTransactionRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"transactionId", k.transactionId},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given RemoteStopTransactionRequest \p k
-    friend void from_json(const json& j, RemoteStopTransactionRequest& k) {
-        // the required parts of the message
-        k.transactionId = j.at("transactionId");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given RemoteStopTransactionRequest \p k to the given output
-    /// stream \p os \returns an output stream with the RemoteStopTransactionRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const RemoteStopTransactionRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given RemoteStopTransactionRequest \p k to a given json object \p j
+void to_json(json& j, const RemoteStopTransactionRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given RemoteStopTransactionRequest \p k
+void from_json(const json& j, RemoteStopTransactionRequest& k);
+
+/// \brief Writes the string representation of the given RemoteStopTransactionRequest \p k to the given output stream \p
+/// os \returns an output stream with the RemoteStopTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const RemoteStopTransactionRequest& k);
 
 /// \brief Contains a OCPP 1.6 RemoteStopTransactionResponse message
 struct RemoteStopTransactionResponse : public Message {
@@ -48,34 +32,18 @@ struct RemoteStopTransactionResponse : public Message {
 
     /// \brief Provides the type of this RemoteStopTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "RemoteStopTransactionResponse";
-    }
-
-    /// \brief Conversion from a given RemoteStopTransactionResponse \p k to a given json object \p j
-    friend void to_json(json& j, const RemoteStopTransactionResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::remote_start_stop_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given RemoteStopTransactionResponse \p k
-    friend void from_json(const json& j, RemoteStopTransactionResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_remote_start_stop_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given RemoteStopTransactionResponse \p k to the given output
-    /// stream \p os \returns an output stream with the RemoteStopTransactionResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const RemoteStopTransactionResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given RemoteStopTransactionResponse \p k to a given json object \p j
+void to_json(json& j, const RemoteStopTransactionResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given RemoteStopTransactionResponse \p k
+void from_json(const json& j, RemoteStopTransactionResponse& k);
+
+/// \brief Writes the string representation of the given RemoteStopTransactionResponse \p k to the given output stream
+/// \p os \returns an output stream with the RemoteStopTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const RemoteStopTransactionResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/ReserveNow.hpp
+++ b/include/ocpp1_6/messages/ReserveNow.hpp
@@ -17,47 +17,18 @@ struct ReserveNowRequest : public Message {
 
     /// \brief Provides the type of this ReserveNow message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ReserveNow";
-    }
-
-    /// \brief Conversion from a given ReserveNowRequest \p k to a given json object \p j
-    friend void to_json(json& j, const ReserveNowRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-            {"expiryDate", k.expiryDate.to_rfc3339()},
-            {"idTag", k.idTag},
-            {"reservationId", k.reservationId},
-        };
-        // the optional parts of the message
-        if (k.parentIdTag) {
-            j["parentIdTag"] = k.parentIdTag.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ReserveNowRequest \p k
-    friend void from_json(const json& j, ReserveNowRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-        k.expiryDate = DateTime(std::string(j.at("expiryDate")));
-        ;
-        k.idTag = j.at("idTag");
-        k.reservationId = j.at("reservationId");
-
-        // the optional parts of the message
-        if (j.contains("parentIdTag")) {
-            k.parentIdTag.emplace(j.at("parentIdTag"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given ReserveNowRequest \p k to the given output stream \p os
-    /// \returns an output stream with the ReserveNowRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const ReserveNowRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ReserveNowRequest \p k to a given json object \p j
+void to_json(json& j, const ReserveNowRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given ReserveNowRequest \p k
+void from_json(const json& j, ReserveNowRequest& k);
+
+/// \brief Writes the string representation of the given ReserveNowRequest \p k to the given output stream \p os
+/// \returns an output stream with the ReserveNowRequest written to
+std::ostream& operator<<(std::ostream& os, const ReserveNowRequest& k);
 
 /// \brief Contains a OCPP 1.6 ReserveNowResponse message
 struct ReserveNowResponse : public Message {
@@ -65,34 +36,18 @@ struct ReserveNowResponse : public Message {
 
     /// \brief Provides the type of this ReserveNowResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ReserveNowResponse";
-    }
-
-    /// \brief Conversion from a given ReserveNowResponse \p k to a given json object \p j
-    friend void to_json(json& j, const ReserveNowResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::reservation_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ReserveNowResponse \p k
-    friend void from_json(const json& j, ReserveNowResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_reservation_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ReserveNowResponse \p k to the given output stream \p os
-    /// \returns an output stream with the ReserveNowResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const ReserveNowResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ReserveNowResponse \p k to a given json object \p j
+void to_json(json& j, const ReserveNowResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given ReserveNowResponse \p k
+void from_json(const json& j, ReserveNowResponse& k);
+
+/// \brief Writes the string representation of the given ReserveNowResponse \p k to the given output stream \p os
+/// \returns an output stream with the ReserveNowResponse written to
+std::ostream& operator<<(std::ostream& os, const ReserveNowResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/Reset.hpp
+++ b/include/ocpp1_6/messages/Reset.hpp
@@ -13,34 +13,18 @@ struct ResetRequest : public Message {
 
     /// \brief Provides the type of this Reset message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "Reset";
-    }
-
-    /// \brief Conversion from a given ResetRequest \p k to a given json object \p j
-    friend void to_json(json& j, const ResetRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"type", conversions::reset_type_to_string(k.type)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ResetRequest \p k
-    friend void from_json(const json& j, ResetRequest& k) {
-        // the required parts of the message
-        k.type = conversions::string_to_reset_type(j.at("type"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ResetRequest \p k to the given output stream \p os
-    /// \returns an output stream with the ResetRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const ResetRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ResetRequest \p k to a given json object \p j
+void to_json(json& j, const ResetRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given ResetRequest \p k
+void from_json(const json& j, ResetRequest& k);
+
+/// \brief Writes the string representation of the given ResetRequest \p k to the given output stream \p os
+/// \returns an output stream with the ResetRequest written to
+std::ostream& operator<<(std::ostream& os, const ResetRequest& k);
 
 /// \brief Contains a OCPP 1.6 ResetResponse message
 struct ResetResponse : public Message {
@@ -48,34 +32,18 @@ struct ResetResponse : public Message {
 
     /// \brief Provides the type of this ResetResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "ResetResponse";
-    }
-
-    /// \brief Conversion from a given ResetResponse \p k to a given json object \p j
-    friend void to_json(json& j, const ResetResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::reset_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ResetResponse \p k
-    friend void from_json(const json& j, ResetResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_reset_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given ResetResponse \p k to the given output stream \p os
-    /// \returns an output stream with the ResetResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const ResetResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given ResetResponse \p k to a given json object \p j
+void to_json(json& j, const ResetResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given ResetResponse \p k
+void from_json(const json& j, ResetResponse& k);
+
+/// \brief Writes the string representation of the given ResetResponse \p k to the given output stream \p os
+/// \returns an output stream with the ResetResponse written to
+std::ostream& operator<<(std::ostream& os, const ResetResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/SendLocalList.hpp
+++ b/include/ocpp1_6/messages/SendLocalList.hpp
@@ -15,50 +15,18 @@ struct SendLocalListRequest : public Message {
 
     /// \brief Provides the type of this SendLocalList message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "SendLocalList";
-    }
-
-    /// \brief Conversion from a given SendLocalListRequest \p k to a given json object \p j
-    friend void to_json(json& j, const SendLocalListRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"listVersion", k.listVersion},
-            {"updateType", conversions::update_type_to_string(k.updateType)},
-        };
-        // the optional parts of the message
-        if (k.localAuthorizationList) {
-            j["localAuthorizationList"] = json::array();
-            for (auto val : k.localAuthorizationList.value()) {
-                j["localAuthorizationList"].push_back(val);
-            }
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given SendLocalListRequest \p k
-    friend void from_json(const json& j, SendLocalListRequest& k) {
-        // the required parts of the message
-        k.listVersion = j.at("listVersion");
-        k.updateType = conversions::string_to_update_type(j.at("updateType"));
-
-        // the optional parts of the message
-        if (j.contains("localAuthorizationList")) {
-            json arr = j.at("localAuthorizationList");
-            std::vector<LocalAuthorizationList> vec;
-            for (auto val : arr) {
-                vec.push_back(val);
-            }
-            k.localAuthorizationList.emplace(vec);
-        }
-    }
-
-    /// \brief Writes the string representation of the given SendLocalListRequest \p k to the given output stream \p os
-    /// \returns an output stream with the SendLocalListRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const SendLocalListRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given SendLocalListRequest \p k to a given json object \p j
+void to_json(json& j, const SendLocalListRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given SendLocalListRequest \p k
+void from_json(const json& j, SendLocalListRequest& k);
+
+/// \brief Writes the string representation of the given SendLocalListRequest \p k to the given output stream \p os
+/// \returns an output stream with the SendLocalListRequest written to
+std::ostream& operator<<(std::ostream& os, const SendLocalListRequest& k);
 
 /// \brief Contains a OCPP 1.6 SendLocalListResponse message
 struct SendLocalListResponse : public Message {
@@ -66,34 +34,18 @@ struct SendLocalListResponse : public Message {
 
     /// \brief Provides the type of this SendLocalListResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "SendLocalListResponse";
-    }
-
-    /// \brief Conversion from a given SendLocalListResponse \p k to a given json object \p j
-    friend void to_json(json& j, const SendLocalListResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::update_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given SendLocalListResponse \p k
-    friend void from_json(const json& j, SendLocalListResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_update_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given SendLocalListResponse \p k to the given output stream \p os
-    /// \returns an output stream with the SendLocalListResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const SendLocalListResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given SendLocalListResponse \p k to a given json object \p j
+void to_json(json& j, const SendLocalListResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given SendLocalListResponse \p k
+void from_json(const json& j, SendLocalListResponse& k);
+
+/// \brief Writes the string representation of the given SendLocalListResponse \p k to the given output stream \p os
+/// \returns an output stream with the SendLocalListResponse written to
+std::ostream& operator<<(std::ostream& os, const SendLocalListResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/SetChargingProfile.hpp
+++ b/include/ocpp1_6/messages/SetChargingProfile.hpp
@@ -14,36 +14,18 @@ struct SetChargingProfileRequest : public Message {
 
     /// \brief Provides the type of this SetChargingProfile message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "SetChargingProfile";
-    }
-
-    /// \brief Conversion from a given SetChargingProfileRequest \p k to a given json object \p j
-    friend void to_json(json& j, const SetChargingProfileRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-            {"csChargingProfiles", k.csChargingProfiles},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given SetChargingProfileRequest \p k
-    friend void from_json(const json& j, SetChargingProfileRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-        k.csChargingProfiles = j.at("csChargingProfiles");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given SetChargingProfileRequest \p k to the given output stream
-    /// \p os \returns an output stream with the SetChargingProfileRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const SetChargingProfileRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given SetChargingProfileRequest \p k to a given json object \p j
+void to_json(json& j, const SetChargingProfileRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given SetChargingProfileRequest \p k
+void from_json(const json& j, SetChargingProfileRequest& k);
+
+/// \brief Writes the string representation of the given SetChargingProfileRequest \p k to the given output stream \p os
+/// \returns an output stream with the SetChargingProfileRequest written to
+std::ostream& operator<<(std::ostream& os, const SetChargingProfileRequest& k);
 
 /// \brief Contains a OCPP 1.6 SetChargingProfileResponse message
 struct SetChargingProfileResponse : public Message {
@@ -51,34 +33,18 @@ struct SetChargingProfileResponse : public Message {
 
     /// \brief Provides the type of this SetChargingProfileResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "SetChargingProfileResponse";
-    }
-
-    /// \brief Conversion from a given SetChargingProfileResponse \p k to a given json object \p j
-    friend void to_json(json& j, const SetChargingProfileResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::charging_profile_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given SetChargingProfileResponse \p k
-    friend void from_json(const json& j, SetChargingProfileResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_charging_profile_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given SetChargingProfileResponse \p k to the given output stream
-    /// \p os \returns an output stream with the SetChargingProfileResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const SetChargingProfileResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given SetChargingProfileResponse \p k to a given json object \p j
+void to_json(json& j, const SetChargingProfileResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given SetChargingProfileResponse \p k
+void from_json(const json& j, SetChargingProfileResponse& k);
+
+/// \brief Writes the string representation of the given SetChargingProfileResponse \p k to the given output stream \p
+/// os \returns an output stream with the SetChargingProfileResponse written to
+std::ostream& operator<<(std::ostream& os, const SetChargingProfileResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/StartTransaction.hpp
+++ b/include/ocpp1_6/messages/StartTransaction.hpp
@@ -17,47 +17,18 @@ struct StartTransactionRequest : public Message {
 
     /// \brief Provides the type of this StartTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "StartTransaction";
-    }
-
-    /// \brief Conversion from a given StartTransactionRequest \p k to a given json object \p j
-    friend void to_json(json& j, const StartTransactionRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-            {"idTag", k.idTag},
-            {"meterStart", k.meterStart},
-            {"timestamp", k.timestamp.to_rfc3339()},
-        };
-        // the optional parts of the message
-        if (k.reservationId) {
-            j["reservationId"] = k.reservationId.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given StartTransactionRequest \p k
-    friend void from_json(const json& j, StartTransactionRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-        k.idTag = j.at("idTag");
-        k.meterStart = j.at("meterStart");
-        k.timestamp = DateTime(std::string(j.at("timestamp")));
-        ;
-
-        // the optional parts of the message
-        if (j.contains("reservationId")) {
-            k.reservationId.emplace(j.at("reservationId"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given StartTransactionRequest \p k to the given output stream \p
-    /// os \returns an output stream with the StartTransactionRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const StartTransactionRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given StartTransactionRequest \p k to a given json object \p j
+void to_json(json& j, const StartTransactionRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given StartTransactionRequest \p k
+void from_json(const json& j, StartTransactionRequest& k);
+
+/// \brief Writes the string representation of the given StartTransactionRequest \p k to the given output stream \p os
+/// \returns an output stream with the StartTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const StartTransactionRequest& k);
 
 /// \brief Contains a OCPP 1.6 StartTransactionResponse message
 struct StartTransactionResponse : public Message {
@@ -66,36 +37,18 @@ struct StartTransactionResponse : public Message {
 
     /// \brief Provides the type of this StartTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "StartTransactionResponse";
-    }
-
-    /// \brief Conversion from a given StartTransactionResponse \p k to a given json object \p j
-    friend void to_json(json& j, const StartTransactionResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"idTagInfo", k.idTagInfo},
-            {"transactionId", k.transactionId},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given StartTransactionResponse \p k
-    friend void from_json(const json& j, StartTransactionResponse& k) {
-        // the required parts of the message
-        k.idTagInfo = j.at("idTagInfo");
-        k.transactionId = j.at("transactionId");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given StartTransactionResponse \p k to the given output stream \p
-    /// os \returns an output stream with the StartTransactionResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const StartTransactionResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given StartTransactionResponse \p k to a given json object \p j
+void to_json(json& j, const StartTransactionResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given StartTransactionResponse \p k
+void from_json(const json& j, StartTransactionResponse& k);
+
+/// \brief Writes the string representation of the given StartTransactionResponse \p k to the given output stream \p os
+/// \returns an output stream with the StartTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const StartTransactionResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/StatusNotification.hpp
+++ b/include/ocpp1_6/messages/StatusNotification.hpp
@@ -19,93 +19,36 @@ struct StatusNotificationRequest : public Message {
 
     /// \brief Provides the type of this StatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "StatusNotification";
-    }
-
-    /// \brief Conversion from a given StatusNotificationRequest \p k to a given json object \p j
-    friend void to_json(json& j, const StatusNotificationRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-            {"errorCode", conversions::charge_point_error_code_to_string(k.errorCode)},
-            {"status", conversions::charge_point_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-        if (k.info) {
-            j["info"] = k.info.value();
-        }
-        if (k.timestamp) {
-            j["timestamp"] = k.timestamp.value().to_rfc3339();
-        }
-        if (k.vendorId) {
-            j["vendorId"] = k.vendorId.value();
-        }
-        if (k.vendorErrorCode) {
-            j["vendorErrorCode"] = k.vendorErrorCode.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given StatusNotificationRequest \p k
-    friend void from_json(const json& j, StatusNotificationRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-        k.errorCode = conversions::string_to_charge_point_error_code(j.at("errorCode"));
-        k.status = conversions::string_to_charge_point_status(j.at("status"));
-
-        // the optional parts of the message
-        if (j.contains("info")) {
-            k.info.emplace(j.at("info"));
-        }
-        if (j.contains("timestamp")) {
-            k.timestamp.emplace(DateTime(std::string(j.at("timestamp"))));
-        }
-        if (j.contains("vendorId")) {
-            k.vendorId.emplace(j.at("vendorId"));
-        }
-        if (j.contains("vendorErrorCode")) {
-            k.vendorErrorCode.emplace(j.at("vendorErrorCode"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given StatusNotificationRequest \p k to the given output stream
-    /// \p os \returns an output stream with the StatusNotificationRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const StatusNotificationRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given StatusNotificationRequest \p k to a given json object \p j
+void to_json(json& j, const StatusNotificationRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given StatusNotificationRequest \p k
+void from_json(const json& j, StatusNotificationRequest& k);
+
+/// \brief Writes the string representation of the given StatusNotificationRequest \p k to the given output stream \p os
+/// \returns an output stream with the StatusNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const StatusNotificationRequest& k);
 
 /// \brief Contains a OCPP 1.6 StatusNotificationResponse message
 struct StatusNotificationResponse : public Message {
 
     /// \brief Provides the type of this StatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "StatusNotificationResponse";
-    }
-
-    /// \brief Conversion from a given StatusNotificationResponse \p k to a given json object \p j
-    friend void to_json(json& j, const StatusNotificationResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given StatusNotificationResponse \p k
-    friend void from_json(const json& j, StatusNotificationResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given StatusNotificationResponse \p k to the given output stream
-    /// \p os \returns an output stream with the StatusNotificationResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const StatusNotificationResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given StatusNotificationResponse \p k to a given json object \p j
+void to_json(json& j, const StatusNotificationResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given StatusNotificationResponse \p k
+void from_json(const json& j, StatusNotificationResponse& k);
+
+/// \brief Writes the string representation of the given StatusNotificationResponse \p k to the given output stream \p
+/// os \returns an output stream with the StatusNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const StatusNotificationResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/StopTransaction.hpp
+++ b/include/ocpp1_6/messages/StopTransaction.hpp
@@ -18,65 +18,18 @@ struct StopTransactionRequest : public Message {
 
     /// \brief Provides the type of this StopTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "StopTransaction";
-    }
-
-    /// \brief Conversion from a given StopTransactionRequest \p k to a given json object \p j
-    friend void to_json(json& j, const StopTransactionRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"meterStop", k.meterStop},
-            {"timestamp", k.timestamp.to_rfc3339()},
-            {"transactionId", k.transactionId},
-        };
-        // the optional parts of the message
-        if (k.idTag) {
-            j["idTag"] = k.idTag.value();
-        }
-        if (k.reason) {
-            j["reason"] = conversions::reason_to_string(k.reason.value());
-        }
-        if (k.transactionData) {
-            j["transactionData"] = json::array();
-            for (auto val : k.transactionData.value()) {
-                j["transactionData"].push_back(val);
-            }
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given StopTransactionRequest \p k
-    friend void from_json(const json& j, StopTransactionRequest& k) {
-        // the required parts of the message
-        k.meterStop = j.at("meterStop");
-        k.timestamp = DateTime(std::string(j.at("timestamp")));
-        ;
-        k.transactionId = j.at("transactionId");
-
-        // the optional parts of the message
-        if (j.contains("idTag")) {
-            k.idTag.emplace(j.at("idTag"));
-        }
-        if (j.contains("reason")) {
-            k.reason.emplace(conversions::string_to_reason(j.at("reason")));
-        }
-        if (j.contains("transactionData")) {
-            json arr = j.at("transactionData");
-            std::vector<TransactionData> vec;
-            for (auto val : arr) {
-                vec.push_back(val);
-            }
-            k.transactionData.emplace(vec);
-        }
-    }
-
-    /// \brief Writes the string representation of the given StopTransactionRequest \p k to the given output stream \p
-    /// os \returns an output stream with the StopTransactionRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const StopTransactionRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given StopTransactionRequest \p k to a given json object \p j
+void to_json(json& j, const StopTransactionRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given StopTransactionRequest \p k
+void from_json(const json& j, StopTransactionRequest& k);
+
+/// \brief Writes the string representation of the given StopTransactionRequest \p k to the given output stream \p os
+/// \returns an output stream with the StopTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const StopTransactionRequest& k);
 
 /// \brief Contains a OCPP 1.6 StopTransactionResponse message
 struct StopTransactionResponse : public Message {
@@ -84,37 +37,18 @@ struct StopTransactionResponse : public Message {
 
     /// \brief Provides the type of this StopTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "StopTransactionResponse";
-    }
-
-    /// \brief Conversion from a given StopTransactionResponse \p k to a given json object \p j
-    friend void to_json(json& j, const StopTransactionResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-        if (k.idTagInfo) {
-            j["idTagInfo"] = k.idTagInfo.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given StopTransactionResponse \p k
-    friend void from_json(const json& j, StopTransactionResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-        if (j.contains("idTagInfo")) {
-            k.idTagInfo.emplace(j.at("idTagInfo"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given StopTransactionResponse \p k to the given output stream \p
-    /// os \returns an output stream with the StopTransactionResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const StopTransactionResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given StopTransactionResponse \p k to a given json object \p j
+void to_json(json& j, const StopTransactionResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given StopTransactionResponse \p k
+void from_json(const json& j, StopTransactionResponse& k);
+
+/// \brief Writes the string representation of the given StopTransactionResponse \p k to the given output stream \p os
+/// \returns an output stream with the StopTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const StopTransactionResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/TriggerMessage.hpp
+++ b/include/ocpp1_6/messages/TriggerMessage.hpp
@@ -14,40 +14,18 @@ struct TriggerMessageRequest : public Message {
 
     /// \brief Provides the type of this TriggerMessage message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "TriggerMessage";
-    }
-
-    /// \brief Conversion from a given TriggerMessageRequest \p k to a given json object \p j
-    friend void to_json(json& j, const TriggerMessageRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"requestedMessage", conversions::message_trigger_to_string(k.requestedMessage)},
-        };
-        // the optional parts of the message
-        if (k.connectorId) {
-            j["connectorId"] = k.connectorId.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given TriggerMessageRequest \p k
-    friend void from_json(const json& j, TriggerMessageRequest& k) {
-        // the required parts of the message
-        k.requestedMessage = conversions::string_to_message_trigger(j.at("requestedMessage"));
-
-        // the optional parts of the message
-        if (j.contains("connectorId")) {
-            k.connectorId.emplace(j.at("connectorId"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given TriggerMessageRequest \p k to the given output stream \p os
-    /// \returns an output stream with the TriggerMessageRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const TriggerMessageRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given TriggerMessageRequest \p k to a given json object \p j
+void to_json(json& j, const TriggerMessageRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given TriggerMessageRequest \p k
+void from_json(const json& j, TriggerMessageRequest& k);
+
+/// \brief Writes the string representation of the given TriggerMessageRequest \p k to the given output stream \p os
+/// \returns an output stream with the TriggerMessageRequest written to
+std::ostream& operator<<(std::ostream& os, const TriggerMessageRequest& k);
 
 /// \brief Contains a OCPP 1.6 TriggerMessageResponse message
 struct TriggerMessageResponse : public Message {
@@ -55,34 +33,18 @@ struct TriggerMessageResponse : public Message {
 
     /// \brief Provides the type of this TriggerMessageResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "TriggerMessageResponse";
-    }
-
-    /// \brief Conversion from a given TriggerMessageResponse \p k to a given json object \p j
-    friend void to_json(json& j, const TriggerMessageResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::trigger_message_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given TriggerMessageResponse \p k
-    friend void from_json(const json& j, TriggerMessageResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_trigger_message_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given TriggerMessageResponse \p k to the given output stream \p
-    /// os \returns an output stream with the TriggerMessageResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const TriggerMessageResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given TriggerMessageResponse \p k to a given json object \p j
+void to_json(json& j, const TriggerMessageResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given TriggerMessageResponse \p k
+void from_json(const json& j, TriggerMessageResponse& k);
+
+/// \brief Writes the string representation of the given TriggerMessageResponse \p k to the given output stream \p os
+/// \returns an output stream with the TriggerMessageResponse written to
+std::ostream& operator<<(std::ostream& os, const TriggerMessageResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/UnlockConnector.hpp
+++ b/include/ocpp1_6/messages/UnlockConnector.hpp
@@ -13,34 +13,18 @@ struct UnlockConnectorRequest : public Message {
 
     /// \brief Provides the type of this UnlockConnector message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "UnlockConnector";
-    }
-
-    /// \brief Conversion from a given UnlockConnectorRequest \p k to a given json object \p j
-    friend void to_json(json& j, const UnlockConnectorRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"connectorId", k.connectorId},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given UnlockConnectorRequest \p k
-    friend void from_json(const json& j, UnlockConnectorRequest& k) {
-        // the required parts of the message
-        k.connectorId = j.at("connectorId");
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given UnlockConnectorRequest \p k to the given output stream \p
-    /// os \returns an output stream with the UnlockConnectorRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const UnlockConnectorRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given UnlockConnectorRequest \p k to a given json object \p j
+void to_json(json& j, const UnlockConnectorRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given UnlockConnectorRequest \p k
+void from_json(const json& j, UnlockConnectorRequest& k);
+
+/// \brief Writes the string representation of the given UnlockConnectorRequest \p k to the given output stream \p os
+/// \returns an output stream with the UnlockConnectorRequest written to
+std::ostream& operator<<(std::ostream& os, const UnlockConnectorRequest& k);
 
 /// \brief Contains a OCPP 1.6 UnlockConnectorResponse message
 struct UnlockConnectorResponse : public Message {
@@ -48,34 +32,18 @@ struct UnlockConnectorResponse : public Message {
 
     /// \brief Provides the type of this UnlockConnectorResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "UnlockConnectorResponse";
-    }
-
-    /// \brief Conversion from a given UnlockConnectorResponse \p k to a given json object \p j
-    friend void to_json(json& j, const UnlockConnectorResponse& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::unlock_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given UnlockConnectorResponse \p k
-    friend void from_json(const json& j, UnlockConnectorResponse& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_unlock_status(j.at("status"));
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given UnlockConnectorResponse \p k to the given output stream \p
-    /// os \returns an output stream with the UnlockConnectorResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const UnlockConnectorResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given UnlockConnectorResponse \p k to a given json object \p j
+void to_json(json& j, const UnlockConnectorResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given UnlockConnectorResponse \p k
+void from_json(const json& j, UnlockConnectorResponse& k);
+
+/// \brief Writes the string representation of the given UnlockConnectorResponse \p k to the given output stream \p os
+/// \returns an output stream with the UnlockConnectorResponse written to
+std::ostream& operator<<(std::ostream& os, const UnlockConnectorResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/messages/UpdateFirmware.hpp
+++ b/include/ocpp1_6/messages/UpdateFirmware.hpp
@@ -9,87 +9,43 @@ namespace ocpp1_6 {
 
 /// \brief Contains a OCPP 1.6 UpdateFirmware message
 struct UpdateFirmwareRequest : public Message {
-    TODO : std::string with format : uri location;
+    std::string location;
     DateTime retrieveDate;
     boost::optional<int32_t> retries;
     boost::optional<int32_t> retryInterval;
 
     /// \brief Provides the type of this UpdateFirmware message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "UpdateFirmware";
-    }
-
-    /// \brief Conversion from a given UpdateFirmwareRequest \p k to a given json object \p j
-    friend void to_json(json& j, const UpdateFirmwareRequest& k) {
-        // the required parts of the message
-        j = json{
-            {"location", k.location},
-            {"retrieveDate", k.retrieveDate.to_rfc3339()},
-        };
-        // the optional parts of the message
-        if (k.retries) {
-            j["retries"] = k.retries.value();
-        }
-        if (k.retryInterval) {
-            j["retryInterval"] = k.retryInterval.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given UpdateFirmwareRequest \p k
-    friend void from_json(const json& j, UpdateFirmwareRequest& k) {
-        // the required parts of the message
-        k.location = j.at("location");
-        k.retrieveDate = DateTime(std::string(j.at("retrieveDate")));
-        ;
-
-        // the optional parts of the message
-        if (j.contains("retries")) {
-            k.retries.emplace(j.at("retries"));
-        }
-        if (j.contains("retryInterval")) {
-            k.retryInterval.emplace(j.at("retryInterval"));
-        }
-    }
-
-    /// \brief Writes the string representation of the given UpdateFirmwareRequest \p k to the given output stream \p os
-    /// \returns an output stream with the UpdateFirmwareRequest written to
-    friend std::ostream& operator<<(std::ostream& os, const UpdateFirmwareRequest& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given UpdateFirmwareRequest \p k to a given json object \p j
+void to_json(json& j, const UpdateFirmwareRequest& k);
+
+/// \brief Conversion from a given json object \p j to a given UpdateFirmwareRequest \p k
+void from_json(const json& j, UpdateFirmwareRequest& k);
+
+/// \brief Writes the string representation of the given UpdateFirmwareRequest \p k to the given output stream \p os
+/// \returns an output stream with the UpdateFirmwareRequest written to
+std::ostream& operator<<(std::ostream& os, const UpdateFirmwareRequest& k);
 
 /// \brief Contains a OCPP 1.6 UpdateFirmwareResponse message
 struct UpdateFirmwareResponse : public Message {
 
     /// \brief Provides the type of this UpdateFirmwareResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const {
-        return "UpdateFirmwareResponse";
-    }
-
-    /// \brief Conversion from a given UpdateFirmwareResponse \p k to a given json object \p j
-    friend void to_json(json& j, const UpdateFirmwareResponse& k) {
-        // the required parts of the message
-        j = json({});
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given UpdateFirmwareResponse \p k
-    friend void from_json(const json& j, UpdateFirmwareResponse& k) {
-        // the required parts of the message
-
-        // the optional parts of the message
-    }
-
-    /// \brief Writes the string representation of the given UpdateFirmwareResponse \p k to the given output stream \p
-    /// os \returns an output stream with the UpdateFirmwareResponse written to
-    friend std::ostream& operator<<(std::ostream& os, const UpdateFirmwareResponse& k) {
-        os << json(k).dump(4);
-        return os;
-    }
+    std::string get_type() const;
 };
+
+/// \brief Conversion from a given UpdateFirmwareResponse \p k to a given json object \p j
+void to_json(json& j, const UpdateFirmwareResponse& k);
+
+/// \brief Conversion from a given json object \p j to a given UpdateFirmwareResponse \p k
+void from_json(const json& j, UpdateFirmwareResponse& k);
+
+/// \brief Writes the string representation of the given UpdateFirmwareResponse \p k to the given output stream \p os
+/// \returns an output stream with the UpdateFirmwareResponse written to
+std::ostream& operator<<(std::ostream& os, const UpdateFirmwareResponse& k);
 
 } // namespace ocpp1_6
 

--- a/include/ocpp1_6/ocpp_types.hpp
+++ b/include/ocpp1_6/ocpp_types.hpp
@@ -3,11 +3,9 @@
 #ifndef OCPP1_6_OCPP_TYPES_HPP
 #define OCPP1_6_OCPP_TYPES_HPP
 
-#include <map>
 #include <string>
 
 #include <boost/optional.hpp>
-#include <nlohmann/json-schema.hpp>
 #include <nlohmann/json.hpp>
 
 #include <ocpp1_6/enums.hpp>
@@ -19,81 +17,31 @@ struct IdTagInfo {
     AuthorizationStatus status;
     boost::optional<DateTime> expiryDate;
     boost::optional<CiString20Type> parentIdTag;
-
-    /// \brief Conversion from a given IdTagInfo \p k to a given json object \p j
-    friend void to_json(json& j, const IdTagInfo& k) {
-        // the required parts of the message
-        j = json{
-            {"status", conversions::authorization_status_to_string(k.status)},
-        };
-        // the optional parts of the message
-        if (k.expiryDate) {
-            j["expiryDate"] = k.expiryDate.value().to_rfc3339();
-        }
-        if (k.parentIdTag) {
-            j["parentIdTag"] = k.parentIdTag.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given IdTagInfo \p k
-    friend void from_json(const json& j, IdTagInfo& k) {
-        // the required parts of the message
-        k.status = conversions::string_to_authorization_status(j.at("status"));
-
-        // the optional parts of the message
-        if (j.contains("expiryDate")) {
-            k.expiryDate.emplace(j.at("expiryDate"));
-        }
-        if (j.contains("parentIdTag")) {
-            k.parentIdTag.emplace(j.at("parentIdTag"));
-        }
-    }
-
-    // \brief Writes the string representation of the given IdTagInfo \p k to the given output stream \p os
-    /// \returns an output stream with the IdTagInfo written to
-    friend std::ostream& operator<<(std::ostream& os, const IdTagInfo& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given IdTagInfo \p k to a given json object \p j
+void to_json(json& j, const IdTagInfo& k);
+
+/// \brief Conversion from a given json object \p j to a given IdTagInfo \p k
+void from_json(const json& j, IdTagInfo& k);
+
+// \brief Writes the string representation of the given IdTagInfo \p k to the given output stream \p os
+/// \returns an output stream with the IdTagInfo written to
+std::ostream& operator<<(std::ostream& os, const IdTagInfo& k);
 
 struct ChargingSchedulePeriod {
     int32_t startPeriod;
     float limit;
     boost::optional<int32_t> numberPhases;
-
-    /// \brief Conversion from a given ChargingSchedulePeriod \p k to a given json object \p j
-    friend void to_json(json& j, const ChargingSchedulePeriod& k) {
-        // the required parts of the message
-        j = json{
-            {"startPeriod", k.startPeriod},
-            {"limit", k.limit},
-        };
-        // the optional parts of the message
-        if (k.numberPhases) {
-            j["numberPhases"] = k.numberPhases.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ChargingSchedulePeriod \p k
-    friend void from_json(const json& j, ChargingSchedulePeriod& k) {
-        // the required parts of the message
-        k.startPeriod = j.at("startPeriod");
-        k.limit = j.at("limit");
-
-        // the optional parts of the message
-        if (j.contains("numberPhases")) {
-            k.numberPhases.emplace(j.at("numberPhases"));
-        }
-    }
-
-    // \brief Writes the string representation of the given ChargingSchedulePeriod \p k to the given output stream \p os
-    /// \returns an output stream with the ChargingSchedulePeriod written to
-    friend std::ostream& operator<<(std::ostream& os, const ChargingSchedulePeriod& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given ChargingSchedulePeriod \p k to a given json object \p j
+void to_json(json& j, const ChargingSchedulePeriod& k);
+
+/// \brief Conversion from a given json object \p j to a given ChargingSchedulePeriod \p k
+void from_json(const json& j, ChargingSchedulePeriod& k);
+
+// \brief Writes the string representation of the given ChargingSchedulePeriod \p k to the given output stream \p os
+/// \returns an output stream with the ChargingSchedulePeriod written to
+std::ostream& operator<<(std::ostream& os, const ChargingSchedulePeriod& k);
 
 struct ChargingSchedule {
     ChargingRateUnit chargingRateUnit;
@@ -101,91 +49,31 @@ struct ChargingSchedule {
     boost::optional<int32_t> duration;
     boost::optional<DateTime> startSchedule;
     boost::optional<float> minChargingRate;
-
-    /// \brief Conversion from a given ChargingSchedule \p k to a given json object \p j
-    friend void to_json(json& j, const ChargingSchedule& k) {
-        // the required parts of the message
-        j = json{
-            {"chargingRateUnit", conversions::charging_rate_unit_to_string(k.chargingRateUnit)},
-            {"chargingSchedulePeriod", k.chargingSchedulePeriod},
-        };
-        // the optional parts of the message
-        if (k.duration) {
-            j["duration"] = k.duration.value();
-        }
-        if (k.startSchedule) {
-            j["startSchedule"] = k.startSchedule.value().to_rfc3339();
-        }
-        if (k.minChargingRate) {
-            j["minChargingRate"] = k.minChargingRate.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ChargingSchedule \p k
-    friend void from_json(const json& j, ChargingSchedule& k) {
-        // the required parts of the message
-        k.chargingRateUnit = conversions::string_to_charging_rate_unit(j.at("chargingRateUnit"));
-        for (auto val : j.at("chargingSchedulePeriod")) {
-            k.chargingSchedulePeriod.push_back(val);
-        }
-
-        // the optional parts of the message
-        if (j.contains("duration")) {
-            k.duration.emplace(j.at("duration"));
-        }
-        if (j.contains("startSchedule")) {
-            k.startSchedule.emplace(j.at("startSchedule"));
-        }
-        if (j.contains("minChargingRate")) {
-            k.minChargingRate.emplace(j.at("minChargingRate"));
-        }
-    }
-
-    // \brief Writes the string representation of the given ChargingSchedule \p k to the given output stream \p os
-    /// \returns an output stream with the ChargingSchedule written to
-    friend std::ostream& operator<<(std::ostream& os, const ChargingSchedule& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given ChargingSchedule \p k to a given json object \p j
+void to_json(json& j, const ChargingSchedule& k);
+
+/// \brief Conversion from a given json object \p j to a given ChargingSchedule \p k
+void from_json(const json& j, ChargingSchedule& k);
+
+// \brief Writes the string representation of the given ChargingSchedule \p k to the given output stream \p os
+/// \returns an output stream with the ChargingSchedule written to
+std::ostream& operator<<(std::ostream& os, const ChargingSchedule& k);
 
 struct KeyValue {
     CiString50Type key;
     bool readonly;
     boost::optional<CiString500Type> value;
-
-    /// \brief Conversion from a given KeyValue \p k to a given json object \p j
-    friend void to_json(json& j, const KeyValue& k) {
-        // the required parts of the message
-        j = json{
-            {"key", k.key},
-            {"readonly", k.readonly},
-        };
-        // the optional parts of the message
-        if (k.value) {
-            j["value"] = k.value.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given KeyValue \p k
-    friend void from_json(const json& j, KeyValue& k) {
-        // the required parts of the message
-        k.key = j.at("key");
-        k.readonly = j.at("readonly");
-
-        // the optional parts of the message
-        if (j.contains("value")) {
-            k.value.emplace(j.at("value"));
-        }
-    }
-
-    // \brief Writes the string representation of the given KeyValue \p k to the given output stream \p os
-    /// \returns an output stream with the KeyValue written to
-    friend std::ostream& operator<<(std::ostream& os, const KeyValue& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given KeyValue \p k to a given json object \p j
+void to_json(json& j, const KeyValue& k);
+
+/// \brief Conversion from a given json object \p j to a given KeyValue \p k
+void from_json(const json& j, KeyValue& k);
+
+// \brief Writes the string representation of the given KeyValue \p k to the given output stream \p os
+/// \returns an output stream with the KeyValue written to
+std::ostream& operator<<(std::ostream& os, const KeyValue& k);
 
 struct SampledValue {
     std::string value;
@@ -195,101 +83,30 @@ struct SampledValue {
     boost::optional<Phase> phase;
     boost::optional<Location> location;
     boost::optional<UnitOfMeasure> unit;
-
-    /// \brief Conversion from a given SampledValue \p k to a given json object \p j
-    friend void to_json(json& j, const SampledValue& k) {
-        // the required parts of the message
-        j = json{
-            {"value", k.value},
-        };
-        // the optional parts of the message
-        if (k.context) {
-            j["context"] = conversions::reading_context_to_string(k.context.value());
-        }
-        if (k.format) {
-            j["format"] = conversions::value_format_to_string(k.format.value());
-        }
-        if (k.measurand) {
-            j["measurand"] = conversions::measurand_to_string(k.measurand.value());
-        }
-        if (k.phase) {
-            j["phase"] = conversions::phase_to_string(k.phase.value());
-        }
-        if (k.location) {
-            j["location"] = conversions::location_to_string(k.location.value());
-        }
-        if (k.unit) {
-            j["unit"] = conversions::unit_of_measure_to_string(k.unit.value());
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given SampledValue \p k
-    friend void from_json(const json& j, SampledValue& k) {
-        // the required parts of the message
-        k.value = j.at("value");
-
-        // the optional parts of the message
-        if (j.contains("context")) {
-            k.context.emplace(j.at("context"));
-        }
-        if (j.contains("format")) {
-            k.format.emplace(j.at("format"));
-        }
-        if (j.contains("measurand")) {
-            k.measurand.emplace(j.at("measurand"));
-        }
-        if (j.contains("phase")) {
-            k.phase.emplace(j.at("phase"));
-        }
-        if (j.contains("location")) {
-            k.location.emplace(j.at("location"));
-        }
-        if (j.contains("unit")) {
-            k.unit.emplace(j.at("unit"));
-        }
-    }
-
-    // \brief Writes the string representation of the given SampledValue \p k to the given output stream \p os
-    /// \returns an output stream with the SampledValue written to
-    friend std::ostream& operator<<(std::ostream& os, const SampledValue& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given SampledValue \p k to a given json object \p j
+void to_json(json& j, const SampledValue& k);
+
+/// \brief Conversion from a given json object \p j to a given SampledValue \p k
+void from_json(const json& j, SampledValue& k);
+
+// \brief Writes the string representation of the given SampledValue \p k to the given output stream \p os
+/// \returns an output stream with the SampledValue written to
+std::ostream& operator<<(std::ostream& os, const SampledValue& k);
 
 struct MeterValue {
     DateTime timestamp;
     std::vector<SampledValue> sampledValue;
-
-    /// \brief Conversion from a given MeterValue \p k to a given json object \p j
-    friend void to_json(json& j, const MeterValue& k) {
-        // the required parts of the message
-        j = json{
-            {"timestamp", k.timestamp.to_rfc3339()},
-            {"sampledValue", k.sampledValue},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given MeterValue \p k
-    friend void from_json(const json& j, MeterValue& k) {
-        // the required parts of the message
-        k.timestamp = DateTime(std::string(j.at("timestamp")));
-        ;
-        for (auto val : j.at("sampledValue")) {
-            k.sampledValue.push_back(val);
-        }
-
-        // the optional parts of the message
-    }
-
-    // \brief Writes the string representation of the given MeterValue \p k to the given output stream \p os
-    /// \returns an output stream with the MeterValue written to
-    friend std::ostream& operator<<(std::ostream& os, const MeterValue& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given MeterValue \p k to a given json object \p j
+void to_json(json& j, const MeterValue& k);
+
+/// \brief Conversion from a given json object \p j to a given MeterValue \p k
+void from_json(const json& j, MeterValue& k);
+
+// \brief Writes the string representation of the given MeterValue \p k to the given output stream \p os
+/// \returns an output stream with the MeterValue written to
+std::ostream& operator<<(std::ostream& os, const MeterValue& k);
 
 struct ChargingProfile {
     int32_t chargingProfileId;
@@ -301,132 +118,45 @@ struct ChargingProfile {
     boost::optional<RecurrencyKindType> recurrencyKind;
     boost::optional<DateTime> validFrom;
     boost::optional<DateTime> validTo;
-
-    /// \brief Conversion from a given ChargingProfile \p k to a given json object \p j
-    friend void to_json(json& j, const ChargingProfile& k) {
-        // the required parts of the message
-        j = json{
-            {"chargingProfileId", k.chargingProfileId},
-            {"stackLevel", k.stackLevel},
-            {"chargingProfilePurpose", conversions::charging_profile_purpose_type_to_string(k.chargingProfilePurpose)},
-            {"chargingProfileKind", conversions::charging_profile_kind_type_to_string(k.chargingProfileKind)},
-            {"chargingSchedule", k.chargingSchedule},
-        };
-        // the optional parts of the message
-        if (k.transactionId) {
-            j["transactionId"] = k.transactionId.value();
-        }
-        if (k.recurrencyKind) {
-            j["recurrencyKind"] = conversions::recurrency_kind_type_to_string(k.recurrencyKind.value());
-        }
-        if (k.validFrom) {
-            j["validFrom"] = k.validFrom.value().to_rfc3339();
-        }
-        if (k.validTo) {
-            j["validTo"] = k.validTo.value().to_rfc3339();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given ChargingProfile \p k
-    friend void from_json(const json& j, ChargingProfile& k) {
-        // the required parts of the message
-        k.chargingProfileId = j.at("chargingProfileId");
-        k.stackLevel = j.at("stackLevel");
-        k.chargingProfilePurpose = conversions::string_to_charging_profile_purpose_type(j.at("chargingProfilePurpose"));
-        k.chargingProfileKind = conversions::string_to_charging_profile_kind_type(j.at("chargingProfileKind"));
-        k.chargingSchedule = j.at("chargingSchedule");
-
-        // the optional parts of the message
-        if (j.contains("transactionId")) {
-            k.transactionId.emplace(j.at("transactionId"));
-        }
-        if (j.contains("recurrencyKind")) {
-            k.recurrencyKind.emplace(j.at("recurrencyKind"));
-        }
-        if (j.contains("validFrom")) {
-            k.validFrom.emplace(j.at("validFrom"));
-        }
-        if (j.contains("validTo")) {
-            k.validTo.emplace(j.at("validTo"));
-        }
-    }
-
-    // \brief Writes the string representation of the given ChargingProfile \p k to the given output stream \p os
-    /// \returns an output stream with the ChargingProfile written to
-    friend std::ostream& operator<<(std::ostream& os, const ChargingProfile& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given ChargingProfile \p k to a given json object \p j
+void to_json(json& j, const ChargingProfile& k);
+
+/// \brief Conversion from a given json object \p j to a given ChargingProfile \p k
+void from_json(const json& j, ChargingProfile& k);
+
+// \brief Writes the string representation of the given ChargingProfile \p k to the given output stream \p os
+/// \returns an output stream with the ChargingProfile written to
+std::ostream& operator<<(std::ostream& os, const ChargingProfile& k);
 
 struct LocalAuthorizationList {
     CiString20Type idTag;
     boost::optional<IdTagInfo> idTagInfo;
-
-    /// \brief Conversion from a given LocalAuthorizationList \p k to a given json object \p j
-    friend void to_json(json& j, const LocalAuthorizationList& k) {
-        // the required parts of the message
-        j = json{
-            {"idTag", k.idTag},
-        };
-        // the optional parts of the message
-        if (k.idTagInfo) {
-            j["idTagInfo"] = k.idTagInfo.value();
-        }
-    }
-
-    /// \brief Conversion from a given json object \p j to a given LocalAuthorizationList \p k
-    friend void from_json(const json& j, LocalAuthorizationList& k) {
-        // the required parts of the message
-        k.idTag = j.at("idTag");
-
-        // the optional parts of the message
-        if (j.contains("idTagInfo")) {
-            k.idTagInfo.emplace(j.at("idTagInfo"));
-        }
-    }
-
-    // \brief Writes the string representation of the given LocalAuthorizationList \p k to the given output stream \p os
-    /// \returns an output stream with the LocalAuthorizationList written to
-    friend std::ostream& operator<<(std::ostream& os, const LocalAuthorizationList& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given LocalAuthorizationList \p k to a given json object \p j
+void to_json(json& j, const LocalAuthorizationList& k);
+
+/// \brief Conversion from a given json object \p j to a given LocalAuthorizationList \p k
+void from_json(const json& j, LocalAuthorizationList& k);
+
+// \brief Writes the string representation of the given LocalAuthorizationList \p k to the given output stream \p os
+/// \returns an output stream with the LocalAuthorizationList written to
+std::ostream& operator<<(std::ostream& os, const LocalAuthorizationList& k);
 
 struct TransactionData {
     DateTime timestamp;
     std::vector<SampledValue> sampledValue;
-
-    /// \brief Conversion from a given TransactionData \p k to a given json object \p j
-    friend void to_json(json& j, const TransactionData& k) {
-        // the required parts of the message
-        j = json{
-            {"timestamp", k.timestamp.to_rfc3339()},
-            {"sampledValue", k.sampledValue},
-        };
-        // the optional parts of the message
-    }
-
-    /// \brief Conversion from a given json object \p j to a given TransactionData \p k
-    friend void from_json(const json& j, TransactionData& k) {
-        // the required parts of the message
-        k.timestamp = DateTime(std::string(j.at("timestamp")));
-        ;
-        for (auto val : j.at("sampledValue")) {
-            k.sampledValue.push_back(val);
-        }
-
-        // the optional parts of the message
-    }
-
-    // \brief Writes the string representation of the given TransactionData \p k to the given output stream \p os
-    /// \returns an output stream with the TransactionData written to
-    friend std::ostream& operator<<(std::ostream& os, const TransactionData& k) {
-        os << json(k).dump(4);
-        return os;
-    }
 };
+/// \brief Conversion from a given TransactionData \p k to a given json object \p j
+void to_json(json& j, const TransactionData& k);
+
+/// \brief Conversion from a given json object \p j to a given TransactionData \p k
+void from_json(const json& j, TransactionData& k);
+
+// \brief Writes the string representation of the given TransactionData \p k to the given output stream \p os
+/// \returns an output stream with the TransactionData written to
+std::ostream& operator<<(std::ostream& os, const TransactionData& k);
+
 } // namespace ocpp1_6
 
 #endif // OCPP1_6_OCPP_TYPES_HPP

--- a/include/ocpp1_6/schemas.hpp
+++ b/include/ocpp1_6/schemas.hpp
@@ -37,7 +37,7 @@ private:
 
 public:
     /// \brief Creates a new Schemas object looking for the root schema file in relation to the provided \p main_dir
-    Schemas(std::string main_dir);
+    explicit Schemas(std::string main_dir);
 
     /// \brief Provides the config profile schema
     /// \returns the config profile schema as as json object

--- a/include/ocpp1_6/schemas.hpp
+++ b/include/ocpp1_6/schemas.hpp
@@ -22,8 +22,8 @@ namespace ocpp1_6 {
 /// \brief Contains the json schema validation for the libocpp config
 class Schemas {
 private:
-    std::map<std::string, json> profile_schemas;
-    std::map<std::string, std::shared_ptr<json_validator>> profile_validators;
+    json profile_schema;
+    std::shared_ptr<json_validator> profile_validator;
     boost::filesystem::path profile_schemas_path;
     std::set<boost::filesystem::path> available_schemas_paths;
     const static std::vector<std::string> profiles;

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -113,7 +113,7 @@ std::string messagetype_to_string(MessageType m);
 
 /// \brief Converts the given std::string \p s to MessageType
 /// \returns a MessageType from a string representation
-MessageType string_to_messagetype(std::string s);
+MessageType string_to_messagetype(const std::string& s);
 
 /// \brief Converts the given bool \p b to a string representation of "true" or "false"
 /// \returns a string representation of the given bool
@@ -462,7 +462,7 @@ std::string charge_point_connection_state_to_string(ChargePointConnectionState e
 
 /// \brief Converts the given std::string \p s to ChargePointConnectionState
 /// \returns a ChargePointConnectionState from a string representation
-ChargePointConnectionState string_to_charge_point_connection_state(std::string s);
+ChargePointConnectionState string_to_charge_point_connection_state(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p charge_point_connection_state
@@ -486,7 +486,7 @@ std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e);
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
-SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s);
+SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string& s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p supported_feature_profiles to the given output stream \p os

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -768,8 +768,8 @@ static const ChargePointConnectionState string_to_charge_point_connection_state(
 }
 } // namespace conversions
 
-/// \brief Writes the string representation of the given \p charge_point_connection_state to the given output stream \p os
-/// \returns an output stream with the ChargePointConnectionState written to
+/// \brief Writes the string representation of the given \p charge_point_connection_state
+/// to the given output stream \p os \returns an output stream with the ChargePointConnectionState written to
 inline std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state) {
     os << conversions::charge_point_connection_state_to_string(charge_point_connection_state);
     return os;

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -140,10 +140,10 @@ std::ostream& operator<<(std::ostream& os, const MessageType& message_type);
 class CiString20Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 20
-    CiString20Type(const std::string& data);
+    explicit CiString20Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 20
-    CiString20Type(const json& data);
+    explicit CiString20Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 20
     CiString20Type();
@@ -168,10 +168,10 @@ void from_json(const json& j, CiString20Type& k);
 class CiString25Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 25
-    CiString25Type(const std::string& data);
+    explicit CiString25Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 25
-    CiString25Type(const json& data);
+    explicit CiString25Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 20
     CiString25Type();
@@ -196,10 +196,10 @@ void from_json(const json& j, CiString25Type& k);
 class CiString50Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 50
-    CiString50Type(const std::string& data);
+    explicit CiString50Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 50
-    CiString50Type(const json& data);
+    explicit CiString50Type(const json& data);
     /// \brief Creates a case insensitive string with a maximum length of 50
     CiString50Type();
 
@@ -223,10 +223,10 @@ void from_json(const json& j, CiString50Type& k);
 class CiString255Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 255
-    CiString255Type(const std::string& data);
+    explicit CiString255Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 255
-    CiString255Type(const json& data);
+    explicit CiString255Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 255
     CiString255Type();
@@ -252,10 +252,10 @@ class CiString500Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 500
 
-    CiString500Type(const std::string& data);
+    explicit CiString500Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 500
-    CiString500Type(const json& data);
+    explicit CiString500Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 500
     CiString500Type();
@@ -281,7 +281,7 @@ void from_json(const json& j, CiString500Type& k);
 class MessageId : public CiString {
 public:
     /// \brief Creates a case insensitive MessageId from the given string \p data and a maximum length of 36
-    MessageId(const std::string& data);
+    explicit MessageId(const std::string& data);
 
     /// \brief Creates a case insensitive MessageId with a maximum length of 36
     MessageId();
@@ -315,10 +315,16 @@ public:
     DateTime();
 
     /// \brief Creates a new DateTime object from the given \p timepoint
-    DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint);
+    explicit DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint);
 
     /// \brief Creates a new DateTime object from the given \p timepoint_str
-    DateTime(const std::string& timepoint_str);
+    explicit DateTime(const std::string& timepoint_str);
+
+    /// \brief Assignment operator= that converts a given string \p s into a DateTime
+    DateTime& operator=(const std::string& s);
+
+    /// \brief Assignment operator= that converts a given char* \p c into a DateTime
+    DateTime& operator=(const char* c);
 };
 
 /// \brief Combines a Measurand with an optional Phase

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -109,27 +109,27 @@ enum class MessageType
 namespace conversions {
 /// \brief Converts the given MessageType \p m to std::string
 /// \returns a string representation of the MessageType
-const std::string messagetype_to_string(MessageType m);
+std::string messagetype_to_string(MessageType m);
 
 /// \brief Converts the given std::string \p s to MessageType
 /// \returns a MessageType from a string representation
-const MessageType string_to_messagetype(std::string s);
+MessageType string_to_messagetype(std::string s);
 
 /// \brief Converts the given bool \p b to a string representation of "true" or "false"
 /// \returns a string representation of the given bool
-const std::string bool_to_string(bool b);
+std::string bool_to_string(bool b);
 
 /// \brief Converts the given string \p s to a bool value. "true" is converted into true, anything else to false
 /// \returns a bool from the given string representation
-const bool string_to_bool(const std::string& s);
+bool string_to_bool(const std::string& s);
 
 /// \brief Converts the given double \p d to a string representation with the given \p precision
 /// \returns a string representation of the given double using the given precision
-const std::string double_to_string(double d, int precision);
+std::string double_to_string(double d, int precision);
 
 /// \brief Converts the given double \p d to a string representation with a fixed precision of 2
 /// \returns a string representation of the given double using a fixed precision of 2
-const std::string double_to_string(double d);
+std::string double_to_string(double d);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p message_type to the given output stream \p os
@@ -452,11 +452,11 @@ enum ChargePointConnectionState
 namespace conversions {
 /// \brief Converts the given ChargePointConnectionState \p e to std::string
 /// \returns a string representation of the ChargePointConnectionState
-const std::string charge_point_connection_state_to_string(ChargePointConnectionState e);
+std::string charge_point_connection_state_to_string(ChargePointConnectionState e);
 
 /// \brief Converts the given std::string \p s to ChargePointConnectionState
 /// \returns a ChargePointConnectionState from a string representation
-const ChargePointConnectionState string_to_charge_point_connection_state(std::string s);
+ChargePointConnectionState string_to_charge_point_connection_state(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p charge_point_connection_state
@@ -476,11 +476,11 @@ enum SupportedFeatureProfiles
 namespace conversions {
 /// \brief Converts the given SupportedFeatureProfiles \p e to std::string
 /// \returns a string representation of the SupportedFeatureProfiles
-const std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e);
+std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e);
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
-const SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s);
+SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p supported_feature_profiles to the given output stream \p os

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -3,14 +3,9 @@
 #ifndef OCPP1_6_TYPES_HPP
 #define OCPP1_6_TYPES_HPP
 
-#include <future>
 #include <sstream>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/asio.hpp>
 #include <boost/optional.hpp>
-#include <everest/logging.hpp>
-#include <everest/timer.hpp>
 #include <nlohmann/json.hpp>
 
 #include <ocpp1_6/enums.hpp>
@@ -114,466 +109,216 @@ enum class MessageType
 namespace conversions {
 /// \brief Converts the given MessageType \p m to std::string
 /// \returns a string representation of the MessageType
-static const std::string messagetype_to_string(MessageType m) {
-    const std::map<MessageType, std::string> MessageTypeStrings{
-        {MessageType::Authorize, "Authorize"},
-        {MessageType::AuthorizeResponse, "AuthorizeResponse"},
-        {MessageType::BootNotification, "BootNotification"},
-        {MessageType::BootNotificationResponse, "BootNotificationResponse"},
-        {MessageType::CancelReservation, "CancelReservation"},
-        {MessageType::CancelReservationResponse, "CancelReservationResponse"},
-        {MessageType::ChangeAvailability, "ChangeAvailability"},
-        {MessageType::ChangeAvailabilityResponse, "ChangeAvailabilityResponse"},
-        {MessageType::ChangeConfiguration, "ChangeConfiguration"},
-        {MessageType::ChangeConfigurationResponse, "ChangeConfigurationResponse"},
-        {MessageType::ClearCache, "ClearCache"},
-        {MessageType::ClearCacheResponse, "ClearCacheResponse"},
-        {MessageType::ClearChargingProfile, "ClearChargingProfile"},
-        {MessageType::ClearChargingProfileResponse, "ClearChargingProfileResponse"},
-        {MessageType::DataTransfer, "DataTransfer"},
-        {MessageType::DataTransferResponse, "DataTransferResponse"},
-        {MessageType::DiagnosticsStatusNotification, "DiagnosticsStatusNotification"},
-        {MessageType::DiagnosticsStatusNotificationResponse, "DiagnosticsStatusNotificationResponse"},
-        {MessageType::FirmwareStatusNotification, "FirmwareStatusNotification"},
-        {MessageType::FirmwareStatusNotificationResponse, "FirmwareStatusNotificationResponse"},
-        {MessageType::GetCompositeSchedule, "GetCompositeSchedule"},
-        {MessageType::GetCompositeScheduleResponse, "GetCompositeScheduleResponse"},
-        {MessageType::GetConfiguration, "GetConfiguration"},
-        {MessageType::GetConfigurationResponse, "GetConfigurationResponse"},
-        {MessageType::GetDiagnostics, "GetDiagnostics"},
-        {MessageType::GetDiagnosticsResponse, "GetDiagnosticsResponse"},
-        {MessageType::GetLocalListVersion, "GetLocalListVersion"},
-        {MessageType::GetLocalListVersionResponse, "GetLocalListVersionResponse"},
-        {MessageType::Heartbeat, "Heartbeat"},
-        {MessageType::HeartbeatResponse, "HeartbeatResponse"},
-        {MessageType::MeterValues, "MeterValues"},
-        {MessageType::MeterValuesResponse, "MeterValuesResponse"},
-        {MessageType::RemoteStartTransaction, "RemoteStartTransaction"},
-        {MessageType::RemoteStartTransactionResponse, "RemoteStartTransactionResponse"},
-        {MessageType::RemoteStopTransaction, "RemoteStopTransaction"},
-        {MessageType::RemoteStopTransactionResponse, "RemoteStopTransactionResponse"},
-        {MessageType::ReserveNow, "ReserveNow"},
-        {MessageType::ReserveNowResponse, "ReserveNowResponse"},
-        {MessageType::Reset, "Reset"},
-        {MessageType::ResetResponse, "ResetResponse"},
-        {MessageType::SendLocalList, "SendLocalList"},
-        {MessageType::SendLocalListResponse, "SendLocalListResponse"},
-        {MessageType::SetChargingProfile, "SetChargingProfile"},
-        {MessageType::SetChargingProfileResponse, "SetChargingProfileResponse"},
-        {MessageType::StartTransaction, "StartTransaction"},
-        {MessageType::StartTransactionResponse, "StartTransactionResponse"},
-        {MessageType::StatusNotification, "StatusNotification"},
-        {MessageType::StatusNotificationResponse, "StatusNotificationResponse"},
-        {MessageType::StopTransaction, "StopTransaction"},
-        {MessageType::StopTransactionResponse, "StopTransactionResponse"},
-        {MessageType::TriggerMessage, "TriggerMessage"},
-        {MessageType::TriggerMessageResponse, "TriggerMessageResponse"},
-        {MessageType::UnlockConnector, "UnlockConnector"},
-        {MessageType::UnlockConnectorResponse, "UnlockConnectorResponse"},
-        {MessageType::UpdateFirmware, "UpdateFirmware"},
-        {MessageType::UpdateFirmwareResponse, "UpdateFirmwareResponse"},
-    };
-    auto it = MessageTypeStrings.find(m);
-    if (it == MessageTypeStrings.end()) {
-        return "InternalError";
-    }
-    return it->second;
-}
+const std::string messagetype_to_string(MessageType m);
 
 /// \brief Converts the given std::string \p s to MessageType
 /// \returns a MessageType from a string representation
-static const MessageType string_to_messagetype(std::string s) {
-    const std::map<std::string, MessageType> MessageTypeStrings{
-        {"Authorize", MessageType::Authorize},
-        {"AuthorizeResponse", MessageType::AuthorizeResponse},
-        {"BootNotification", MessageType::BootNotification},
-        {"BootNotificationResponse", MessageType::BootNotificationResponse},
-        {"CancelReservation", MessageType::CancelReservation},
-        {"CancelReservationResponse", MessageType::CancelReservationResponse},
-        {"ChangeAvailability", MessageType::ChangeAvailability},
-        {"ChangeAvailabilityResponse", MessageType::ChangeAvailabilityResponse},
-        {"ChangeConfiguration", MessageType::ChangeConfiguration},
-        {"ChangeConfigurationResponse", MessageType::ChangeConfigurationResponse},
-        {"ClearCache", MessageType::ClearCache},
-        {"ClearCacheResponse", MessageType::ClearCacheResponse},
-        {"ClearChargingProfile", MessageType::ClearChargingProfile},
-        {"ClearChargingProfileResponse", MessageType::ClearChargingProfileResponse},
-        {"DataTransfer", MessageType::DataTransfer},
-        {"DataTransferResponse", MessageType::DataTransferResponse},
-        {"DiagnosticsStatusNotification", MessageType::DiagnosticsStatusNotification},
-        {"DiagnosticsStatusNotificationResponse", MessageType::DiagnosticsStatusNotificationResponse},
-        {"FirmwareStatusNotification", MessageType::FirmwareStatusNotification},
-        {"FirmwareStatusNotificationResponse", MessageType::FirmwareStatusNotificationResponse},
-        {"GetCompositeSchedule", MessageType::GetCompositeSchedule},
-        {"GetCompositeScheduleResponse", MessageType::GetCompositeScheduleResponse},
-        {"GetConfiguration", MessageType::GetConfiguration},
-        {"GetConfigurationResponse", MessageType::GetConfigurationResponse},
-        {"GetDiagnostics", MessageType::GetDiagnostics},
-        {"GetDiagnosticsResponse", MessageType::GetDiagnosticsResponse},
-        {"GetLocalListVersion", MessageType::GetLocalListVersion},
-        {"GetLocalListVersionResponse", MessageType::GetLocalListVersionResponse},
-        {"Heartbeat", MessageType::Heartbeat},
-        {"HeartbeatResponse", MessageType::HeartbeatResponse},
-        {"MeterValues", MessageType::MeterValues},
-        {"MeterValuesResponse", MessageType::MeterValuesResponse},
-        {"RemoteStartTransaction", MessageType::RemoteStartTransaction},
-        {"RemoteStartTransactionResponse", MessageType::RemoteStartTransactionResponse},
-        {"RemoteStopTransaction", MessageType::RemoteStopTransaction},
-        {"RemoteStopTransactionResponse", MessageType::RemoteStopTransactionResponse},
-        {"ReserveNow", MessageType::ReserveNow},
-        {"ReserveNowResponse", MessageType::ReserveNowResponse},
-        {"Reset", MessageType::Reset},
-        {"ResetResponse", MessageType::ResetResponse},
-        {"SendLocalList", MessageType::SendLocalList},
-        {"SendLocalListResponse", MessageType::SendLocalListResponse},
-        {"SetChargingProfile", MessageType::SetChargingProfile},
-        {"SetChargingProfileResponse", MessageType::SetChargingProfileResponse},
-        {"StartTransaction", MessageType::StartTransaction},
-        {"StartTransactionResponse", MessageType::StartTransactionResponse},
-        {"StatusNotification", MessageType::StatusNotification},
-        {"StatusNotificationResponse", MessageType::StatusNotificationResponse},
-        {"StopTransaction", MessageType::StopTransaction},
-        {"StopTransactionResponse", MessageType::StopTransactionResponse},
-        {"TriggerMessage", MessageType::TriggerMessage},
-        {"TriggerMessageResponse", MessageType::TriggerMessageResponse},
-        {"UnlockConnector", MessageType::UnlockConnector},
-        {"UnlockConnectorResponse", MessageType::UnlockConnectorResponse},
-        {"UpdateFirmware", MessageType::UpdateFirmware},
-        {"UpdateFirmwareResponse", MessageType::UpdateFirmwareResponse},
-    };
-    auto it = MessageTypeStrings.find(s);
-    if (it == MessageTypeStrings.end()) {
-        return MessageType::InternalError;
-    }
-    return it->second;
-}
+const MessageType string_to_messagetype(std::string s);
 
 /// \brief Converts the given bool \p b to a string representation of "true" or "false"
 /// \returns a string representation of the given bool
-static const std::string bool_to_string(bool b) {
-    if (b) {
-        return "true";
-    }
-    return "false";
-}
+const std::string bool_to_string(bool b);
 
 /// \brief Converts the given string \p s to a bool value. "true" is converted into true, anything else to false
 /// \returns a bool from the given string representation
-static const bool string_to_bool(const std::string& s) {
-    if (s == "true") {
-        return true;
-    }
-    return false;
-}
+const bool string_to_bool(const std::string& s);
 
 /// \brief Converts the given double \p d to a string representation with the given \p precision
 /// \returns a string representation of the given double using the given precision
-static const std::string double_to_string(double d, int precision) {
-    std::ostringstream str;
-    str.precision(precision);
-    str << std::fixed << d;
-    return str.str();
-}
+const std::string double_to_string(double d, int precision);
 
 /// \brief Converts the given double \p d to a string representation with a fixed precision of 2
 /// \returns a string representation of the given double using a fixed precision of 2
-static const std::string double_to_string(double d) {
-    return conversions::double_to_string(d, 2);
-}
+const std::string double_to_string(double d);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p message_type to the given output stream \p os
 /// \returns an output stream with the MessageType written to
-inline std::ostream& operator<<(std::ostream& os, const MessageType& message_type) {
-    os << conversions::messagetype_to_string(message_type);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const MessageType& message_type);
 
 /// \brief Contains a CaseInsensitive string implementation with a maximum length of 20 printable ASCII characters
 class CiString20Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 20
-    CiString20Type(const std::string& data) : CiString(data, 20) {
-    }
+    CiString20Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 20
-    CiString20Type(const json& data) : CiString(data.get<std::string>(), 20) {
-    }
+    CiString20Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 20
-    CiString20Type() : CiString(20) {
-    }
+    CiString20Type();
 
     /// \brief Assignment operator= that converts a given string \p s into a CiString20Type
-    CiString20Type& operator=(const std::string& s) {
-        this->set(s);
-        return *this;
-    }
+    CiString20Type& operator=(const std::string& s);
 
     /// \brief Assignment operator= that converts a given char* \p c into a CiString20Type
-    CiString20Type& operator=(const char* c) {
-        this->set(std::string(c));
-        return *this;
-    }
+    CiString20Type& operator=(const char* c);
 
     /// \brief Assignment operator= that converts a given json \p j into a CiString20Type
-    CiString20Type& operator=(const json& j) {
-        this->set(j.get<std::string>());
-        return *this;
-    }
-
-    /// \brief Conversion from a given CiString20Type \p k to a given json object \p j
-    friend void to_json(json& j, const CiString20Type& k) {
-        j = json(k.get());
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CiString20Type \p k
-    friend void from_json(const json& j, CiString20Type& k) {
-        k.set(j);
-    }
+    CiString20Type& operator=(const json& j);
 };
+
+/// \brief Conversion from a given CiString20Type \p k to a given json object \p j
+void to_json(json& j, const CiString20Type& k);
+
+/// \brief Conversion from a given json object \p j to a given CiString20Type \p k
+void from_json(const json& j, CiString20Type& k);
 
 /// \brief Contains a CaseInsensitive string implementation with a maximum length of 25 printable ASCII characters
 class CiString25Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 25
-    CiString25Type(const std::string& data) : CiString(data, 25) {
-    }
+    CiString25Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 25
-    CiString25Type(const json& data) : CiString(data.get<std::string>(), 25) {
-    }
+    CiString25Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 20
-    CiString25Type() : CiString(25) {
-    }
+    CiString25Type();
 
     /// \brief Assignment operator= that converts a given string \p s into a CiString25Type
-    CiString25Type& operator=(const std::string& s) {
-        this->set(s);
-        return *this;
-    }
+    CiString25Type& operator=(const std::string& s);
 
     /// \brief Assignment operator= that converts a given char* \p c into a CiString25Type
-    CiString25Type& operator=(const char* c) {
-        this->set(std::string(c));
-        return *this;
-    }
+    CiString25Type& operator=(const char* c);
 
     /// \brief Assignment operator= that converts a given json \p j into a CiString25Type
-    CiString25Type& operator=(const json& j) {
-        this->set(j.get<std::string>());
-        return *this;
-    }
-
-    /// \brief Conversion from a given CiString25Type \p k to a given json object \p j
-    friend void to_json(json& j, const CiString25Type& k) {
-        j = json(k.get());
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CiString25Type \p k
-    friend void from_json(const json& j, CiString25Type& k) {
-        k.set(j);
-    }
+    CiString25Type& operator=(const json& j);
 };
+
+/// \brief Conversion from a given CiString25Type \p k to a given json object \p j
+void to_json(json& j, const CiString25Type& k);
+
+/// \brief Conversion from a given json object \p j to a given CiString25Type \p k
+void from_json(const json& j, CiString25Type& k);
 
 /// \brief Contains a CaseInsensitive string implementation with a maximum length of 50 printable ASCII characters
 class CiString50Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 50
-    CiString50Type(const std::string& data) : CiString(data, 50) {
-    }
+    CiString50Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 50
-    CiString50Type(const json& data) : CiString(data.get<std::string>(), 50) {
-    }
+    CiString50Type(const json& data);
     /// \brief Creates a case insensitive string with a maximum length of 50
-    CiString50Type() : CiString(50) {
-    }
+    CiString50Type();
 
     /// \brief Assignment operator= that converts a given string \p s into a CiString50Type
-    CiString50Type& operator=(const std::string& s) {
-        this->set(s);
-        return *this;
-    }
+    CiString50Type& operator=(const std::string& s);
 
     /// \brief Assignment operator= that converts a given char* \p c into a CiString50Type
-    CiString50Type& operator=(const char* c) {
-        this->set(std::string(c));
-        return *this;
-    }
+    CiString50Type& operator=(const char* c);
 
     /// \brief Assignment operator= that converts a given json \p j into a CiString50Type
-    CiString50Type& operator=(const json& j) {
-        this->set(j.get<std::string>());
-        return *this;
-    }
-
-    /// \brief Conversion from a given CiString50Type \p k to a given json object \p j
-    friend void to_json(json& j, const CiString50Type& k) {
-        j = json(k.get());
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CiString50Type \p k
-    friend void from_json(const json& j, CiString50Type& k) {
-        k.set(j);
-    }
+    CiString50Type& operator=(const json& j);
 };
+
+/// \brief Conversion from a given CiString50Type \p k to a given json object \p j
+void to_json(json& j, const CiString50Type& k);
+
+/// \brief Conversion from a given json object \p j to a given CiString50Type \p k
+void from_json(const json& j, CiString50Type& k);
 
 /// \brief Contains a CaseInsensitive string implementation with a maximum length of 255 printable ASCII characters
 class CiString255Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 255
-    CiString255Type(const std::string& data) : CiString(data, 255) {
-    }
+    CiString255Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 255
-    CiString255Type(const json& data) : CiString(data.get<std::string>(), 255) {
-    }
+    CiString255Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 255
-    CiString255Type() : CiString(255) {
-    }
+    CiString255Type();
 
     /// \brief Assignment operator= that converts a given string \p s into a CiString255Type
-    CiString255Type& operator=(const std::string& s) {
-        this->set(s);
-        return *this;
-    }
+    CiString255Type& operator=(const std::string& s);
 
     /// \brief Assignment operator= that converts a given char* \p c into a CiString255Type
-    CiString255Type& operator=(const char* c) {
-        this->set(std::string(c));
-        return *this;
-    }
+    CiString255Type& operator=(const char* c);
 
     /// \brief Assignment operator= that converts a given json \p j into a CiString255Type
-    CiString255Type& operator=(const json& j) {
-        this->set(j.get<std::string>());
-        return *this;
-    }
-
-    /// \brief Conversion from a given CiString255Type \p k to a given json object \p j
-    friend void to_json(json& j, const CiString255Type& k) {
-        j = json(k.get());
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CiString255Type \p k
-    friend void from_json(const json& j, CiString255Type& k) {
-        k.set(j);
-    }
+    CiString255Type& operator=(const json& j);
 };
+
+/// \brief Conversion from a given CiString255Type \p k to a given json object \p j
+void to_json(json& j, const CiString255Type& k);
+
+/// \brief Conversion from a given json object \p j to a given CiString255Type \p k
+void from_json(const json& j, CiString255Type& k);
 
 /// \brief Contains a CaseInsensitive string implementation with a maximum length of 500 printable ASCII characters
 class CiString500Type : public CiString {
 public:
     /// \brief Creates a case insensitive string from the given string \p data and a maximum length of 500
 
-    CiString500Type(const std::string& data) : CiString(data, 500) {
-    }
+    CiString500Type(const std::string& data);
 
     /// \brief Creates a case insensitive string from the given json \p data and a maximum length of 500
-    CiString500Type(const json& data) : CiString(data.get<std::string>(), 500) {
-    }
+    CiString500Type(const json& data);
 
     /// \brief Creates a case insensitive string with a maximum length of 500
-    CiString500Type() : CiString(500) {
-    }
+    CiString500Type();
 
     /// \brief Assignment operator= that converts a given string \p s into a CiString500Type
-    CiString500Type& operator=(const std::string& s) {
-        this->set(s);
-        return *this;
-    }
+    CiString500Type& operator=(const std::string& s);
 
     /// \brief Assignment operator= that converts a given char* \p c into a CiString500Type
-    CiString500Type& operator=(const char* c) {
-        this->set(std::string(c));
-        return *this;
-    }
+    CiString500Type& operator=(const char* c);
 
     /// \brief Assignment operator= that converts a given json \p j into a CiString500Type
-    CiString500Type& operator=(const json& j) {
-        this->set(j.get<std::string>());
-        return *this;
-    }
-
-    /// \brief Conversion from a given CiString500Type \p k to a given json object \p j
-    friend void to_json(json& j, const CiString500Type& k) {
-        j = json(k.get());
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CiString500Type \p k
-    friend void from_json(const json& j, CiString500Type& k) {
-        k.set(j);
-    }
+    CiString500Type& operator=(const json& j);
 };
+
+/// \brief Conversion from a given CiString500Type \p k to a given json object \p j
+void to_json(json& j, const CiString500Type& k);
+
+/// \brief Conversion from a given json object \p j to a given CiString500Type \p k
+void from_json(const json& j, CiString500Type& k);
 
 /// \brief Contains a MessageId implementation based on a case insensitive string with a maximum length of 36 printable
 /// ASCII characters
 class MessageId : public CiString {
 public:
     /// \brief Creates a case insensitive MessageId from the given string \p data and a maximum length of 36
-    MessageId(const std::string& data) : CiString(data, 36) {
-    }
+    MessageId(const std::string& data);
 
     /// \brief Creates a case insensitive MessageId with a maximum length of 36
-    MessageId() : CiString(36) {
-    }
+    MessageId();
 
     /// \brief Assignment operator= that converts a given string \p s into a MessageId
-    MessageId& operator=(const std::string& s) {
-        this->set(s);
-        return *this;
-    }
+    MessageId& operator=(const std::string& s);
 
     /// \brief Assignment operator= that converts a given char* \p c into a MessageId
-    MessageId& operator=(const char* c) {
-        this->set(std::string(c));
-        return *this;
-    }
+    MessageId& operator=(const char* c);
 
     /// \brief Assignment operator= that converts a given json \p j into a MessageId
-    MessageId& operator=(const json& j) {
-        this->set(j.get<std::string>());
-        return *this;
-    }
+    MessageId& operator=(const json& j);
 
     /// \brief Comparison operator< between this MessageId and the givenn MessageId \p rhs
-    bool operator<(const MessageId& rhs) {
-        return this->get() < rhs.get();
-    }
-
-    /// \brief Comparison operator< between two MessageId \p lhs and \p rhs
-    friend bool operator<(const MessageId& lhs, const MessageId& rhs) {
-        return lhs.get() < rhs.get();
-    }
-
-    /// \brief Conversion from a given MessageId \p k to a given json object \p j
-    friend void to_json(json& j, const MessageId& k) {
-        j = json(k.get());
-    }
-
-    /// \brief Conversion from a given json object \p j to a given MessageId \p k
-    friend void from_json(const json& j, MessageId& k) {
-        k.set(j);
-    }
+    bool operator<(const MessageId& rhs);
 };
+
+/// \brief Comparison operator< between two MessageId \p lhs and \p rhs
+bool operator<(const MessageId& lhs, const MessageId& rhs);
+
+/// \brief Conversion from a given MessageId \p k to a given json object \p j
+void to_json(json& j, const MessageId& k);
+
+/// \brief Conversion from a given json object \p j to a given MessageId \p k
+void from_json(const json& j, MessageId& k);
 
 /// \brief Contains a DateTime implementation that can parse and create RFC 3339 compatible strings
 class DateTime : public DateTimeImpl {
 public:
     /// \brief Creates a new DateTime object with the current system time
-    DateTime() : DateTimeImpl() {
-    }
+    DateTime();
 
     /// \brief Creates a new DateTime object from the given \p timepoint
-    DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint) : DateTimeImpl(timepoint) {
-    }
+    DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint);
 
     /// \brief Creates a new DateTime object from the given \p timepoint_str
-    DateTime(const std::string& timepoint_str) : DateTimeImpl(timepoint_str) {
-    }
+    DateTime(const std::string& timepoint_str);
 };
 
 /// \brief Combines a Measurand with an optional Phase
@@ -583,20 +328,7 @@ struct MeasurandWithPhase {
 
     /// \brief Comparison operator== between this MeasurandWithPhase and the given \p measurand_with_phase
     /// \returns true when measurand and phase are equal
-    bool operator==(MeasurandWithPhase measurand_with_phase) {
-        if (this->measurand == measurand_with_phase.measurand) {
-            if (this->phase || measurand_with_phase.phase) {
-                if (this->phase && measurand_with_phase.phase) {
-                    if (this->phase.value() == measurand_with_phase.phase.value()) {
-                        return true;
-                    }
-                }
-            } else {
-                return true;
-            }
-        }
-        return false;
-    };
+    bool operator==(MeasurandWithPhase measurand_with_phase);
 };
 
 /// \brief Combines a Measurand with a list of Phases
@@ -690,45 +422,23 @@ struct CallError {
     json errorDetails;
 
     /// \brief Creates a new CallError message object
-    CallError() {
-    }
+    CallError();
 
     /// \brief Creates a new CallResult message object with the given \p uniqueID \p errorCode \p errorDescription and
     /// \p errorDetails
     CallError(const MessageId& uniqueId, const std::string& errorCode, const std::string& errorDescription,
-              const json& errorDetails) {
-        this->uniqueId = uniqueId;
-        this->errorCode = errorCode;
-        this->errorDescription = errorDescription;
-        this->errorDetails = errorDetails;
-    }
-
-    /// \brief Conversion from a given CallError message \p c to a given json object \p j
-    friend void to_json(json& j, const CallError& c) {
-        j = json::array();
-        j.push_back(MessageTypeId::CALLERROR);
-        j.push_back(c.uniqueId.get());
-        j.push_back(c.errorCode);
-        j.push_back(c.errorDescription);
-        j.push_back(c.errorDetails);
-    }
-
-    /// \brief Conversion from a given json object \p j to a given CallError message \p c
-    friend void from_json(const json& j, CallError& c) {
-        // the required parts of the message
-        c.uniqueId.set(j.at(MESSAGE_ID));
-        c.errorCode = j.at(CALLERROR_ERROR_CODE);
-        c.errorDescription = j.at(CALLERROR_ERROR_DESCRIPTION);
-        c.errorDetails = j.at(CALLERROR_ERROR_DETAILS);
-    }
-
-    /// \brief Writes the given case CallError \p c to the given output stream \p os
-    /// \returns an output stream with the CallError written to
-    friend std::ostream& operator<<(std::ostream& os, const CallError& c) {
-        os << json(c).dump(4);
-        return os;
-    }
+              const json& errorDetails);
 };
+
+/// \brief Conversion from a given CallError message \p c to a given json object \p j
+void to_json(json& j, const CallError& c);
+
+/// \brief Conversion from a given json object \p j to a given CallError message \p c
+void from_json(const json& j, CallError& c);
+
+/// \brief Writes the given case CallError \p c to the given output stream \p os
+/// \returns an output stream with the CallError written to
+std::ostream& operator<<(std::ostream& os, const CallError& c);
 
 /// \brief Contains the different connection states of the charge point
 enum ChargePointConnectionState
@@ -740,40 +450,18 @@ enum ChargePointConnectionState
     Rejected,
 };
 namespace conversions {
-static const std::map<ChargePointConnectionState, std::string> ChargePointConnectionStateStrings{
-    {ChargePointConnectionState::Disconnected, "Disconnected"},
-    {ChargePointConnectionState::Connected, "Connected"},
-    {ChargePointConnectionState::Booted, "Booted"},
-    {ChargePointConnectionState::Pending, "Pending"},
-    {ChargePointConnectionState::Rejected, "Rejected"},
-};
-static const std::map<std::string, ChargePointConnectionState> ChargePointConnectionStateValues{
-    {"Disconnected", ChargePointConnectionState::Disconnected},
-    {"Connected", ChargePointConnectionState::Connected},
-    {"Booted", ChargePointConnectionState::Booted},
-    {"Pending", ChargePointConnectionState::Pending},
-    {"Rejected", ChargePointConnectionState::Rejected},
-};
-
 /// \brief Converts the given ChargePointConnectionState \p e to std::string
 /// \returns a string representation of the ChargePointConnectionState
-static const std::string charge_point_connection_state_to_string(ChargePointConnectionState e) {
-    return ChargePointConnectionStateStrings.at(e);
-}
+const std::string charge_point_connection_state_to_string(ChargePointConnectionState e);
 
 /// \brief Converts the given std::string \p s to ChargePointConnectionState
 /// \returns a ChargePointConnectionState from a string representation
-static const ChargePointConnectionState string_to_charge_point_connection_state(std::string s) {
-    return ChargePointConnectionStateValues.at(s);
-}
+const ChargePointConnectionState string_to_charge_point_connection_state(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p charge_point_connection_state
 /// to the given output stream \p os \returns an output stream with the ChargePointConnectionState written to
-inline std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state) {
-    os << conversions::charge_point_connection_state_to_string(charge_point_connection_state);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state);
 
 /// \brief Contains the supported OCPP 1.6 feature profiles
 enum SupportedFeatureProfiles
@@ -786,42 +474,18 @@ enum SupportedFeatureProfiles
     RemoteTrigger,
 };
 namespace conversions {
-static const std::map<SupportedFeatureProfiles, std::string> SupportedFeatureProfilesStrings{
-    {SupportedFeatureProfiles::Core, "Core"},
-    {SupportedFeatureProfiles::FirmwareManagement, "FirmwareManagement"},
-    {SupportedFeatureProfiles::LocalAuthListManagement, "LocalAuthListManagement"},
-    {SupportedFeatureProfiles::Reservation, "Reservation"},
-    {SupportedFeatureProfiles::SmartCharging, "SmartCharging"},
-    {SupportedFeatureProfiles::RemoteTrigger, "RemoteTrigger"},
-};
-static const std::map<std::string, SupportedFeatureProfiles> SupportedFeatureProfilesValues{
-    {"Core", SupportedFeatureProfiles::Core},
-    {"FirmwareManagement", SupportedFeatureProfiles::FirmwareManagement},
-    {"LocalAuthListManagement", SupportedFeatureProfiles::LocalAuthListManagement},
-    {"Reservation", SupportedFeatureProfiles::Reservation},
-    {"SmartCharging", SupportedFeatureProfiles::SmartCharging},
-    {"RemoteTrigger", SupportedFeatureProfiles::RemoteTrigger},
-};
-
 /// \brief Converts the given SupportedFeatureProfiles \p e to std::string
 /// \returns a string representation of the SupportedFeatureProfiles
-static const std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
-    return SupportedFeatureProfilesStrings.at(e);
-}
+const std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e);
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
-static const SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s) {
-    return SupportedFeatureProfilesValues.at(s);
-}
+const SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s);
 } // namespace conversions
 
 /// \brief Writes the string representation of the given \p supported_feature_profiles to the given output stream \p os
 /// \returns an output stream with the SupportedFeatureProfiles written to
-inline std::ostream& operator<<(std::ostream& os, const SupportedFeatureProfiles& supported_feature_profiles) {
-    os << conversions::supported_feature_profiles_to_string(supported_feature_profiles);
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const SupportedFeatureProfiles& supported_feature_profiles);
 
 } // namespace ocpp1_6
 #endif // OCPP1_6_TYPES_HPP

--- a/include/ocpp1_6/types_internal.hpp
+++ b/include/ocpp1_6/types_internal.hpp
@@ -75,14 +75,17 @@ public:
     DateTimeImpl();
 
     /// \brief Creates a new DateTimeImpl object from the given \p timepoint
-    DateTimeImpl(std::chrono::time_point<std::chrono::system_clock> timepoint);
+    explicit DateTimeImpl(std::chrono::time_point<std::chrono::system_clock> timepoint);
 
     /// \brief Creates a new DateTimeImpl object from the given \p timepoint_str
-    DateTimeImpl(const std::string& timepoint_str);
+    explicit DateTimeImpl(const std::string& timepoint_str);
 
     /// \brief Converts this DateTimeImpl to a RFC 3339 compatible string
     /// \returns a RFC 3339 compatible string representation of the stored DateTime
     std::string to_rfc3339() const;
+
+    /// \brief Sets the timepoint of this DateTimeImpl to the given \p timepoint_str
+    void from_rfc3339(const std::string& timepoint_str);
 
     /// \brief Converts this DateTimeImpl to a std::chrono::time_point
     /// \returns a std::chrono::time_point
@@ -118,6 +121,11 @@ public:
     /// \brief Comparison operator== between two DateTimeImpl \p lhs and \p rhs
     friend bool operator==(const DateTimeImpl& lhs, const DateTimeImpl& rhs) {
         return lhs.to_rfc3339() == rhs.to_rfc3339();
+    }
+
+    DateTimeImpl& operator=(const DateTimeImpl& dt) {
+        this->timepoint = dt.timepoint;
+        return *this;
     }
 };
 

--- a/include/ocpp1_6/types_internal.hpp
+++ b/include/ocpp1_6/types_internal.hpp
@@ -23,7 +23,7 @@ public:
     CiString(const std::string& data, size_t length);
 
     /// \brief Creates a case insensitive string from the given maximum \p length
-    CiString(size_t length);
+    explicit CiString(size_t length);
 
     /// \brief A CiString without a maximum length is not allowed
     CiString() = delete;

--- a/include/ocpp1_6/websocket.hpp
+++ b/include/ocpp1_6/websocket.hpp
@@ -8,9 +8,7 @@
 #include <websocketpp/client.hpp>
 #include <websocketpp/config/asio_client.hpp>
 
-#include <everest/timer.hpp>
-
-#include <ocpp1_6/charge_point_configuration.hpp>
+class ChargePointConfiguration;
 
 namespace ocpp1_6 {
 

--- a/include/ocpp1_6/websocket.hpp
+++ b/include/ocpp1_6/websocket.hpp
@@ -5,105 +5,24 @@
 
 #include <thread>
 
-#include <websocketpp/client.hpp>
-#include <websocketpp/config/asio_client.hpp>
+#include <ocpp1_6/websocket_plain.hpp>
+#include <ocpp1_6/websocket_tls.hpp>
 
 class ChargePointConfiguration;
 
 namespace ocpp1_6 {
-
-typedef websocketpp::client<websocketpp::config::asio_client> client;
-typedef websocketpp::client<websocketpp::config::asio_tls_client> tls_client;
-typedef websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context> tls_context;
-
-using websocketpp::lib::bind;
-using websocketpp::lib::placeholders::_1;
-using websocketpp::lib::placeholders::_2;
 
 ///
 /// \brief contains a websocket abstraction that can connect to TLS and non-TLS websocket endpoints
 ///
 class Websocket {
 private:
-    websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;
     std::shared_ptr<ChargePointConfiguration> configuration;
-    client ws_client;
-    tls_client wss_client;
+    std::unique_ptr<WebsocketPlain> websocket_plain;
+    std::unique_ptr<WebsocketTLS> websocket_tls;
     std::string uri;
     bool tls;
     bool shutting_down;
-    websocketpp::connection_hdl handle;
-    websocketpp::lib::shared_ptr<websocketpp::lib::thread> ws_thread;
-    std::mutex reconnect_mutex;
-    long reconnect_interval_ms;
-    websocketpp::transport::timer_handler reconnect_callback;
-    websocketpp::lib::shared_ptr<boost::asio::steady_timer> reconnect_timer;
-    std::function<void()> connected_callback;
-    std::function<void()> disconnected_callback;
-    std::function<void(const std::string& message)> message_callback;
-
-    /// \brief Indicates if the required callbacks are registered and the websocket is not shutting down
-    /// \returns true if the websocket is properly initialized
-    bool initialized();
-
-    /// \brief Reconnects the websocket using the reconnect timer, a reason for this reconnect can be provided with the
-    /// \p reason parameter
-    void reconnect(std::error_code reason);
-
-    /// \brief Extracts the hostname from the provided \p uri
-    /// FIXME(kai): this only works with a very limited subset of hostnames and should be extended to work spec conform
-    /// \returns the extracted hostname
-    std::string get_hostname(std::string uri);
-
-    // plaintext websocket
-
-    /// \brief Connect to a plaintext websocket
-    void connect_plain();
-
-    /// \brief Called when a plaintext websocket connection is established, calls the connected callback
-    void on_open_plain(client* c, websocketpp::connection_hdl hdl);
-
-    /// \brief Called when a message is received over the plaintext websocket, calls the message callback
-    void on_message_plain(websocketpp::connection_hdl hdl, client::message_ptr msg);
-
-    /// \brief Called when a plaintext websocket connection is closed, tries to reconnect
-    void on_close_plain(client* c, websocketpp::connection_hdl hdl);
-
-    /// \brief Called when a plaintext websocket connection fails to be established, tries to reconnect
-    void on_fail_plain(client* c, websocketpp::connection_hdl hdl);
-
-    /// \brief Closes a plaintext websocket connection
-    void close_plain(websocketpp::close::status::value code, const std::string& reason);
-
-    // TLS websocket
-
-    /// \brief FIXME: this should verify the certificate
-    /// FIXME(kai): implement validation!
-    /// \returns FIXME: always true at the moment because no certificate verification is performed
-    bool verify_certificate(std::string hostname, bool preverified, boost::asio::ssl::verify_context& context);
-
-    /// \brief Called when a TLS websocket connection gets initialized, manages the supported TLS versions, cipher lists
-    /// and how verification of the server certificate is handled
-    tls_context on_tls_init(std::string hostname, websocketpp::connection_hdl hdl);
-
-    /// \brief Connect to a TLS websocket, if the provided \p authorization_header is not empty use it to add a HTTP
-    /// Authorization header
-    void connect_tls(std::string authorization_header);
-
-    /// \brief Called when a TLS websocket connection is established, calls the connected callback
-    void on_open_tls(tls_client* c, websocketpp::connection_hdl hdl);
-
-    /// \brief Called when a message is received over the TLS websocket, calls the message callback
-    void on_message_tls(websocketpp::connection_hdl hdl, tls_client::message_ptr msg);
-
-    /// \brief Called when a TLS websocket connection is closed, tries to reconnect
-    void on_close_tls(tls_client* c, websocketpp::connection_hdl hdl);
-
-    /// \brief Called when a TLS websocket connection fails to be established, tries to reconnect
-    void on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl);
-
-    /// \brief Closes a TLS websocket connection
-    void close_tls(websocketpp::close::status::value code, const std::string& reason);
 
 public:
     /// \brief Creates a new Websocket object with the providede \p configuration

--- a/include/ocpp1_6/websocket/websocket.hpp
+++ b/include/ocpp1_6/websocket/websocket.hpp
@@ -8,9 +8,9 @@
 #include <ocpp1_6/websocket/websocket_plain.hpp>
 #include <ocpp1_6/websocket/websocket_tls.hpp>
 
-class ChargePointConfiguration;
-
 namespace ocpp1_6 {
+
+class ChargePointConfiguration;
 
 ///
 /// \brief contains a websocket abstraction that can connect to TLS and non-TLS websocket endpoints

--- a/include/ocpp1_6/websocket/websocket.hpp
+++ b/include/ocpp1_6/websocket/websocket.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef OCPP_WEBSOCKET_HPP
+#define OCPP_WEBSOCKET_HPP
+
+#include <thread>
+
+#include <ocpp1_6/websocket/websocket_plain.hpp>
+#include <ocpp1_6/websocket/websocket_tls.hpp>
+
+class ChargePointConfiguration;
+
+namespace ocpp1_6 {
+
+///
+/// \brief contains a websocket abstraction that can connect to TLS and non-TLS websocket endpoints
+///
+class Websocket {
+private:
+    std::shared_ptr<ChargePointConfiguration> configuration;
+    std::unique_ptr<WebsocketPlain> websocket_plain;
+    std::unique_ptr<WebsocketTLS> websocket_tls;
+    std::string uri;
+    bool tls;
+    bool shutting_down;
+
+public:
+    /// \brief Creates a new Websocket object with the providede \p configuration
+    explicit Websocket(std::shared_ptr<ChargePointConfiguration> configuration);
+
+    /// \brief connect to a websocket (TLS or non-TLS depending on the central system uri in the configuration)
+    /// \returns true if the websocket is initialized and a connection attempt is made
+    bool connect();
+
+    /// \brief disconnect the websocket
+    void disconnect();
+
+    /// \brief register a \p callback that is called when the websocket is connected successfully
+    void register_connected_callback(const std::function<void()>& callback);
+
+    /// \brief register a \p callback that is called when the websocket is disconnected
+    void register_disconnected_callback(const std::function<void()>& callback);
+
+    /// \brief register a \p callback that is called when the websocket receives a message
+    void register_message_callback(const std::function<void(const std::string& message)>& callback);
+
+    /// \brief send a \p message over the websocket
+    /// \returns true if the message was sent successfully
+    bool send(const std::string& message);
+};
+
+} // namespace ocpp1_6
+#endif // OCPP_WEBSOCKET_HPP

--- a/include/ocpp1_6/websocket/websocket.hpp
+++ b/include/ocpp1_6/websocket/websocket.hpp
@@ -17,11 +17,8 @@ namespace ocpp1_6 {
 ///
 class Websocket {
 private:
-    std::shared_ptr<ChargePointConfiguration> configuration;
-    std::unique_ptr<WebsocketPlain> websocket_plain;
-    std::unique_ptr<WebsocketTLS> websocket_tls;
+    std::unique_ptr<WebsocketBase> websocket;
     std::string uri;
-    bool tls;
     bool shutting_down;
 
 public:

--- a/include/ocpp1_6/websocket/websocket_base.hpp
+++ b/include/ocpp1_6/websocket/websocket_base.hpp
@@ -1,39 +1,40 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
-#ifndef OCPP_WEBSOCKET_HPP
-#define OCPP_WEBSOCKET_HPP
+#ifndef OCPP_WEBSOCKET_BASE_HPP
+#define OCPP_WEBSOCKET_BASE_HPP
 
-#include <thread>
-
-#include <ocpp1_6/websocket_plain.hpp>
-#include <ocpp1_6/websocket_tls.hpp>
+#include <functional>
+#include <memory>
 
 class ChargePointConfiguration;
 
 namespace ocpp1_6 {
 
 ///
-/// \brief contains a websocket abstraction that can connect to TLS and non-TLS websocket endpoints
+/// \brief contains a websocket abstraction
 ///
-class Websocket {
-private:
-    std::shared_ptr<ChargePointConfiguration> configuration;
-    std::unique_ptr<WebsocketPlain> websocket_plain;
-    std::unique_ptr<WebsocketTLS> websocket_tls;
-    std::string uri;
-    bool tls;
+class WebsocketBase {
+protected:
     bool shutting_down;
+    std::shared_ptr<ChargePointConfiguration> configuration;
+    std::function<void()> connected_callback;
+    std::function<void()> disconnected_callback;
+    std::function<void(const std::string& message)> message_callback;
+
+    /// \brief Indicates if the required callbacks are registered and the websocket is not shutting down
+    /// \returns true if the websocket is properly initialized
+    bool initialized();
 
 public:
-    /// \brief Creates a new Websocket object with the providede \p configuration
-    explicit Websocket(std::shared_ptr<ChargePointConfiguration> configuration);
+    /// \brief Creates a new WebsocketBase object with the providede \p configuration
+    explicit WebsocketBase(std::shared_ptr<ChargePointConfiguration> configuration);
 
-    /// \brief connect to a websocket (TLS or non-TLS depending on the central system uri in the configuration)
+    /// \brief connect to a websocket
     /// \returns true if the websocket is initialized and a connection attempt is made
-    bool connect();
+    virtual bool connect() = 0;
 
     /// \brief disconnect the websocket
-    void disconnect();
+    virtual void disconnect() = 0;
 
     /// \brief register a \p callback that is called when the websocket is connected successfully
     void register_connected_callback(const std::function<void()>& callback);
@@ -46,8 +47,8 @@ public:
 
     /// \brief send a \p message over the websocket
     /// \returns true if the message was sent successfully
-    bool send(const std::string& message);
+    virtual bool send(const std::string& message) = 0;
 };
 
 } // namespace ocpp1_6
-#endif // OCPP_WEBSOCKET_HPP
+#endif // OCPP_WEBSOCKET_BASE_HPP

--- a/include/ocpp1_6/websocket/websocket_base.hpp
+++ b/include/ocpp1_6/websocket/websocket_base.hpp
@@ -6,9 +6,9 @@
 #include <functional>
 #include <memory>
 
-class ChargePointConfiguration;
-
 namespace ocpp1_6 {
+
+class ChargePointConfiguration;
 
 ///
 /// \brief contains a websocket abstraction

--- a/include/ocpp1_6/websocket/websocket_plain.hpp
+++ b/include/ocpp1_6/websocket/websocket_plain.hpp
@@ -10,9 +10,9 @@
 
 #include <ocpp1_6/websocket/websocket_base.hpp>
 
-class ChargePointConfiguration;
-
 namespace ocpp1_6 {
+
+class ChargePointConfiguration;
 
 typedef websocketpp::client<websocketpp::config::asio_client> client;
 

--- a/include/ocpp1_6/websocket/websocket_plain.hpp
+++ b/include/ocpp1_6/websocket/websocket_plain.hpp
@@ -8,6 +8,8 @@
 #include <websocketpp/client.hpp>
 #include <websocketpp/config/asio_client.hpp>
 
+#include <ocpp1_6/websocket/websocket_base.hpp>
+
 class ChargePointConfiguration;
 
 namespace ocpp1_6 {
@@ -21,26 +23,17 @@ using websocketpp::lib::placeholders::_2;
 ///
 /// \brief contains a websocket abstraction that can connect to plaintext websocket endpoints (ws://)
 ///
-class WebsocketPlain {
+class WebsocketPlain : public WebsocketBase {
 private:
     websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;
-    std::shared_ptr<ChargePointConfiguration> configuration;
     client ws_client;
     std::string uri;
-    bool shutting_down;
     websocketpp::connection_hdl handle;
     websocketpp::lib::shared_ptr<websocketpp::lib::thread> ws_thread;
     std::mutex reconnect_mutex;
     long reconnect_interval_ms;
     websocketpp::transport::timer_handler reconnect_callback;
     websocketpp::lib::shared_ptr<boost::asio::steady_timer> reconnect_timer;
-    std::function<void()> connected_callback;
-    std::function<void()> disconnected_callback;
-    std::function<void(const std::string& message)> message_callback;
-
-    /// \brief Indicates if the required callbacks are registered and the websocket is not shutting down
-    /// \returns true if the websocket is properly initialized
-    bool initialized();
 
     /// \brief Reconnects the websocket using the reconnect timer, a reason for this reconnect can be provided with the
     /// \p reason parameter
@@ -70,23 +63,14 @@ public:
 
     /// \brief connect to a plaintext websocket
     /// \returns true if the websocket is initialized and a connection attempt is made
-    bool connect();
+    bool connect() override;
 
     /// \brief disconnect the websocket
-    void disconnect();
-
-    /// \brief register a \p callback that is called when the websocket is connected successfully
-    void register_connected_callback(const std::function<void()>& callback);
-
-    /// \brief register a \p callback that is called when the websocket is disconnected
-    void register_disconnected_callback(const std::function<void()>& callback);
-
-    /// \brief register a \p callback that is called when the websocket receives a message
-    void register_message_callback(const std::function<void(const std::string& message)>& callback);
+    void disconnect() override;
 
     /// \brief send a \p message over the websocket
     /// \returns true if the message was sent successfully
-    bool send(const std::string& message);
+    bool send(const std::string& message) override;
 };
 
 } // namespace ocpp1_6

--- a/include/ocpp1_6/websocket/websocket_tls.hpp
+++ b/include/ocpp1_6/websocket/websocket_tls.hpp
@@ -10,9 +10,9 @@
 
 #include <ocpp1_6/websocket/websocket_base.hpp>
 
-class ChargePointConfiguration;
-
 namespace ocpp1_6 {
+
+class ChargePointConfiguration;
 
 typedef websocketpp::client<websocketpp::config::asio_tls_client> tls_client;
 typedef websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context> tls_context;

--- a/include/ocpp1_6/websocket/websocket_tls.hpp
+++ b/include/ocpp1_6/websocket/websocket_tls.hpp
@@ -8,6 +8,8 @@
 #include <websocketpp/client.hpp>
 #include <websocketpp/config/asio_client.hpp>
 
+#include <ocpp1_6/websocket/websocket_base.hpp>
+
 class ChargePointConfiguration;
 
 namespace ocpp1_6 {
@@ -22,26 +24,17 @@ using websocketpp::lib::placeholders::_2;
 ///
 /// \brief contains a websocket abstraction that can connect to TLS and non-TLS websocket endpoints
 ///
-class WebsocketTLS {
+class WebsocketTLS : public WebsocketBase {
 private:
     websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;
-    std::shared_ptr<ChargePointConfiguration> configuration;
     tls_client wss_client;
     std::string uri;
-    bool shutting_down;
     websocketpp::connection_hdl handle;
     websocketpp::lib::shared_ptr<websocketpp::lib::thread> ws_thread;
     std::mutex reconnect_mutex;
     long reconnect_interval_ms;
     websocketpp::transport::timer_handler reconnect_callback;
     websocketpp::lib::shared_ptr<boost::asio::steady_timer> reconnect_timer;
-    std::function<void()> connected_callback;
-    std::function<void()> disconnected_callback;
-    std::function<void(const std::string& message)> message_callback;
-
-    /// \brief Indicates if the required callbacks are registered and the websocket is not shutting down
-    /// \returns true if the websocket is properly initialized
-    bool initialized();
 
     /// \brief Reconnects the websocket using the reconnect timer, a reason for this reconnect can be provided with the
     /// \p reason parameter
@@ -86,23 +79,14 @@ public:
 
     /// \brief connect to a TLS websocket
     /// \returns true if the websocket is initialized and a connection attempt is made
-    bool connect();
+    bool connect() override;
 
     /// \brief disconnect the websocket
-    void disconnect();
-
-    /// \brief register a \p callback that is called when the websocket is connected successfully
-    void register_connected_callback(const std::function<void()>& callback);
-
-    /// \brief register a \p callback that is called when the websocket is disconnected
-    void register_disconnected_callback(const std::function<void()>& callback);
-
-    /// \brief register a \p callback that is called when the websocket receives a message
-    void register_message_callback(const std::function<void(const std::string& message)>& callback);
+    void disconnect() override;
 
     /// \brief send a \p message over the websocket
     /// \returns true if the message was sent successfully
-    bool send(const std::string& message);
+    bool send(const std::string& message) override;
 };
 
 } // namespace ocpp1_6

--- a/include/ocpp1_6/websocket_plain.hpp
+++ b/include/ocpp1_6/websocket_plain.hpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef OCPP_WEBSOCKET_PLAIN_HPP
+#define OCPP_WEBSOCKET_PLAIN_HPP
+
+#include <thread>
+
+#include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_client.hpp>
+
+class ChargePointConfiguration;
+
+namespace ocpp1_6 {
+
+typedef websocketpp::client<websocketpp::config::asio_client> client;
+
+using websocketpp::lib::bind;
+using websocketpp::lib::placeholders::_1;
+using websocketpp::lib::placeholders::_2;
+
+///
+/// \brief contains a websocket abstraction that can connect to plaintext websocket endpoints (ws://)
+///
+class WebsocketPlain {
+private:
+    websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;
+    std::shared_ptr<ChargePointConfiguration> configuration;
+    client ws_client;
+    std::string uri;
+    bool shutting_down;
+    websocketpp::connection_hdl handle;
+    websocketpp::lib::shared_ptr<websocketpp::lib::thread> ws_thread;
+    std::mutex reconnect_mutex;
+    long reconnect_interval_ms;
+    websocketpp::transport::timer_handler reconnect_callback;
+    websocketpp::lib::shared_ptr<boost::asio::steady_timer> reconnect_timer;
+    std::function<void()> connected_callback;
+    std::function<void()> disconnected_callback;
+    std::function<void(const std::string& message)> message_callback;
+
+    /// \brief Indicates if the required callbacks are registered and the websocket is not shutting down
+    /// \returns true if the websocket is properly initialized
+    bool initialized();
+
+    /// \brief Reconnects the websocket using the reconnect timer, a reason for this reconnect can be provided with the
+    /// \p reason parameter
+    void reconnect(std::error_code reason);
+
+    /// \brief Connect to a plaintext websocket
+    void connect_plain();
+
+    /// \brief Called when a plaintext websocket connection is established, calls the connected callback
+    void on_open_plain(client* c, websocketpp::connection_hdl hdl);
+
+    /// \brief Called when a message is received over the plaintext websocket, calls the message callback
+    void on_message_plain(websocketpp::connection_hdl hdl, client::message_ptr msg);
+
+    /// \brief Called when a plaintext websocket connection is closed, tries to reconnect
+    void on_close_plain(client* c, websocketpp::connection_hdl hdl);
+
+    /// \brief Called when a plaintext websocket connection fails to be established, tries to reconnect
+    void on_fail_plain(client* c, websocketpp::connection_hdl hdl);
+
+    /// \brief Closes a plaintext websocket connection
+    void close_plain(websocketpp::close::status::value code, const std::string& reason);
+
+public:
+    /// \brief Creates a new WebsocketPlain object with the providede \p configuration
+    explicit WebsocketPlain(std::shared_ptr<ChargePointConfiguration> configuration);
+
+    /// \brief connect to a plaintext websocket
+    /// \returns true if the websocket is initialized and a connection attempt is made
+    bool connect();
+
+    /// \brief disconnect the websocket
+    void disconnect();
+
+    /// \brief register a \p callback that is called when the websocket is connected successfully
+    void register_connected_callback(const std::function<void()>& callback);
+
+    /// \brief register a \p callback that is called when the websocket is disconnected
+    void register_disconnected_callback(const std::function<void()>& callback);
+
+    /// \brief register a \p callback that is called when the websocket receives a message
+    void register_message_callback(const std::function<void(const std::string& message)>& callback);
+
+    /// \brief send a \p message over the websocket
+    /// \returns true if the message was sent successfully
+    bool send(const std::string& message);
+};
+
+} // namespace ocpp1_6
+#endif // OCPP_WEBSOCKET_PLAIN_HPP

--- a/include/ocpp1_6/websocket_tls.hpp
+++ b/include/ocpp1_6/websocket_tls.hpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef OCPP_WEBSOCKET_TLS_HPP
+#define OCPP_WEBSOCKET_TLS_HPP
+
+#include <thread>
+
+#include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_client.hpp>
+
+class ChargePointConfiguration;
+
+namespace ocpp1_6 {
+
+typedef websocketpp::client<websocketpp::config::asio_tls_client> tls_client;
+typedef websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context> tls_context;
+
+using websocketpp::lib::bind;
+using websocketpp::lib::placeholders::_1;
+using websocketpp::lib::placeholders::_2;
+
+///
+/// \brief contains a websocket abstraction that can connect to TLS and non-TLS websocket endpoints
+///
+class WebsocketTLS {
+private:
+    websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;
+    std::shared_ptr<ChargePointConfiguration> configuration;
+    tls_client wss_client;
+    std::string uri;
+    bool shutting_down;
+    websocketpp::connection_hdl handle;
+    websocketpp::lib::shared_ptr<websocketpp::lib::thread> ws_thread;
+    std::mutex reconnect_mutex;
+    long reconnect_interval_ms;
+    websocketpp::transport::timer_handler reconnect_callback;
+    websocketpp::lib::shared_ptr<boost::asio::steady_timer> reconnect_timer;
+    std::function<void()> connected_callback;
+    std::function<void()> disconnected_callback;
+    std::function<void(const std::string& message)> message_callback;
+
+    /// \brief Indicates if the required callbacks are registered and the websocket is not shutting down
+    /// \returns true if the websocket is properly initialized
+    bool initialized();
+
+    /// \brief Reconnects the websocket using the reconnect timer, a reason for this reconnect can be provided with the
+    /// \p reason parameter
+    void reconnect(std::error_code reason);
+
+    /// \brief Extracts the hostname from the provided \p uri
+    /// FIXME(kai): this only works with a very limited subset of hostnames and should be extended to work spec conform
+    /// \returns the extracted hostname
+    std::string get_hostname(std::string uri);
+
+    /// \brief FIXME: this should verify the certificate
+    /// FIXME(kai): implement validation!
+    /// \returns FIXME: always true at the moment because no certificate verification is performed
+    bool verify_certificate(std::string hostname, bool preverified, boost::asio::ssl::verify_context& context);
+
+    /// \brief Called when a TLS websocket connection gets initialized, manages the supported TLS versions, cipher lists
+    /// and how verification of the server certificate is handled
+    tls_context on_tls_init(std::string hostname, websocketpp::connection_hdl hdl);
+
+    /// \brief Connect to a TLS websocket, if the provided \p authorization_header is not empty use it to add a HTTP
+    /// Authorization header
+    void connect_tls(std::string authorization_header);
+
+    /// \brief Called when a TLS websocket connection is established, calls the connected callback
+    void on_open_tls(tls_client* c, websocketpp::connection_hdl hdl);
+
+    /// \brief Called when a message is received over the TLS websocket, calls the message callback
+    void on_message_tls(websocketpp::connection_hdl hdl, tls_client::message_ptr msg);
+
+    /// \brief Called when a TLS websocket connection is closed, tries to reconnect
+    void on_close_tls(tls_client* c, websocketpp::connection_hdl hdl);
+
+    /// \brief Called when a TLS websocket connection fails to be established, tries to reconnect
+    void on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl);
+
+    /// \brief Closes a TLS websocket connection
+    void close_tls(websocketpp::close::status::value code, const std::string& reason);
+
+public:
+    /// \brief Creates a new Websocket object with the providede \p configuration
+    explicit WebsocketTLS(std::shared_ptr<ChargePointConfiguration> configuration);
+
+    /// \brief connect to a TLS websocket
+    /// \returns true if the websocket is initialized and a connection attempt is made
+    bool connect();
+
+    /// \brief disconnect the websocket
+    void disconnect();
+
+    /// \brief register a \p callback that is called when the websocket is connected successfully
+    void register_connected_callback(const std::function<void()>& callback);
+
+    /// \brief register a \p callback that is called when the websocket is disconnected
+    void register_disconnected_callback(const std::function<void()>& callback);
+
+    /// \brief register a \p callback that is called when the websocket receives a message
+    void register_message_callback(const std::function<void(const std::string& message)>& callback);
+
+    /// \brief send a \p message over the websocket
+    /// \returns true if the message was sent successfully
+    bool send(const std::string& message);
+};
+
+} // namespace ocpp1_6
+#endif // OCPP_WEBSOCKET_HPP

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,8 +12,11 @@ target_sources(ocpp
         ocpp1_6/charge_point_configuration.cpp
         ocpp1_6/charge_point_state_machine.cpp
         ocpp1_6/charging_session.cpp
+        ocpp1_6/enums.cpp
         ocpp1_6/message_queue.cpp
+        ocpp1_6/ocpp_types.cpp
         ocpp1_6/schemas.cpp
+        ocpp1_6/types.cpp
         ocpp1_6/types_internal.cpp
         ocpp1_6/websocket.cpp
 )

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,12 +18,10 @@ target_sources(ocpp
         ocpp1_6/schemas.cpp
         ocpp1_6/types.cpp
         ocpp1_6/types_internal.cpp
-        ocpp1_6/websocket.cpp
-        ocpp1_6/websocket_plain.cpp
-        ocpp1_6/websocket_tls.cpp
 )
 
 add_subdirectory(ocpp1_6/messages)
+add_subdirectory(ocpp1_6/websocket)
 
 target_include_directories(ocpp PUBLIC ${INCLUDE_DIR} ${websocketpp_SOURCE_DIR})
 target_link_libraries(ocpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -20,6 +20,9 @@ target_sources(ocpp
         ocpp1_6/types_internal.cpp
         ocpp1_6/websocket.cpp
 )
+
+add_subdirectory(ocpp1_6/messages)
+
 target_include_directories(ocpp PUBLIC ${INCLUDE_DIR} ${websocketpp_SOURCE_DIR})
 target_link_libraries(ocpp
     PRIVATE

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -19,6 +19,8 @@ target_sources(ocpp
         ocpp1_6/types.cpp
         ocpp1_6/types_internal.cpp
         ocpp1_6/websocket.cpp
+        ocpp1_6/websocket_plain.cpp
+        ocpp1_6/websocket_tls.cpp
 )
 
 add_subdirectory(ocpp1_6/messages)

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -718,7 +718,7 @@ void ChargePoint::handleDataTransferRequest(Call<DataTransferRequest> call) {
     DataTransferResponse response;
 
     auto vendorId = call.msg.vendorId.get();
-    auto messageId = call.msg.messageId.get_value_or(std::string("")).get();
+    auto messageId = call.msg.messageId.get_value_or(CiString50Type()).get();
     std::function<void(const std::string data)> callback;
     {
         std::lock_guard<std::mutex> lock(data_transfer_callbacks_mutex);
@@ -1068,7 +1068,7 @@ void ChargePoint::handleGetCompositeScheduleRequest(Call<GetCompositeScheduleReq
                 }
                 if (profile.second.validTo) {
                     // check if this profile is even valid
-                    if (start_time > profile.second.validTo.value()) {
+                    if (start_time > profile.second.validTo.value().to_time_point()) {
                         // profile only valid before the requested dura>tion
                         continue;
                     } else {

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -475,8 +475,8 @@ void ChargePoint::message_callback(const std::string& message) {
             if (enhanced_message.messageType == MessageType::BootNotificationResponse) {
                 this->handleBootNotificationResponse(json_message);
             }
-            break;
         }
+        break;
     }
     case ChargePointConnectionState::Booted: {
         // lots of messages are allowed here

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1457,6 +1457,9 @@ bool ChargePoint::start_transaction(int32_t connector) {
 
     // FIXME(kai): new fsm
     // this->status_notification(connector, ChargePointErrorCode::NoError, this->status[connector]->suspended_ev());
+    if (this->resume_charging_callback != nullptr) {
+        this->resume_charging_callback(connector);
+    }
 
     return true;
 }

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -571,7 +571,7 @@ void ChargePoint::handleBootNotificationResponse(CallResult<BootNotificationResp
         this->configuration->setHeartbeatInterval(call_result.msg.interval);
     }
     switch (call_result.msg.status) {
-    case RegistrationStatus::Accepted:{
+    case RegistrationStatus::Accepted: {
         this->connection_state = ChargePointConnectionState::Booted;
         // we are allowed to send messages to the central system
         // activate heartbeat
@@ -590,10 +590,9 @@ void ChargePoint::handleBootNotificationResponse(CallResult<BootNotificationResp
         // }
         auto connector_availability = this->configuration->getConnectorAvailability();
         connector_availability[0] =
-        AvailabilityType::Operative; // FIXME(kai): fix internal representation in charge point states, we need a
-                                     // different kind of state machine for connector 0 anyway (with reduced states)
+            AvailabilityType::Operative; // FIXME(kai): fix internal representation in charge point states, we need a
+                                         // different kind of state machine for connector 0 anyway (with reduced states)
         this->status->run(connector_availability);
-
 
         break;
     }
@@ -929,7 +928,8 @@ void ChargePoint::handleSetChargingProfileRequest(Call<SetChargingProfileRequest
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatus::Rejected;
     auto number_of_connectors = this->configuration->getNumberOfConnectors();
-    if (call.msg.connectorId > number_of_connectors || call.msg.connectorId < 0 || call.msg.csChargingProfiles.stackLevel < 0 ||
+    if (call.msg.connectorId > number_of_connectors || call.msg.connectorId < 0 ||
+        call.msg.csChargingProfiles.stackLevel < 0 ||
         call.msg.csChargingProfiles.stackLevel > this->configuration->getChargeProfileMaxStackLevel()) {
         response.status = ChargingProfileStatus::Rejected;
     } else {

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1332,7 +1332,7 @@ AuthorizationStatus ChargePoint::authorize_id_tag(CiString20Type idTag) {
 }
 
 DataTransferResponse ChargePoint::data_transfer(const CiString255Type& vendorId, const CiString50Type& messageId,
-                                                const std::string data) {
+                                                const std::string& data) {
     DataTransferRequest req;
     req.vendorId = vendorId;
     req.messageId = messageId;

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -863,6 +863,7 @@ void ChargePoint::handleResetRequest(Call<ResetRequest> call) {
         // TODO(kai): implement hard reset, if possible send StopTransaction for any running
         // transactions This type of reset should restart all hardware!
         this->reset_thread = std::thread([this]() {
+            this->stop_all_transactions(Reason::SoftReset);
             kill(getpid(), SIGINT); // FIXME(kai): this leads to a somewhat dirty reset
         });
     }
@@ -870,6 +871,7 @@ void ChargePoint::handleResetRequest(Call<ResetRequest> call) {
         // TODO(kai): gracefully stop all transactions and send StopTransaction. Restart software
         // afterwards
         this->reset_thread = std::thread([this]() {
+            this->stop_all_transactions(Reason::SoftReset);
             kill(getpid(), SIGINT); // FIXME(kai): this leads to a somewhat dirty reset
         });
     }

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -646,13 +646,13 @@ void ChargePoint::handleChangeAvailabilityRequest(Call<ChangeAvailabilityRequest
                         this->enable_evse_callback(connector);
                     }
 
-                    this->status->submit_event(connector, Event_H1_ConnectorSetAvailableByChangeAvailability());
+                    this->status->submit_event(connector, Event_BecomeAvailable());
                 } else {
                     if (this->disable_evse_callback != nullptr) {
                         // TODO(kai): check return value
                         this->disable_evse_callback(connector);
                     }
-                    this->status->submit_event(connector, Event_A8_ChangeAvailabilityToUnavailable());
+                    this->status->submit_event(connector, Event_ChangeAvailabilityToUnavailable());
                 }
             }
         }
@@ -1588,35 +1588,23 @@ bool ChargePoint::stop_session(int32_t connector, DateTime timestamp, double ene
 }
 
 bool ChargePoint::start_charging(int32_t connector) {
-    // FIXME(kai): libfsm
-    // if (this->status[connector]->get_current_state() == ChargePointStatus::SuspendedEV) {
-    //     if (this->status[connector]->resume_ev() == ChargePointStatus::Charging) {
-    //         return true;
-    //     }
-    // }
-    return false;
+    this->status->submit_event(connector, Event_StartCharging());
+    return true;
 }
 
 bool ChargePoint::suspend_charging_ev(int32_t connector) {
-    // FIXME(kai): libfsm
-    // if (this->status[connector]->suspended_ev() == ChargePointStatus::SuspendedEV) {
-    //     return true;
-    // }
-    return false;
+    this->status->submit_event(connector, Event_PauseChargingEV());
+    return true;
 }
 
 bool ChargePoint::suspend_charging_evse(int32_t connector) {
-    // FIXME(kai): libfsm
-    // if (this->status[connector]->suspended_evse() == ChargePointStatus::SuspendedEVSE) {
-    //     return true;
-    // }
-    return false;
+    this->status->submit_event(connector, Event_PauseChargingEVSE());
+    return true;
 }
 
 bool ChargePoint::resume_charging(int32_t connector) {
-    // FIXME(kai): implement
-    // FIXME(kai): libfsm
-    return false;
+    this->status->submit_event(connector, Event_StartCharging());
+    return true;
 }
 
 bool ChargePoint::error(int32_t connector, ChargePointErrorCode error_code) {

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1684,6 +1684,11 @@ bool ChargePoint::resume_charging(int32_t connector) {
     return true;
 }
 
+bool ChargePoint::plug_disconnected(int32_t connector) {
+    this->status->submit_event(connector, Event_BecomeAvailable());
+    return true;
+}
+
 bool ChargePoint::error(int32_t connector, ChargePointErrorCode error_code) {
     // FIXME(kai): implement
     // FIXME(kai): libfsm

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1254,10 +1254,19 @@ void ChargePoint::handleTriggerMessageRequest(Call<TriggerMessageRequest> call) 
         break;
     }
 
+    auto connector = call.msg.connectorId.value_or(0);
+    bool valid = true;
+    if (connector < 0 || connector > this->configuration->getNumberOfConnectors()) {
+        response.status = TriggerMessageStatus::Rejected;
+        valid = false;
+    }
+
     CallResult<TriggerMessageResponse> call_result(response, call.uniqueId);
     this->send<TriggerMessageResponse>(call_result);
 
-    auto connector = call.msg.connectorId.value_or(0);
+    if (!valid) {
+        return;
+    }
 
     switch (call.msg.requestedMessage) {
     case MessageTrigger::BootNotification:

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -8,7 +8,6 @@
 #include <ocpp1_6/charge_point.hpp>
 #include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/schemas.hpp>
-#include <ocpp1_6/websocket.hpp>
 
 namespace ocpp1_6 {
 

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1662,4 +1662,7 @@ void ChargePoint::register_unlock_connector_callback(const std::function<bool(in
     this->unlock_connector_callback = callback;
 }
 
+void ChargePoint::register_set_max_current_callback(const std::function<void(int32_t connector, double max_current)>& callback) {
+    this->set_max_current_callback = callback;
+}
 } // namespace ocpp1_6

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1527,8 +1527,10 @@ bool ChargePoint::stop_transaction(int32_t connector, Reason reason) {
         }
     }
 
-    // TODO(kai): unlock connector!
-    // this->unlock_connector(connector);
+    // unlock connector
+    if (this->unlock_connector_callback != nullptr) {
+        this->unlock_connector_callback(connector);
+    }
 
     // perform a queued connector availability change
     bool change_queued = false;

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -850,6 +850,7 @@ void ChargePoint::handleRemoteStopTransactionRequest(Call<RemoteStopTransactionR
     this->send<RemoteStopTransactionResponse>(call_result);
 
     if (connector > 0) {
+        this->cancel_charging_callback(connector);
         this->charging_sessions->add_stop_energy_wh(
             connector, std::make_shared<StampedEnergyWh>(DateTime(), this->get_meter_wh(connector)));
         {

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1660,6 +1660,7 @@ bool ChargePoint::stop_session(int32_t connector, DateTime timestamp, double ene
     }
     this->charging_sessions->remove_session(connector);
 
+    this->status->submit_event(connector, Event_TransactionStoppedAndUserActionRequired());
     return true; // FIXME
 }
 

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -2,7 +2,6 @@
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include <thread>
 
-#include <boost/bind/bind.hpp>
 #include <date/date.h>
 #include <everest/logging.hpp>
 

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1520,6 +1520,7 @@ bool ChargePoint::start_transaction(int32_t connector) {
         auto meter_value = this->get_latest_meter_value(
             connector, this->configuration->getMeterValuesSampledDataVector(), ReadingContext::Sample_Periodic);
         this->charging_sessions->add_sampled_meter_value(connector, meter_value);
+        this->send_meter_value(connector, meter_value);
     });
     auto transaction =
         std::make_unique<Transaction>(start_transaction_response.transactionId, std::move(meter_values_sample_timer));

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -87,7 +87,7 @@ void ChargePoint::boot_notification() {
 void ChargePoint::clock_aligned_meter_values_sample() {
     if (this->initialized) {
         EVLOG(debug) << "Sending clock aligned meter values";
-        for (size_t connector = 1; connector < this->configuration->getNumberOfConnectors() + 1; connector++) {
+        for (int32_t connector = 1; connector < this->configuration->getNumberOfConnectors() + 1; connector++) {
             auto meter_value = this->get_latest_meter_value(
                 connector, this->configuration->getMeterValuesAlignedDataVector(), ReadingContext::Sample_Clock);
             this->charging_sessions->add_clock_aligned_meter_value(connector, meter_value);
@@ -927,6 +927,7 @@ void ChargePoint::handleSetChargingProfileRequest(Call<SetChargingProfileRequest
     EVLOG(debug) << "Received SetChargingProfileRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
 
     SetChargingProfileResponse response;
+    response.status = ChargingProfileStatus::Rejected;
     auto number_of_connectors = this->configuration->getNumberOfConnectors();
     if (call.msg.connectorId > number_of_connectors || call.msg.connectorId < 0 || call.msg.csChargingProfiles.stackLevel < 0 ||
         call.msg.csChargingProfiles.stackLevel > this->configuration->getChargeProfileMaxStackLevel()) {

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -642,8 +642,17 @@ void ChargePoint::handleChangeAvailabilityRequest(Call<ChangeAvailabilityRequest
                 this->configuration->setConnectorAvailability(connector, call.msg.type);
             if (availability_change_succeeded) {
                 if (call.msg.type == AvailabilityType::Operative) {
+                    if (this->enable_evse_callback != nullptr) {
+                        // TODO(kai): check return value
+                        this->enable_evse_callback(connector);
+                    }
+
                     this->status->submit_event(connector, Event_H1_ConnectorSetAvailableByChangeAvailability());
                 } else {
+                    if (this->disable_evse_callback != nullptr) {
+                        // TODO(kai): check return value
+                        this->disable_evse_callback(connector);
+                    }
                     this->status->submit_event(connector, Event_A8_ChangeAvailabilityToUnavailable());
                 }
             }
@@ -1542,8 +1551,16 @@ bool ChargePoint::stop_transaction(int32_t connector, Reason reason) {
             EVLOG(info) << oss.str();
 
             if (connector_availability == AvailabilityType::Operative) {
+                if (this->enable_evse_callback != nullptr) {
+                    // TODO(kai): check return value
+                    this->enable_evse_callback(connector);
+                }
                 this->status_notification(connector, ChargePointErrorCode::NoError, ChargePointStatus::Available);
             } else {
+                if (this->disable_evse_callback != nullptr) {
+                    // TODO(kai): check return value
+                    this->disable_evse_callback(connector);
+                }
                 this->status_notification(connector, ChargePointErrorCode::NoError, ChargePointStatus::Unavailable);
             }
         } else {

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -6,9 +6,10 @@
 #include <date/date.h>
 #include <everest/logging.hpp>
 
-#include <ocpp1_6/schemas.hpp>
-
 #include <ocpp1_6/charge_point.hpp>
+#include <ocpp1_6/charge_point_configuration.hpp>
+#include <ocpp1_6/schemas.hpp>
+#include <ocpp1_6/websocket.hpp>
 
 namespace ocpp1_6 {
 

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1626,16 +1626,24 @@ bool ChargePoint::permanent_fault(int32_t connector) {
     return false;
 }
 
+void ChargePoint::register_enable_evse_callback(const std::function<bool(int32_t connector)>& callback) {
+    this->enable_evse_callback = callback;
+}
+
+void ChargePoint::register_disable_evse_callback(const std::function<bool(int32_t connector)>& callback) {
+    this->disable_evse_callback = callback;
+}
+
 void ChargePoint::register_pause_charging_callback(const std::function<bool(int32_t connector)>& callback) {
-    // FIXME(kai): implement
+    this->pause_charging_callback = callback;
 }
 
 void ChargePoint::register_resume_charging_callback(const std::function<bool(int32_t connector)>& callback) {
-    // FIXME(kai): implement
+    this->resume_charging_callback = callback;
 }
 
 void ChargePoint::register_cancel_charging_callback(const std::function<bool(int32_t connector)>& callback) {
-    // FIXME(kai): implement
+    this->cancel_charging_callback = callback;
 }
 
 void ChargePoint::register_reserve_now_callback(
@@ -1652,7 +1660,7 @@ void ChargePoint::register_unlock_connector_callback(const std::function<bool(in
 }
 
 void ChargePoint::register_set_max_current_callback(
-    const std::function<void(int32_t connector, double max_current)>& callback) {
+    const std::function<bool(int32_t connector, double max_current)>& callback) {
     this->set_max_current_callback = callback;
 }
 } // namespace ocpp1_6

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -1309,6 +1309,7 @@ KeyValue ChargePointConfiguration::getMaxChargingProfilesInstalledKeyValue() {
 }
 
 boost::optional<KeyValue> ChargePointConfiguration::get(CiString50Type key) {
+    // Core Profile
     if (key == "AllowOfflineTxForUnknownId") {
         return this->getAllowOfflineTxForUnknownIdKeyValue();
     }
@@ -1411,20 +1412,25 @@ boost::optional<KeyValue> ChargePointConfiguration::get(CiString50Type key) {
     if (key == "WebsocketPingInterval") {
         return this->getWebsocketPingIntervalKeyValue();
     }
-    if (key == "ChargeProfileMaxStackLevel") {
-        return this->getChargeProfileMaxStackLevelKeyValue();
-    }
-    if (key == "ChargingScheduleAllowedChargingRateUnit") {
-        return this->getChargingScheduleAllowedChargingRateUnitKeyValue();
-    }
-    if (key == "ChargingScheduleMaxPeriods") {
-        return this->getChargingScheduleMaxPeriodsKeyValue();
-    }
-    if (key == "ConnectorSwitch3to1PhaseSupported") {
-        return this->getConnectorSwitch3to1PhaseSupportedKeyValue();
-    }
-    if (key == "MaxChargingProfilesInstalled") {
-        return this->getMaxChargingProfilesInstalledKeyValue();
+
+    // Smart Charging
+    if (this->supported_feature_profiles.count(SupportedFeatureProfiles::SmartCharging))
+    {
+        if (key == "ChargeProfileMaxStackLevel") {
+            return this->getChargeProfileMaxStackLevelKeyValue();
+        }
+        if (key == "ChargingScheduleAllowedChargingRateUnit") {
+            return this->getChargingScheduleAllowedChargingRateUnitKeyValue();
+        }
+        if (key == "ChargingScheduleMaxPeriods") {
+            return this->getChargingScheduleMaxPeriodsKeyValue();
+        }
+        if (key == "ConnectorSwitch3to1PhaseSupported") {
+            return this->getConnectorSwitch3to1PhaseSupportedKeyValue();
+        }
+        if (key == "MaxChargingProfilesInstalled") {
+            return this->getMaxChargingProfilesInstalledKeyValue();
+        }
     }
 
     return boost::none;

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <future>
+#include <mutex>
+
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/schemas.hpp>

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -1249,6 +1249,20 @@ KeyValue ChargePointConfiguration::getChargingScheduleAllowedChargingRateUnitKey
     kv.value.emplace(this->getChargingScheduleAllowedChargingRateUnit());
     return kv;
 }
+std::vector<ChargingRateUnit> ChargePointConfiguration::getChargingScheduleAllowedChargingRateUnitVector() {
+    std::vector<std::string> components;
+    auto csv = this->getChargingScheduleAllowedChargingRateUnit();
+    boost::split(components, csv, boost::is_any_of(","));
+    std::vector<ChargingRateUnit> charging_rate_unit_vector;
+    for (auto component : components) {
+        if (component == "Current") {
+            charging_rate_unit_vector.push_back(ChargingRateUnit::A);
+        } else if (component == "Power") {
+            charging_rate_unit_vector.push_back(ChargingRateUnit::W);
+        }
+    }
+    return charging_rate_unit_vector;
+}
 
 int32_t ChargePointConfiguration::getChargingScheduleMaxPeriods() {
     return this->config["SmartCharging"]["ChargingScheduleMaxPeriods"];
@@ -1261,15 +1275,26 @@ KeyValue ChargePointConfiguration::getChargingScheduleMaxPeriodsKeyValue() {
     return kv;
 }
 
-bool ChargePointConfiguration::getConnectorSwitch3to1PhaseSupported() {
-    return this->config["SmartCharging"]["ConnectorSwitch3to1PhaseSupported"];
+boost::optional<bool> ChargePointConfiguration::getConnectorSwitch3to1PhaseSupported() {
+    boost::optional<bool> connector_switch_3_to_1_phase_supported = boost::none;
+    if (this->config["SmartCharging"].contains("ConnectorSwitch3to1PhaseSupported")) {
+        connector_switch_3_to_1_phase_supported.emplace(
+            this->config["SmartCharging"]["ConnectorSwitch3to1PhaseSupported"]);
+    }
+    return connector_switch_3_to_1_phase_supported;
 }
-KeyValue ChargePointConfiguration::getConnectorSwitch3to1PhaseSupportedKeyValue() {
-    ocpp1_6::KeyValue kv;
-    kv.key = "ConnectorSwitch3to1PhaseSupported";
-    kv.readonly = true;
-    kv.value.emplace(conversions::bool_to_string(this->getConnectorSwitch3to1PhaseSupported()));
-    return kv;
+boost::optional<KeyValue> ChargePointConfiguration::getConnectorSwitch3to1PhaseSupportedKeyValue() {
+    boost::optional<KeyValue> connector_switch_3_to_1_phase_supported_kv = boost::none;
+
+    auto connector_switch_3_to_1_phase_supported = this->getConnectorSwitch3to1PhaseSupported();
+    if (connector_switch_3_to_1_phase_supported != boost::none) {
+        ocpp1_6::KeyValue kv;
+        kv.key = "ConnectorSwitch3to1PhaseSupported";
+        kv.readonly = true;
+        kv.value.emplace(conversions::bool_to_string(connector_switch_3_to_1_phase_supported.value()));
+        connector_switch_3_to_1_phase_supported_kv.emplace(kv);
+    }
+    return connector_switch_3_to_1_phase_supported_kv;
 }
 
 int32_t ChargePointConfiguration::getMaxChargingProfilesInstalled() {
@@ -1386,21 +1411,21 @@ boost::optional<KeyValue> ChargePointConfiguration::get(CiString50Type key) {
     if (key == "WebsocketPingInterval") {
         return this->getWebsocketPingIntervalKeyValue();
     }
-    // if (key == "ChargeProfileMaxStackLevel") {
-    //     return this->getChargeProfileMaxStackLevelKeyValue();
-    // }
-    // if (key == "ChargingScheduleAllowedChargingRateUnit") {
-    //     return this->getChargingScheduleAllowedChargingRateUnitKeyValue();
-    // }
-    // if (key == "ChargingScheduleMaxPeriods") {
-    //     return this->getChargingScheduleMaxPeriodsKeyValue();
-    // }
-    // if (key == "ConnectorSwitch3to1PhaseSupported") {
-    //     return this->getConnectorSwitch3to1PhaseSupportedKeyValue();
-    // }
-    // if (key == "MaxChargingProfilesInstalled") {
-    //     return this->getMaxChargingProfilesInstalledKeyValue();
-    // }
+    if (key == "ChargeProfileMaxStackLevel") {
+        return this->getChargeProfileMaxStackLevelKeyValue();
+    }
+    if (key == "ChargingScheduleAllowedChargingRateUnit") {
+        return this->getChargingScheduleAllowedChargingRateUnitKeyValue();
+    }
+    if (key == "ChargingScheduleMaxPeriods") {
+        return this->getChargingScheduleMaxPeriodsKeyValue();
+    }
+    if (key == "ConnectorSwitch3to1PhaseSupported") {
+        return this->getConnectorSwitch3to1PhaseSupportedKeyValue();
+    }
+    if (key == "MaxChargingProfilesInstalled") {
+        return this->getMaxChargingProfilesInstalledKeyValue();
+    }
 
     return boost::none;
 }

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -314,7 +314,6 @@ std::vector<MeasurandWithPhase> ChargePointConfiguration::csv_to_measurand_with_
     for (auto m : measurand_with_phase_vector) {
         if (!m.phase) {
             EVLOG(debug) << "measurand without phase: " << m.measurand;
-
         } else {
             EVLOG(debug) << "measurand: " << m.measurand
                          << " with phase: " << ocpp1_6::conversions::phase_to_string(m.phase.value());
@@ -327,7 +326,6 @@ bool ChargePointConfiguration::measurands_supported(std::string csv) {
     auto requested_measurands = this->csv_to_measurand_with_phase_vector(csv);
     // check if the requested measurands are supported, otherwise return false
     for (auto req : requested_measurands) {
-        EVLOG(error) << "requested_measurand: " << conversions::measurand_to_string(req.measurand);
         if (this->supported_measurands.count(req.measurand) == 0) {
             return false;
         }
@@ -335,7 +333,6 @@ bool ChargePointConfiguration::measurands_supported(std::string csv) {
         if (req.phase) {
             auto phase = req.phase.value();
             auto measurand = this->supported_measurands[req.measurand];
-            EVLOG(error) << "  there was specific phase requested...: " << conversions::phase_to_string(phase);
 
             if (std::find(measurand.begin(), measurand.end(), phase) == measurand.end()) {
                 // phase not found, this is an error
@@ -545,7 +542,7 @@ boost::optional<IdTagInfo> ChargePointConfiguration::getAuthorizationCacheEntry(
 
     IdTagInfo idTagInfo;
     std::string auth_status_str = std::string(reinterpret_cast<const char*>(sqlite3_column_text(select_statement, 1)));
-    EVLOG(error) << "auth_status_str: " << auth_status_str;
+
     idTagInfo.status = conversions::string_to_authorization_status(auth_status_str);
     auto expiry_date_ptr = sqlite3_column_text(select_statement, 2);
     if (expiry_date_ptr != nullptr) {

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -201,52 +201,52 @@ std::string ChargePointConfiguration::getChargePointId() {
 std::string ChargePointConfiguration::getCentralSystemURI() {
     return this->config["Internal"]["CentralSystemURI"];
 }
-boost::optional<std::string> ChargePointConfiguration::getChargeBoxSerialNumber() {
-    boost::optional<std::string> charge_box_serial_number = boost::none;
+boost::optional<CiString25Type> ChargePointConfiguration::getChargeBoxSerialNumber() {
+    boost::optional<CiString25Type> charge_box_serial_number = boost::none;
     if (this->config["Internal"].contains("ChargeBoxSerialNumber")) {
         charge_box_serial_number.emplace(this->config["Internal"]["ChargeBoxSerialNumber"]);
     }
     return charge_box_serial_number;
 }
-std::string ChargePointConfiguration::getChargePointModel() {
-    return this->config["Internal"]["ChargePointModel"];
+CiString20Type ChargePointConfiguration::getChargePointModel() {
+    return CiString20Type(this->config["Internal"]["ChargePointModel"]);
 }
-boost::optional<std::string> ChargePointConfiguration::getChargePointSerialNumber() {
-    boost::optional<std::string> charge_point_serial_number = boost::none;
+boost::optional<CiString25Type> ChargePointConfiguration::getChargePointSerialNumber() {
+    boost::optional<CiString25Type> charge_point_serial_number = boost::none;
     if (this->config["Internal"].contains("ChargePointSerialNumber")) {
         charge_point_serial_number.emplace(this->config["Internal"]["ChargePointSerialNumber"]);
     }
     return charge_point_serial_number;
 }
-std::string ChargePointConfiguration::getChargePointVendor() {
-    return this->config["Internal"]["ChargePointVendor"];
+CiString20Type ChargePointConfiguration::getChargePointVendor() {
+    return CiString20Type(this->config["Internal"]["ChargePointVendor"]);
 }
-std::string ChargePointConfiguration::getFirmwareVersion() {
-    return this->config["Internal"]["FirmwareVersion"];
+CiString50Type ChargePointConfiguration::getFirmwareVersion() {
+    return CiString50Type(this->config["Internal"]["FirmwareVersion"]);
 }
-boost::optional<std::string> ChargePointConfiguration::getICCID() {
-    boost::optional<std::string> iccid = boost::none;
+boost::optional<CiString20Type> ChargePointConfiguration::getICCID() {
+    boost::optional<CiString20Type> iccid = boost::none;
     if (this->config["Internal"].contains("ICCID")) {
         iccid.emplace(this->config["Internal"]["ICCID"]);
     }
     return iccid;
 }
-boost::optional<std::string> ChargePointConfiguration::getIMSI() {
-    boost::optional<std::string> imsi = boost::none;
+boost::optional<CiString20Type> ChargePointConfiguration::getIMSI() {
+    boost::optional<CiString20Type> imsi = boost::none;
     if (this->config["Internal"].contains("IMSI")) {
         imsi.emplace(this->config["Internal"]["IMSI"]);
     }
     return imsi;
 }
-boost::optional<std::string> ChargePointConfiguration::getMeterSerialNumber() {
-    boost::optional<std::string> meter_serial_number = boost::none;
+boost::optional<CiString25Type> ChargePointConfiguration::getMeterSerialNumber() {
+    boost::optional<CiString25Type> meter_serial_number = boost::none;
     if (this->config["Internal"].contains("MeterSerialNumber")) {
         meter_serial_number.emplace(this->config["Internal"]["MeterSerialNumber"]);
     }
     return meter_serial_number;
 }
-boost::optional<std::string> ChargePointConfiguration::getMeterType() {
-    boost::optional<std::string> meter_type = boost::none;
+boost::optional<CiString25Type> ChargePointConfiguration::getMeterType() {
+    boost::optional<CiString25Type> meter_type = boost::none;
     if (this->config["Internal"].contains("MeterType")) {
         meter_type.emplace(this->config["Internal"]["MeterType"]);
     }

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -1419,8 +1419,7 @@ boost::optional<KeyValue> ChargePointConfiguration::get(CiString50Type key) {
     }
 
     // Smart Charging
-    if (this->supported_feature_profiles.count(SupportedFeatureProfiles::SmartCharging))
-    {
+    if (this->supported_feature_profiles.count(SupportedFeatureProfiles::SmartCharging)) {
         if (key == "ChargeProfileMaxStackLevel") {
             return this->getChargeProfileMaxStackLevelKeyValue();
         }

--- a/lib/ocpp1_6/charge_point_state_machine.cpp
+++ b/lib/ocpp1_6/charge_point_state_machine.cpp
@@ -212,7 +212,7 @@ ChargePointStates::ChargePointStates(
     const std::function<void(int32_t connector, ChargePointErrorCode errorCode, ChargePointStatus status)>&
         status_notification_callback) :
     status_notification_callback(status_notification_callback) {
-    for (size_t connector = 0; connector < number_of_connectors + 1; connector++) {
+    for (int32_t connector = 0; connector < number_of_connectors + 1; connector++) {
         // TODO special state machine for connector 0
         auto state_machine = std::make_shared<ChargePointStateMachine>([this, connector](ChargePointStatus status) {
             this->status_notification_callback(connector, ChargePointErrorCode::NoError, status);
@@ -240,7 +240,7 @@ void ChargePointStates::run(std::map<int32_t, ocpp1_6::AvailabilityType> connect
 }
 
 void ChargePointStates::submit_event(int32_t connector, EventBaseType event) {
-    if (connector > 0 && connector < this->state_machines.size()) {
+    if (connector > 0 && connector < static_cast<int>(this->state_machines.size())) {
         this->state_machines.at(connector)->controller->submit_event(event);
     }
 }

--- a/lib/ocpp1_6/charge_point_state_machine.cpp
+++ b/lib/ocpp1_6/charge_point_state_machine.cpp
@@ -240,7 +240,7 @@ void ChargePointStates::run(std::map<int32_t, ocpp1_6::AvailabilityType> connect
 }
 
 void ChargePointStates::submit_event(int32_t connector, EventBaseType event) {
-    if (connector > 0 && connector < static_cast<int>(this->state_machines.size())) {
+    if (connector > 0 && connector < static_cast<int32_t>(this->state_machines.size())) {
         this->state_machines.at(connector)->controller->submit_event(event);
     }
 }

--- a/lib/ocpp1_6/charge_point_state_machine.cpp
+++ b/lib/ocpp1_6/charge_point_state_machine.cpp
@@ -27,6 +27,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_available.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::Available;
         this->status_notification_callback(ChargePointStatus::Available);
     };
 
@@ -49,6 +50,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_preparing.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::Preparing;
         this->status_notification_callback(ChargePointStatus::Preparing);
     };
 
@@ -71,6 +73,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_charging.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::Charging;
         this->status_notification_callback(ChargePointStatus::Charging);
     };
 
@@ -93,6 +96,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_suspended_ev.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::SuspendedEV;
         this->status_notification_callback(ChargePointStatus::SuspendedEV);
     };
 
@@ -115,6 +119,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_suspended_evse.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::SuspendedEVSE;
         this->status_notification_callback(ChargePointStatus::SuspendedEVSE);
     };
 
@@ -133,6 +138,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_finishing.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::Finishing;
         this->status_notification_callback(ChargePointStatus::Finishing);
     };
 
@@ -151,6 +157,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_reserved.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::Reserved;
         this->status_notification_callback(ChargePointStatus::Reserved);
     };
 
@@ -173,6 +180,7 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_unavailable.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::Unavailable;
         this->status_notification_callback(ChargePointStatus::Unavailable);
     };
 
@@ -199,8 +207,13 @@ ChargePointStateMachine::ChargePointStateMachine(
         }
     };
     this->sd_faulted.state_fun = [this](FSMContextType& ctx) {
+        this->state = ChargePointStatus::Faulted;
         this->status_notification_callback(ChargePointStatus::Faulted);
     };
+}
+
+ChargePointStatus ChargePointStateMachine::get_state() {
+    return this->state;
 }
 
 ChargePointStates::ChargePointStates(
@@ -239,6 +252,15 @@ void ChargePointStates::submit_event(int32_t connector, EventBaseType event) {
     if (connector > 0 && connector < static_cast<int32_t>(this->state_machines.size())) {
         this->state_machines.at(connector)->controller->submit_event(event);
     }
+}
+
+ChargePointStatus ChargePointStates::get_state(int32_t connector) {
+    if (connector > 0 && connector < static_cast<int32_t>(this->state_machines.size())) {
+        return this->state_machines.at(connector)->state_machine->get_state();
+    }else if (connector == 0) {
+        return ChargePointStatus::Available;
+    }
+    return ChargePointStatus::Unavailable;
 }
 
 } // namespace ocpp1_6

--- a/lib/ocpp1_6/charge_point_state_machine.cpp
+++ b/lib/ocpp1_6/charge_point_state_machine.cpp
@@ -8,19 +8,19 @@ ChargePointStateMachine::ChargePointStateMachine(
     status_notification_callback(status_notification_callback) {
     this->sd_available.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::A2_UsageInitiated:
+        case ChargePointStatusTransition::UsageInitiated:
             return trans.set(this->sd_preparing);
-        case ChargePointStatusTransition::A3_UsageInitiatedWithoutAuthorization:
+        case ChargePointStatusTransition::StartCharging:
             return trans.set(this->sd_charging);
-        case ChargePointStatusTransition::A4_UsageInitiatedEVDoesNotStartCharging:
+        case ChargePointStatusTransition::PauseChargingEV:
             return trans.set(this->sd_suspended_ev);
-        case ChargePointStatusTransition::A5_UsageInitiatedEVSEDoesNotAllowCharging:
+        case ChargePointStatusTransition::PauseChargingEVSE:
             return trans.set(this->sd_suspended_evse);
-        case ChargePointStatusTransition::A7_ReserveNowReservesConnector:
+        case ChargePointStatusTransition::ReserveConnector:
             return trans.set(this->sd_reserved);
-        case ChargePointStatusTransition::A8_ChangeAvailabilityToUnavailable:
+        case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
-        case ChargePointStatusTransition::A9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;
@@ -32,17 +32,17 @@ ChargePointStateMachine::ChargePointStateMachine(
 
     this->sd_preparing.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::B1_IntendedUsageIsEnded:
+        case ChargePointStatusTransition::BecomeAvailable:
             return trans.set(this->sd_available);
-        case ChargePointStatusTransition::B3_PrerequisitesForChargingMetAndChargingStarts:
+        case ChargePointStatusTransition::StartCharging:
             return trans.set(this->sd_charging);
-        case ChargePointStatusTransition::B4_PrerequisitesForChargingMetEVDoesNotStartCharging:
+        case ChargePointStatusTransition::PauseChargingEV:
             return trans.set(this->sd_suspended_ev);
-        case ChargePointStatusTransition::B5_PrerequisitesForChargingMetEVSEDoesNotAllowCharging:
+        case ChargePointStatusTransition::PauseChargingEVSE:
             return trans.set(this->sd_suspended_evse);
-        case ChargePointStatusTransition::B6_TimedOut:
+        case ChargePointStatusTransition::TransactionStoppedAndUserActionRequired:
             return trans.set(this->sd_finishing);
-        case ChargePointStatusTransition::B9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;
@@ -54,18 +54,17 @@ ChargePointStateMachine::ChargePointStateMachine(
 
     this->sd_charging.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::C1_ChargingSessionEndsNoUserActionRequired:
+        case ChargePointStatusTransition::BecomeAvailable:
             return trans.set(this->sd_available);
-        case ChargePointStatusTransition::C4_ChargingStopsUponEVRequest:
+        case ChargePointStatusTransition::PauseChargingEV:
             return trans.set(this->sd_suspended_ev);
-        case ChargePointStatusTransition::C5_ChargingStopsUponEVSERequest:
+        case ChargePointStatusTransition::PauseChargingEVSE:
             return trans.set(this->sd_suspended_evse);
-        case ChargePointStatusTransition::C6_TransactionStoppedAndUserActionRequired:
+        case ChargePointStatusTransition::TransactionStoppedAndUserActionRequired:
             return trans.set(this->sd_finishing);
-        case ChargePointStatusTransition::
-            C8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable:
+        case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
-        case ChargePointStatusTransition::C9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;
@@ -77,18 +76,17 @@ ChargePointStateMachine::ChargePointStateMachine(
 
     this->sd_suspended_ev.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::D1_ChargingSessionEndsNoUserActionRequired:
+        case ChargePointStatusTransition::BecomeAvailable:
             return trans.set(this->sd_available);
-        case ChargePointStatusTransition::D3_ChargingResumesUponEVRequest:
+        case ChargePointStatusTransition::StartCharging:
             return trans.set(this->sd_charging);
-        case ChargePointStatusTransition::D5_ChargingSuspendedByEVSE:
+        case ChargePointStatusTransition::PauseChargingEVSE:
             return trans.set(this->sd_suspended_evse);
-        case ChargePointStatusTransition::D6_TransactionStoppedNoUserActionRequired:
+        case ChargePointStatusTransition::TransactionStoppedAndUserActionRequired:
             return trans.set(this->sd_finishing);
-        case ChargePointStatusTransition::
-            D8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable:
+        case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
-        case ChargePointStatusTransition::D9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;
@@ -100,18 +98,17 @@ ChargePointStateMachine::ChargePointStateMachine(
 
     this->sd_suspended_evse.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::E1_ChargingSessionEndsNoUserActionRequired:
+        case ChargePointStatusTransition::BecomeAvailable:
             return trans.set(this->sd_available);
-        case ChargePointStatusTransition::E3_ChargingResumesEVSERestrictionLifted:
+        case ChargePointStatusTransition::StartCharging:
             return trans.set(this->sd_charging);
-        case ChargePointStatusTransition::E4_EVSERestrictionLiftedEVDoesNotStartCharging:
+        case ChargePointStatusTransition::PauseChargingEV:
             return trans.set(this->sd_suspended_ev);
-        case ChargePointStatusTransition::E6_TransactionStoppedAndUserActionRequired:
+        case ChargePointStatusTransition::TransactionStoppedAndUserActionRequired:
             return trans.set(this->sd_finishing);
-        case ChargePointStatusTransition::
-            E8_ChargingSessionEndsNoUserActionRequiredConnectorScheduledToBecomeUnavailable:
+        case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
-        case ChargePointStatusTransition::E9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;
@@ -123,13 +120,13 @@ ChargePointStateMachine::ChargePointStateMachine(
 
     this->sd_finishing.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::F1_AllUserActionsCompleted:
+        case ChargePointStatusTransition::BecomeAvailable:
             return trans.set(this->sd_available);
-        case ChargePointStatusTransition::F2_UsersRestartChargingSession:
+        case ChargePointStatusTransition::UsageInitiated: // user restarts charging session
             return trans.set(this->sd_preparing);
-        case ChargePointStatusTransition::F8_AllUserActionsCompletedConnectorScheduledToBecomeUnavailable:
+        case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
-        case ChargePointStatusTransition::F9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;
@@ -141,14 +138,13 @@ ChargePointStateMachine::ChargePointStateMachine(
 
     this->sd_reserved.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::G1_ReservationExpiresOrCancelReservationReceived:
+        case ChargePointStatusTransition::BecomeAvailable:
             return trans.set(this->sd_available);
-        case ChargePointStatusTransition::G2_ReservationIdentityPresented:
+        case ChargePointStatusTransition::UsageInitiated:
             return trans.set(this->sd_preparing);
-        case ChargePointStatusTransition::
-            G8_ReservationExpiresOrCancelReservationReceivedConnectorScheduledToBecomeUnavailable:
+        case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
-        case ChargePointStatusTransition::G9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;
@@ -160,17 +156,17 @@ ChargePointStateMachine::ChargePointStateMachine(
 
     this->sd_unavailable.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
-        case ChargePointStatusTransition::H1_ConnectorSetAvailableByChangeAvailability:
+        case ChargePointStatusTransition::BecomeAvailable:
             return trans.set(this->sd_available);
-        case ChargePointStatusTransition::H2_ConnectorSetAvailableAfterUserInteractedWithChargePoint:
+        case ChargePointStatusTransition::UsageInitiated:
             return trans.set(this->sd_preparing);
-        case ChargePointStatusTransition::H3_ConnectorSetAvailableNoUserActionRequiredToStartCharging:
+        case ChargePointStatusTransition::StartCharging:
             return trans.set(this->sd_charging);
-        case ChargePointStatusTransition::H4_ConnectorSetAvailableNoUserActionRequiredEVDoesNotStartCharging:
+        case ChargePointStatusTransition::PauseChargingEV:
             return trans.set(this->sd_suspended_ev);
-        case ChargePointStatusTransition::H5_ConnectorSetAvailableNoUserActionRequiredEVSEDoesNotAllowCharging:
+        case ChargePointStatusTransition::PauseChargingEVSE:
             return trans.set(this->sd_suspended_evse);
-        case ChargePointStatusTransition::H9_FaultDetected:
+        case ChargePointStatusTransition::FaultDetected:
             return trans.set(this->sd_faulted);
         default:
             return;

--- a/lib/ocpp1_6/charging_session.cpp
+++ b/lib/ocpp1_6/charging_session.cpp
@@ -178,14 +178,14 @@ std::vector<MeterValue> ChargingSession::get_clock_aligned_meter_values() {
 }
 
 bool ChargingSessions::valid_connector(int32_t connector) {
-    if (connector < 0 || connector > this->charging_sessions.size()) {
+    if (connector < 0 || connector > static_cast<int32_t>(this->charging_sessions.size())) {
         return false;
     }
     return true;
 }
 
 ChargingSessions::ChargingSessions(int32_t number_of_connectors) : number_of_connectors(number_of_connectors) {
-    for (size_t i = 0; i < number_of_connectors + 1; i++) {
+    for (int32_t i = 0; i < number_of_connectors + 1; i++) {
         this->charging_sessions.push_back(nullptr);
     }
 }

--- a/lib/ocpp1_6/charging_session.cpp
+++ b/lib/ocpp1_6/charging_session.cpp
@@ -191,13 +191,10 @@ ChargingSessions::ChargingSessions(int32_t number_of_connectors) : number_of_con
 }
 
 int32_t ChargingSessions::add_authorized_token(CiString20Type idTag, IdTagInfo idTagInfo) {
-    // EVLOG(error) << "add token thingy";
     return this->add_authorized_token(0, idTag, idTagInfo);
 }
 
 int32_t ChargingSessions::add_authorized_token(int32_t connector, CiString20Type idTag, IdTagInfo idTagInfo) {
-    EVLOG(critical) << "add_authorized_token to connector " << connector;
-
     if (!this->valid_connector(connector)) {
         return -1;
     }
@@ -230,7 +227,6 @@ int32_t ChargingSessions::add_authorized_token(int32_t connector, CiString20Type
                 // do not add a authorized token to a running charging session
                 return -1;
             }
-            EVLOG(info) << "Adding authorized token " << authorized_token->idTag;
             this->charging_sessions.at(connector)->add_authorized_token(std::move(authorized_token));
         }
     }

--- a/lib/ocpp1_6/charging_session.cpp
+++ b/lib/ocpp1_6/charging_session.cpp
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <mutex>
+
+#include <everest/logging.hpp>
+#include <everest/timer.hpp>
+
 #include <ocpp1_6/charging_session.hpp>
 
 namespace ocpp1_6 {

--- a/lib/ocpp1_6/enums.cpp
+++ b/lib/ocpp1_6/enums.cpp
@@ -25,7 +25,7 @@ std::string authorization_status_to_string(AuthorizationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type AuthorizationStatus");
 }
 
-AuthorizationStatus string_to_authorization_status(std::string s) {
+AuthorizationStatus string_to_authorization_status(const std::string& s) {
     if (s == "Accepted") {
         return AuthorizationStatus::Accepted;
     }
@@ -66,7 +66,7 @@ std::string registration_status_to_string(RegistrationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type RegistrationStatus");
 }
 
-RegistrationStatus string_to_registration_status(std::string s) {
+RegistrationStatus string_to_registration_status(const std::string& s) {
     if (s == "Accepted") {
         return RegistrationStatus::Accepted;
     }
@@ -99,7 +99,7 @@ std::string cancel_reservation_status_to_string(CancelReservationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type CancelReservationStatus");
 }
 
-CancelReservationStatus string_to_cancel_reservation_status(std::string s) {
+CancelReservationStatus string_to_cancel_reservation_status(const std::string& s) {
     if (s == "Accepted") {
         return CancelReservationStatus::Accepted;
     }
@@ -129,7 +129,7 @@ std::string availability_type_to_string(AvailabilityType e) {
     throw std::out_of_range("No known string conversion for provided enum of type AvailabilityType");
 }
 
-AvailabilityType string_to_availability_type(std::string s) {
+AvailabilityType string_to_availability_type(const std::string& s) {
     if (s == "Inoperative") {
         return AvailabilityType::Inoperative;
     }
@@ -161,7 +161,7 @@ std::string availability_status_to_string(AvailabilityStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type AvailabilityStatus");
 }
 
-AvailabilityStatus string_to_availability_status(std::string s) {
+AvailabilityStatus string_to_availability_status(const std::string& s) {
     if (s == "Accepted") {
         return AvailabilityStatus::Accepted;
     }
@@ -198,7 +198,7 @@ std::string configuration_status_to_string(ConfigurationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ConfigurationStatus");
 }
 
-ConfigurationStatus string_to_configuration_status(std::string s) {
+ConfigurationStatus string_to_configuration_status(const std::string& s) {
     if (s == "Accepted") {
         return ConfigurationStatus::Accepted;
     }
@@ -234,7 +234,7 @@ std::string clear_cache_status_to_string(ClearCacheStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ClearCacheStatus");
 }
 
-ClearCacheStatus string_to_clear_cache_status(std::string s) {
+ClearCacheStatus string_to_clear_cache_status(const std::string& s) {
     if (s == "Accepted") {
         return ClearCacheStatus::Accepted;
     }
@@ -266,7 +266,7 @@ std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e
     throw std::out_of_range("No known string conversion for provided enum of type ChargingProfilePurposeType");
 }
 
-ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s) {
+ChargingProfilePurposeType string_to_charging_profile_purpose_type(const std::string& s) {
     if (s == "ChargePointMaxProfile") {
         return ChargingProfilePurposeType::ChargePointMaxProfile;
     }
@@ -300,7 +300,7 @@ std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e
     throw std::out_of_range("No known string conversion for provided enum of type ClearChargingProfileStatus");
 }
 
-ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s) {
+ClearChargingProfileStatus string_to_clear_charging_profile_status(const std::string& s) {
     if (s == "Accepted") {
         return ClearChargingProfileStatus::Accepted;
     }
@@ -335,7 +335,7 @@ std::string data_transfer_status_to_string(DataTransferStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type DataTransferStatus");
 }
 
-DataTransferStatus string_to_data_transfer_status(std::string s) {
+DataTransferStatus string_to_data_transfer_status(const std::string& s) {
     if (s == "Accepted") {
         return DataTransferStatus::Accepted;
     }
@@ -375,7 +375,7 @@ std::string diagnostics_status_to_string(DiagnosticsStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type DiagnosticsStatus");
 }
 
-DiagnosticsStatus string_to_diagnostics_status(std::string s) {
+DiagnosticsStatus string_to_diagnostics_status(const std::string& s) {
     if (s == "Idle") {
         return DiagnosticsStatus::Idle;
     }
@@ -421,7 +421,7 @@ std::string firmware_status_to_string(FirmwareStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type FirmwareStatus");
 }
 
-FirmwareStatus string_to_firmware_status(std::string s) {
+FirmwareStatus string_to_firmware_status(const std::string& s) {
     if (s == "Downloaded") {
         return FirmwareStatus::Downloaded;
     }
@@ -466,7 +466,7 @@ std::string charging_rate_unit_to_string(ChargingRateUnit e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargingRateUnit");
 }
 
-ChargingRateUnit string_to_charging_rate_unit(std::string s) {
+ChargingRateUnit string_to_charging_rate_unit(const std::string& s) {
     if (s == "A") {
         return ChargingRateUnit::A;
     }
@@ -496,7 +496,7 @@ std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e
     throw std::out_of_range("No known string conversion for provided enum of type GetCompositeScheduleStatus");
 }
 
-GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s) {
+GetCompositeScheduleStatus string_to_get_composite_schedule_status(const std::string& s) {
     if (s == "Accepted") {
         return GetCompositeScheduleStatus::Accepted;
     }
@@ -539,7 +539,7 @@ std::string reading_context_to_string(ReadingContext e) {
     throw std::out_of_range("No known string conversion for provided enum of type ReadingContext");
 }
 
-ReadingContext string_to_reading_context(std::string s) {
+ReadingContext string_to_reading_context(const std::string& s) {
     if (s == "Interruption.Begin") {
         return ReadingContext::Interruption_Begin;
     }
@@ -587,7 +587,7 @@ std::string value_format_to_string(ValueFormat e) {
     throw std::out_of_range("No known string conversion for provided enum of type ValueFormat");
 }
 
-ValueFormat string_to_value_format(std::string s) {
+ValueFormat string_to_value_format(const std::string& s) {
     if (s == "Raw") {
         return ValueFormat::Raw;
     }
@@ -657,7 +657,7 @@ std::string measurand_to_string(Measurand e) {
     throw std::out_of_range("No known string conversion for provided enum of type Measurand");
 }
 
-Measurand string_to_measurand(std::string s) {
+Measurand string_to_measurand(const std::string& s) {
     if (s == "Energy.Active.Export.Register") {
         return Measurand::Energy_Active_Export_Register;
     }
@@ -763,7 +763,7 @@ std::string phase_to_string(Phase e) {
     throw std::out_of_range("No known string conversion for provided enum of type Phase");
 }
 
-Phase string_to_phase(std::string s) {
+Phase string_to_phase(const std::string& s) {
     if (s == "L1") {
         return Phase::L1;
     }
@@ -823,7 +823,7 @@ std::string location_to_string(Location e) {
     throw std::out_of_range("No known string conversion for provided enum of type Location");
 }
 
-Location string_to_location(std::string s) {
+Location string_to_location(const std::string& s) {
     if (s == "Cable") {
         return Location::Cable;
     }
@@ -892,7 +892,7 @@ std::string unit_of_measure_to_string(UnitOfMeasure e) {
     throw std::out_of_range("No known string conversion for provided enum of type UnitOfMeasure");
 }
 
-UnitOfMeasure string_to_unit_of_measure(std::string s) {
+UnitOfMeasure string_to_unit_of_measure(const std::string& s) {
     if (s == "Wh") {
         return UnitOfMeasure::Wh;
     }
@@ -969,7 +969,7 @@ std::string charging_profile_kind_type_to_string(ChargingProfileKindType e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileKindType");
 }
 
-ChargingProfileKindType string_to_charging_profile_kind_type(std::string s) {
+ChargingProfileKindType string_to_charging_profile_kind_type(const std::string& s) {
     if (s == "Absolute") {
         return ChargingProfileKindType::Absolute;
     }
@@ -1002,7 +1002,7 @@ std::string recurrency_kind_type_to_string(RecurrencyKindType e) {
     throw std::out_of_range("No known string conversion for provided enum of type RecurrencyKindType");
 }
 
-RecurrencyKindType string_to_recurrency_kind_type(std::string s) {
+RecurrencyKindType string_to_recurrency_kind_type(const std::string& s) {
     if (s == "Daily") {
         return RecurrencyKindType::Daily;
     }
@@ -1032,7 +1032,7 @@ std::string remote_start_stop_status_to_string(RemoteStartStopStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type RemoteStartStopStatus");
 }
 
-RemoteStartStopStatus string_to_remote_start_stop_status(std::string s) {
+RemoteStartStopStatus string_to_remote_start_stop_status(const std::string& s) {
     if (s == "Accepted") {
         return RemoteStartStopStatus::Accepted;
     }
@@ -1068,7 +1068,7 @@ std::string reservation_status_to_string(ReservationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ReservationStatus");
 }
 
-ReservationStatus string_to_reservation_status(std::string s) {
+ReservationStatus string_to_reservation_status(const std::string& s) {
     if (s == "Accepted") {
         return ReservationStatus::Accepted;
     }
@@ -1107,7 +1107,7 @@ std::string reset_type_to_string(ResetType e) {
     throw std::out_of_range("No known string conversion for provided enum of type ResetType");
 }
 
-ResetType string_to_reset_type(std::string s) {
+ResetType string_to_reset_type(const std::string& s) {
     if (s == "Hard") {
         return ResetType::Hard;
     }
@@ -1137,7 +1137,7 @@ std::string reset_status_to_string(ResetStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ResetStatus");
 }
 
-ResetStatus string_to_reset_status(std::string s) {
+ResetStatus string_to_reset_status(const std::string& s) {
     if (s == "Accepted") {
         return ResetStatus::Accepted;
     }
@@ -1167,7 +1167,7 @@ std::string update_type_to_string(UpdateType e) {
     throw std::out_of_range("No known string conversion for provided enum of type UpdateType");
 }
 
-UpdateType string_to_update_type(std::string s) {
+UpdateType string_to_update_type(const std::string& s) {
     if (s == "Differential") {
         return UpdateType::Differential;
     }
@@ -1201,7 +1201,7 @@ std::string update_status_to_string(UpdateStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type UpdateStatus");
 }
 
-UpdateStatus string_to_update_status(std::string s) {
+UpdateStatus string_to_update_status(const std::string& s) {
     if (s == "Accepted") {
         return UpdateStatus::Accepted;
     }
@@ -1239,7 +1239,7 @@ std::string charging_profile_status_to_string(ChargingProfileStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileStatus");
 }
 
-ChargingProfileStatus string_to_charging_profile_status(std::string s) {
+ChargingProfileStatus string_to_charging_profile_status(const std::string& s) {
     if (s == "Accepted") {
         return ChargingProfileStatus::Accepted;
     }
@@ -1300,7 +1300,7 @@ std::string charge_point_error_code_to_string(ChargePointErrorCode e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargePointErrorCode");
 }
 
-ChargePointErrorCode string_to_charge_point_error_code(std::string s) {
+ChargePointErrorCode string_to_charge_point_error_code(const std::string& s) {
     if (s == "ConnectorLockFailure") {
         return ChargePointErrorCode::ConnectorLockFailure;
     }
@@ -1386,7 +1386,7 @@ std::string charge_point_status_to_string(ChargePointStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargePointStatus");
 }
 
-ChargePointStatus string_to_charge_point_status(std::string s) {
+ChargePointStatus string_to_charge_point_status(const std::string& s) {
     if (s == "Available") {
         return ChargePointStatus::Available;
     }
@@ -1455,7 +1455,7 @@ std::string reason_to_string(Reason e) {
     throw std::out_of_range("No known string conversion for provided enum of type Reason");
 }
 
-Reason string_to_reason(std::string s) {
+Reason string_to_reason(const std::string& s) {
     if (s == "EmergencyStop") {
         return Reason::EmergencyStop;
     }
@@ -1520,7 +1520,7 @@ std::string message_trigger_to_string(MessageTrigger e) {
     throw std::out_of_range("No known string conversion for provided enum of type MessageTrigger");
 }
 
-MessageTrigger string_to_message_trigger(std::string s) {
+MessageTrigger string_to_message_trigger(const std::string& s) {
     if (s == "BootNotification") {
         return MessageTrigger::BootNotification;
     }
@@ -1564,7 +1564,7 @@ std::string trigger_message_status_to_string(TriggerMessageStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type TriggerMessageStatus");
 }
 
-TriggerMessageStatus string_to_trigger_message_status(std::string s) {
+TriggerMessageStatus string_to_trigger_message_status(const std::string& s) {
     if (s == "Accepted") {
         return TriggerMessageStatus::Accepted;
     }
@@ -1599,7 +1599,7 @@ std::string unlock_status_to_string(UnlockStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type UnlockStatus");
 }
 
-UnlockStatus string_to_unlock_status(std::string s) {
+UnlockStatus string_to_unlock_status(const std::string& s) {
     if (s == "Unlocked") {
         return UnlockStatus::Unlocked;
     }

--- a/lib/ocpp1_6/enums.cpp
+++ b/lib/ocpp1_6/enums.cpp
@@ -1,0 +1,1622 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <ocpp1_6/enums.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace ocpp1_6 {
+
+// from: AuthorizeResponse
+namespace conversions {
+const std::string authorization_status_to_string(AuthorizationStatus e) {
+    switch (e) {
+    case AuthorizationStatus::Accepted:
+        return "Accepted";
+    case AuthorizationStatus::Blocked:
+        return "Blocked";
+    case AuthorizationStatus::Expired:
+        return "Expired";
+    case AuthorizationStatus::Invalid:
+        return "Invalid";
+    case AuthorizationStatus::ConcurrentTx:
+        return "ConcurrentTx";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type AuthorizationStatus");
+}
+
+const AuthorizationStatus string_to_authorization_status(std::string s) {
+    if (s == "Accepted") {
+        return AuthorizationStatus::Accepted;
+    }
+    if (s == "Blocked") {
+        return AuthorizationStatus::Blocked;
+    }
+    if (s == "Expired") {
+        return AuthorizationStatus::Expired;
+    }
+    if (s == "Invalid") {
+        return AuthorizationStatus::Invalid;
+    }
+    if (s == "ConcurrentTx") {
+        return AuthorizationStatus::ConcurrentTx;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AuthorizationStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const AuthorizationStatus& authorization_status) {
+    os << conversions::authorization_status_to_string(authorization_status);
+    return os;
+}
+
+// from: BootNotificationResponse
+namespace conversions {
+const std::string registration_status_to_string(RegistrationStatus e) {
+    switch (e) {
+    case RegistrationStatus::Accepted:
+        return "Accepted";
+    case RegistrationStatus::Pending:
+        return "Pending";
+    case RegistrationStatus::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type RegistrationStatus");
+}
+
+const RegistrationStatus string_to_registration_status(std::string s) {
+    if (s == "Accepted") {
+        return RegistrationStatus::Accepted;
+    }
+    if (s == "Pending") {
+        return RegistrationStatus::Pending;
+    }
+    if (s == "Rejected") {
+        return RegistrationStatus::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RegistrationStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const RegistrationStatus& registration_status) {
+    os << conversions::registration_status_to_string(registration_status);
+    return os;
+}
+
+// from: CancelReservationResponse
+namespace conversions {
+const std::string cancel_reservation_status_to_string(CancelReservationStatus e) {
+    switch (e) {
+    case CancelReservationStatus::Accepted:
+        return "Accepted";
+    case CancelReservationStatus::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type CancelReservationStatus");
+}
+
+const CancelReservationStatus string_to_cancel_reservation_status(std::string s) {
+    if (s == "Accepted") {
+        return CancelReservationStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return CancelReservationStatus::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type CancelReservationStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const CancelReservationStatus& cancel_reservation_status) {
+    os << conversions::cancel_reservation_status_to_string(cancel_reservation_status);
+    return os;
+}
+
+// from: ChangeAvailabilityRequest
+namespace conversions {
+const std::string availability_type_to_string(AvailabilityType e) {
+    switch (e) {
+    case AvailabilityType::Inoperative:
+        return "Inoperative";
+    case AvailabilityType::Operative:
+        return "Operative";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type AvailabilityType");
+}
+
+const AvailabilityType string_to_availability_type(std::string s) {
+    if (s == "Inoperative") {
+        return AvailabilityType::Inoperative;
+    }
+    if (s == "Operative") {
+        return AvailabilityType::Operative;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AvailabilityType");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const AvailabilityType& availability_type) {
+    os << conversions::availability_type_to_string(availability_type);
+    return os;
+}
+
+// from: ChangeAvailabilityResponse
+namespace conversions {
+const std::string availability_status_to_string(AvailabilityStatus e) {
+    switch (e) {
+    case AvailabilityStatus::Accepted:
+        return "Accepted";
+    case AvailabilityStatus::Rejected:
+        return "Rejected";
+    case AvailabilityStatus::Scheduled:
+        return "Scheduled";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type AvailabilityStatus");
+}
+
+const AvailabilityStatus string_to_availability_status(std::string s) {
+    if (s == "Accepted") {
+        return AvailabilityStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return AvailabilityStatus::Rejected;
+    }
+    if (s == "Scheduled") {
+        return AvailabilityStatus::Scheduled;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AvailabilityStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const AvailabilityStatus& availability_status) {
+    os << conversions::availability_status_to_string(availability_status);
+    return os;
+}
+
+// from: ChangeConfigurationResponse
+namespace conversions {
+const std::string configuration_status_to_string(ConfigurationStatus e) {
+    switch (e) {
+    case ConfigurationStatus::Accepted:
+        return "Accepted";
+    case ConfigurationStatus::Rejected:
+        return "Rejected";
+    case ConfigurationStatus::RebootRequired:
+        return "RebootRequired";
+    case ConfigurationStatus::NotSupported:
+        return "NotSupported";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ConfigurationStatus");
+}
+
+const ConfigurationStatus string_to_configuration_status(std::string s) {
+    if (s == "Accepted") {
+        return ConfigurationStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return ConfigurationStatus::Rejected;
+    }
+    if (s == "RebootRequired") {
+        return ConfigurationStatus::RebootRequired;
+    }
+    if (s == "NotSupported") {
+        return ConfigurationStatus::NotSupported;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ConfigurationStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ConfigurationStatus& configuration_status) {
+    os << conversions::configuration_status_to_string(configuration_status);
+    return os;
+}
+
+// from: ClearCacheResponse
+namespace conversions {
+const std::string clear_cache_status_to_string(ClearCacheStatus e) {
+    switch (e) {
+    case ClearCacheStatus::Accepted:
+        return "Accepted";
+    case ClearCacheStatus::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ClearCacheStatus");
+}
+
+const ClearCacheStatus string_to_clear_cache_status(std::string s) {
+    if (s == "Accepted") {
+        return ClearCacheStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return ClearCacheStatus::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ClearCacheStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ClearCacheStatus& clear_cache_status) {
+    os << conversions::clear_cache_status_to_string(clear_cache_status);
+    return os;
+}
+
+// from: ClearChargingProfileRequest
+namespace conversions {
+const std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e) {
+    switch (e) {
+    case ChargingProfilePurposeType::ChargePointMaxProfile:
+        return "ChargePointMaxProfile";
+    case ChargingProfilePurposeType::TxDefaultProfile:
+        return "TxDefaultProfile";
+    case ChargingProfilePurposeType::TxProfile:
+        return "TxProfile";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfilePurposeType");
+}
+
+const ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s) {
+    if (s == "ChargePointMaxProfile") {
+        return ChargingProfilePurposeType::ChargePointMaxProfile;
+    }
+    if (s == "TxDefaultProfile") {
+        return ChargingProfilePurposeType::TxDefaultProfile;
+    }
+    if (s == "TxProfile") {
+        return ChargingProfilePurposeType::TxProfile;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type ChargingProfilePurposeType");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargingProfilePurposeType& charging_profile_purpose_type) {
+    os << conversions::charging_profile_purpose_type_to_string(charging_profile_purpose_type);
+    return os;
+}
+
+// from: ClearChargingProfileResponse
+namespace conversions {
+const std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e) {
+    switch (e) {
+    case ClearChargingProfileStatus::Accepted:
+        return "Accepted";
+    case ClearChargingProfileStatus::Unknown:
+        return "Unknown";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ClearChargingProfileStatus");
+}
+
+const ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s) {
+    if (s == "Accepted") {
+        return ClearChargingProfileStatus::Accepted;
+    }
+    if (s == "Unknown") {
+        return ClearChargingProfileStatus::Unknown;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type ClearChargingProfileStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ClearChargingProfileStatus& clear_charging_profile_status) {
+    os << conversions::clear_charging_profile_status_to_string(clear_charging_profile_status);
+    return os;
+}
+
+// from: DataTransferResponse
+namespace conversions {
+const std::string data_transfer_status_to_string(DataTransferStatus e) {
+    switch (e) {
+    case DataTransferStatus::Accepted:
+        return "Accepted";
+    case DataTransferStatus::Rejected:
+        return "Rejected";
+    case DataTransferStatus::UnknownMessageId:
+        return "UnknownMessageId";
+    case DataTransferStatus::UnknownVendorId:
+        return "UnknownVendorId";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type DataTransferStatus");
+}
+
+const DataTransferStatus string_to_data_transfer_status(std::string s) {
+    if (s == "Accepted") {
+        return DataTransferStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return DataTransferStatus::Rejected;
+    }
+    if (s == "UnknownMessageId") {
+        return DataTransferStatus::UnknownMessageId;
+    }
+    if (s == "UnknownVendorId") {
+        return DataTransferStatus::UnknownVendorId;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type DataTransferStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const DataTransferStatus& data_transfer_status) {
+    os << conversions::data_transfer_status_to_string(data_transfer_status);
+    return os;
+}
+
+// from: DiagnosticsStatusNotificationRequest
+namespace conversions {
+const std::string diagnostics_status_to_string(DiagnosticsStatus e) {
+    switch (e) {
+    case DiagnosticsStatus::Idle:
+        return "Idle";
+    case DiagnosticsStatus::Uploaded:
+        return "Uploaded";
+    case DiagnosticsStatus::UploadFailed:
+        return "UploadFailed";
+    case DiagnosticsStatus::Uploading:
+        return "Uploading";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type DiagnosticsStatus");
+}
+
+const DiagnosticsStatus string_to_diagnostics_status(std::string s) {
+    if (s == "Idle") {
+        return DiagnosticsStatus::Idle;
+    }
+    if (s == "Uploaded") {
+        return DiagnosticsStatus::Uploaded;
+    }
+    if (s == "UploadFailed") {
+        return DiagnosticsStatus::UploadFailed;
+    }
+    if (s == "Uploading") {
+        return DiagnosticsStatus::Uploading;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type DiagnosticsStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const DiagnosticsStatus& diagnostics_status) {
+    os << conversions::diagnostics_status_to_string(diagnostics_status);
+    return os;
+}
+
+// from: FirmwareStatusNotificationRequest
+namespace conversions {
+const std::string firmware_status_to_string(FirmwareStatus e) {
+    switch (e) {
+    case FirmwareStatus::Downloaded:
+        return "Downloaded";
+    case FirmwareStatus::DownloadFailed:
+        return "DownloadFailed";
+    case FirmwareStatus::Downloading:
+        return "Downloading";
+    case FirmwareStatus::Idle:
+        return "Idle";
+    case FirmwareStatus::InstallationFailed:
+        return "InstallationFailed";
+    case FirmwareStatus::Installing:
+        return "Installing";
+    case FirmwareStatus::Installed:
+        return "Installed";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type FirmwareStatus");
+}
+
+const FirmwareStatus string_to_firmware_status(std::string s) {
+    if (s == "Downloaded") {
+        return FirmwareStatus::Downloaded;
+    }
+    if (s == "DownloadFailed") {
+        return FirmwareStatus::DownloadFailed;
+    }
+    if (s == "Downloading") {
+        return FirmwareStatus::Downloading;
+    }
+    if (s == "Idle") {
+        return FirmwareStatus::Idle;
+    }
+    if (s == "InstallationFailed") {
+        return FirmwareStatus::InstallationFailed;
+    }
+    if (s == "Installing") {
+        return FirmwareStatus::Installing;
+    }
+    if (s == "Installed") {
+        return FirmwareStatus::Installed;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type FirmwareStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const FirmwareStatus& firmware_status) {
+    os << conversions::firmware_status_to_string(firmware_status);
+    return os;
+}
+
+// from: GetCompositeScheduleRequest
+namespace conversions {
+const std::string charging_rate_unit_to_string(ChargingRateUnit e) {
+    switch (e) {
+    case ChargingRateUnit::A:
+        return "A";
+    case ChargingRateUnit::W:
+        return "W";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargingRateUnit");
+}
+
+const ChargingRateUnit string_to_charging_rate_unit(std::string s) {
+    if (s == "A") {
+        return ChargingRateUnit::A;
+    }
+    if (s == "W") {
+        return ChargingRateUnit::W;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingRateUnit");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargingRateUnit& charging_rate_unit) {
+    os << conversions::charging_rate_unit_to_string(charging_rate_unit);
+    return os;
+}
+
+// from: GetCompositeScheduleResponse
+namespace conversions {
+const std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e) {
+    switch (e) {
+    case GetCompositeScheduleStatus::Accepted:
+        return "Accepted";
+    case GetCompositeScheduleStatus::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type GetCompositeScheduleStatus");
+}
+
+const GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s) {
+    if (s == "Accepted") {
+        return GetCompositeScheduleStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return GetCompositeScheduleStatus::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type GetCompositeScheduleStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleStatus& get_composite_schedule_status) {
+    os << conversions::get_composite_schedule_status_to_string(get_composite_schedule_status);
+    return os;
+}
+
+// from: MeterValuesRequest
+namespace conversions {
+const std::string reading_context_to_string(ReadingContext e) {
+    switch (e) {
+    case ReadingContext::Interruption_Begin:
+        return "Interruption.Begin";
+    case ReadingContext::Interruption_End:
+        return "Interruption.End";
+    case ReadingContext::Sample_Clock:
+        return "Sample.Clock";
+    case ReadingContext::Sample_Periodic:
+        return "Sample.Periodic";
+    case ReadingContext::Transaction_Begin:
+        return "Transaction.Begin";
+    case ReadingContext::Transaction_End:
+        return "Transaction.End";
+    case ReadingContext::Trigger:
+        return "Trigger";
+    case ReadingContext::Other:
+        return "Other";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ReadingContext");
+}
+
+const ReadingContext string_to_reading_context(std::string s) {
+    if (s == "Interruption.Begin") {
+        return ReadingContext::Interruption_Begin;
+    }
+    if (s == "Interruption.End") {
+        return ReadingContext::Interruption_End;
+    }
+    if (s == "Sample.Clock") {
+        return ReadingContext::Sample_Clock;
+    }
+    if (s == "Sample.Periodic") {
+        return ReadingContext::Sample_Periodic;
+    }
+    if (s == "Transaction.Begin") {
+        return ReadingContext::Transaction_Begin;
+    }
+    if (s == "Transaction.End") {
+        return ReadingContext::Transaction_End;
+    }
+    if (s == "Trigger") {
+        return ReadingContext::Trigger;
+    }
+    if (s == "Other") {
+        return ReadingContext::Other;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReadingContext");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ReadingContext& reading_context) {
+    os << conversions::reading_context_to_string(reading_context);
+    return os;
+}
+
+// from: MeterValuesRequest
+namespace conversions {
+const std::string value_format_to_string(ValueFormat e) {
+    switch (e) {
+    case ValueFormat::Raw:
+        return "Raw";
+    case ValueFormat::SignedData:
+        return "SignedData";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ValueFormat");
+}
+
+const ValueFormat string_to_value_format(std::string s) {
+    if (s == "Raw") {
+        return ValueFormat::Raw;
+    }
+    if (s == "SignedData") {
+        return ValueFormat::SignedData;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ValueFormat");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ValueFormat& value_format) {
+    os << conversions::value_format_to_string(value_format);
+    return os;
+}
+
+// from: MeterValuesRequest
+namespace conversions {
+const std::string measurand_to_string(Measurand e) {
+    switch (e) {
+    case Measurand::Energy_Active_Export_Register:
+        return "Energy.Active.Export.Register";
+    case Measurand::Energy_Active_Import_Register:
+        return "Energy.Active.Import.Register";
+    case Measurand::Energy_Reactive_Export_Register:
+        return "Energy.Reactive.Export.Register";
+    case Measurand::Energy_Reactive_Import_Register:
+        return "Energy.Reactive.Import.Register";
+    case Measurand::Energy_Active_Export_Interval:
+        return "Energy.Active.Export.Interval";
+    case Measurand::Energy_Active_Import_Interval:
+        return "Energy.Active.Import.Interval";
+    case Measurand::Energy_Reactive_Export_Interval:
+        return "Energy.Reactive.Export.Interval";
+    case Measurand::Energy_Reactive_Import_Interval:
+        return "Energy.Reactive.Import.Interval";
+    case Measurand::Power_Active_Export:
+        return "Power.Active.Export";
+    case Measurand::Power_Active_Import:
+        return "Power.Active.Import";
+    case Measurand::Power_Offered:
+        return "Power.Offered";
+    case Measurand::Power_Reactive_Export:
+        return "Power.Reactive.Export";
+    case Measurand::Power_Reactive_Import:
+        return "Power.Reactive.Import";
+    case Measurand::Power_Factor:
+        return "Power.Factor";
+    case Measurand::Current_Import:
+        return "Current.Import";
+    case Measurand::Current_Export:
+        return "Current.Export";
+    case Measurand::Current_Offered:
+        return "Current.Offered";
+    case Measurand::Voltage:
+        return "Voltage";
+    case Measurand::Frequency:
+        return "Frequency";
+    case Measurand::Temperature:
+        return "Temperature";
+    case Measurand::SoC:
+        return "SoC";
+    case Measurand::RPM:
+        return "RPM";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type Measurand");
+}
+
+const Measurand string_to_measurand(std::string s) {
+    if (s == "Energy.Active.Export.Register") {
+        return Measurand::Energy_Active_Export_Register;
+    }
+    if (s == "Energy.Active.Import.Register") {
+        return Measurand::Energy_Active_Import_Register;
+    }
+    if (s == "Energy.Reactive.Export.Register") {
+        return Measurand::Energy_Reactive_Export_Register;
+    }
+    if (s == "Energy.Reactive.Import.Register") {
+        return Measurand::Energy_Reactive_Import_Register;
+    }
+    if (s == "Energy.Active.Export.Interval") {
+        return Measurand::Energy_Active_Export_Interval;
+    }
+    if (s == "Energy.Active.Import.Interval") {
+        return Measurand::Energy_Active_Import_Interval;
+    }
+    if (s == "Energy.Reactive.Export.Interval") {
+        return Measurand::Energy_Reactive_Export_Interval;
+    }
+    if (s == "Energy.Reactive.Import.Interval") {
+        return Measurand::Energy_Reactive_Import_Interval;
+    }
+    if (s == "Power.Active.Export") {
+        return Measurand::Power_Active_Export;
+    }
+    if (s == "Power.Active.Import") {
+        return Measurand::Power_Active_Import;
+    }
+    if (s == "Power.Offered") {
+        return Measurand::Power_Offered;
+    }
+    if (s == "Power.Reactive.Export") {
+        return Measurand::Power_Reactive_Export;
+    }
+    if (s == "Power.Reactive.Import") {
+        return Measurand::Power_Reactive_Import;
+    }
+    if (s == "Power.Factor") {
+        return Measurand::Power_Factor;
+    }
+    if (s == "Current.Import") {
+        return Measurand::Current_Import;
+    }
+    if (s == "Current.Export") {
+        return Measurand::Current_Export;
+    }
+    if (s == "Current.Offered") {
+        return Measurand::Current_Offered;
+    }
+    if (s == "Voltage") {
+        return Measurand::Voltage;
+    }
+    if (s == "Frequency") {
+        return Measurand::Frequency;
+    }
+    if (s == "Temperature") {
+        return Measurand::Temperature;
+    }
+    if (s == "SoC") {
+        return Measurand::SoC;
+    }
+    if (s == "RPM") {
+        return Measurand::RPM;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Measurand");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const Measurand& measurand) {
+    os << conversions::measurand_to_string(measurand);
+    return os;
+}
+
+// from: MeterValuesRequest
+namespace conversions {
+const std::string phase_to_string(Phase e) {
+    switch (e) {
+    case Phase::L1:
+        return "L1";
+    case Phase::L2:
+        return "L2";
+    case Phase::L3:
+        return "L3";
+    case Phase::N:
+        return "N";
+    case Phase::L1_N:
+        return "L1-N";
+    case Phase::L2_N:
+        return "L2-N";
+    case Phase::L3_N:
+        return "L3-N";
+    case Phase::L1_L2:
+        return "L1-L2";
+    case Phase::L2_L3:
+        return "L2-L3";
+    case Phase::L3_L1:
+        return "L3-L1";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type Phase");
+}
+
+const Phase string_to_phase(std::string s) {
+    if (s == "L1") {
+        return Phase::L1;
+    }
+    if (s == "L2") {
+        return Phase::L2;
+    }
+    if (s == "L3") {
+        return Phase::L3;
+    }
+    if (s == "N") {
+        return Phase::N;
+    }
+    if (s == "L1-N") {
+        return Phase::L1_N;
+    }
+    if (s == "L2-N") {
+        return Phase::L2_N;
+    }
+    if (s == "L3-N") {
+        return Phase::L3_N;
+    }
+    if (s == "L1-L2") {
+        return Phase::L1_L2;
+    }
+    if (s == "L2-L3") {
+        return Phase::L2_L3;
+    }
+    if (s == "L3-L1") {
+        return Phase::L3_L1;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Phase");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const Phase& phase) {
+    os << conversions::phase_to_string(phase);
+    return os;
+}
+
+// from: MeterValuesRequest
+namespace conversions {
+const std::string location_to_string(Location e) {
+    switch (e) {
+    case Location::Cable:
+        return "Cable";
+    case Location::EV:
+        return "EV";
+    case Location::Inlet:
+        return "Inlet";
+    case Location::Outlet:
+        return "Outlet";
+    case Location::Body:
+        return "Body";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type Location");
+}
+
+const Location string_to_location(std::string s) {
+    if (s == "Cable") {
+        return Location::Cable;
+    }
+    if (s == "EV") {
+        return Location::EV;
+    }
+    if (s == "Inlet") {
+        return Location::Inlet;
+    }
+    if (s == "Outlet") {
+        return Location::Outlet;
+    }
+    if (s == "Body") {
+        return Location::Body;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Location");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const Location& location) {
+    os << conversions::location_to_string(location);
+    return os;
+}
+
+// from: MeterValuesRequest
+namespace conversions {
+const std::string unit_of_measure_to_string(UnitOfMeasure e) {
+    switch (e) {
+    case UnitOfMeasure::Wh:
+        return "Wh";
+    case UnitOfMeasure::kWh:
+        return "kWh";
+    case UnitOfMeasure::varh:
+        return "varh";
+    case UnitOfMeasure::kvarh:
+        return "kvarh";
+    case UnitOfMeasure::W:
+        return "W";
+    case UnitOfMeasure::kW:
+        return "kW";
+    case UnitOfMeasure::VA:
+        return "VA";
+    case UnitOfMeasure::kVA:
+        return "kVA";
+    case UnitOfMeasure::var:
+        return "var";
+    case UnitOfMeasure::kvar:
+        return "kvar";
+    case UnitOfMeasure::A:
+        return "A";
+    case UnitOfMeasure::V:
+        return "V";
+    case UnitOfMeasure::K:
+        return "K";
+    case UnitOfMeasure::Celcius:
+        return "Celcius";
+    case UnitOfMeasure::Celsius:
+        return "Celsius";
+    case UnitOfMeasure::Fahrenheit:
+        return "Fahrenheit";
+    case UnitOfMeasure::Percent:
+        return "Percent";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type UnitOfMeasure");
+}
+
+const UnitOfMeasure string_to_unit_of_measure(std::string s) {
+    if (s == "Wh") {
+        return UnitOfMeasure::Wh;
+    }
+    if (s == "kWh") {
+        return UnitOfMeasure::kWh;
+    }
+    if (s == "varh") {
+        return UnitOfMeasure::varh;
+    }
+    if (s == "kvarh") {
+        return UnitOfMeasure::kvarh;
+    }
+    if (s == "W") {
+        return UnitOfMeasure::W;
+    }
+    if (s == "kW") {
+        return UnitOfMeasure::kW;
+    }
+    if (s == "VA") {
+        return UnitOfMeasure::VA;
+    }
+    if (s == "kVA") {
+        return UnitOfMeasure::kVA;
+    }
+    if (s == "var") {
+        return UnitOfMeasure::var;
+    }
+    if (s == "kvar") {
+        return UnitOfMeasure::kvar;
+    }
+    if (s == "A") {
+        return UnitOfMeasure::A;
+    }
+    if (s == "V") {
+        return UnitOfMeasure::V;
+    }
+    if (s == "K") {
+        return UnitOfMeasure::K;
+    }
+    if (s == "Celcius") {
+        return UnitOfMeasure::Celcius;
+    }
+    if (s == "Celsius") {
+        return UnitOfMeasure::Celsius;
+    }
+    if (s == "Fahrenheit") {
+        return UnitOfMeasure::Fahrenheit;
+    }
+    if (s == "Percent") {
+        return UnitOfMeasure::Percent;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UnitOfMeasure");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const UnitOfMeasure& unit_of_measure) {
+    os << conversions::unit_of_measure_to_string(unit_of_measure);
+    return os;
+}
+
+// from: RemoteStartTransactionRequest
+namespace conversions {
+const std::string charging_profile_kind_type_to_string(ChargingProfileKindType e) {
+    switch (e) {
+    case ChargingProfileKindType::Absolute:
+        return "Absolute";
+    case ChargingProfileKindType::Recurring:
+        return "Recurring";
+    case ChargingProfileKindType::Relative:
+        return "Relative";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileKindType");
+}
+
+const ChargingProfileKindType string_to_charging_profile_kind_type(std::string s) {
+    if (s == "Absolute") {
+        return ChargingProfileKindType::Absolute;
+    }
+    if (s == "Recurring") {
+        return ChargingProfileKindType::Recurring;
+    }
+    if (s == "Relative") {
+        return ChargingProfileKindType::Relative;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingProfileKindType");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargingProfileKindType& charging_profile_kind_type) {
+    os << conversions::charging_profile_kind_type_to_string(charging_profile_kind_type);
+    return os;
+}
+
+// from: RemoteStartTransactionRequest
+namespace conversions {
+const std::string recurrency_kind_type_to_string(RecurrencyKindType e) {
+    switch (e) {
+    case RecurrencyKindType::Daily:
+        return "Daily";
+    case RecurrencyKindType::Weekly:
+        return "Weekly";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type RecurrencyKindType");
+}
+
+const RecurrencyKindType string_to_recurrency_kind_type(std::string s) {
+    if (s == "Daily") {
+        return RecurrencyKindType::Daily;
+    }
+    if (s == "Weekly") {
+        return RecurrencyKindType::Weekly;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RecurrencyKindType");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const RecurrencyKindType& recurrency_kind_type) {
+    os << conversions::recurrency_kind_type_to_string(recurrency_kind_type);
+    return os;
+}
+
+// from: RemoteStartTransactionResponse
+namespace conversions {
+const std::string remote_start_stop_status_to_string(RemoteStartStopStatus e) {
+    switch (e) {
+    case RemoteStartStopStatus::Accepted:
+        return "Accepted";
+    case RemoteStartStopStatus::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type RemoteStartStopStatus");
+}
+
+const RemoteStartStopStatus string_to_remote_start_stop_status(std::string s) {
+    if (s == "Accepted") {
+        return RemoteStartStopStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return RemoteStartStopStatus::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RemoteStartStopStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const RemoteStartStopStatus& remote_start_stop_status) {
+    os << conversions::remote_start_stop_status_to_string(remote_start_stop_status);
+    return os;
+}
+
+// from: ReserveNowResponse
+namespace conversions {
+const std::string reservation_status_to_string(ReservationStatus e) {
+    switch (e) {
+    case ReservationStatus::Accepted:
+        return "Accepted";
+    case ReservationStatus::Faulted:
+        return "Faulted";
+    case ReservationStatus::Occupied:
+        return "Occupied";
+    case ReservationStatus::Rejected:
+        return "Rejected";
+    case ReservationStatus::Unavailable:
+        return "Unavailable";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ReservationStatus");
+}
+
+const ReservationStatus string_to_reservation_status(std::string s) {
+    if (s == "Accepted") {
+        return ReservationStatus::Accepted;
+    }
+    if (s == "Faulted") {
+        return ReservationStatus::Faulted;
+    }
+    if (s == "Occupied") {
+        return ReservationStatus::Occupied;
+    }
+    if (s == "Rejected") {
+        return ReservationStatus::Rejected;
+    }
+    if (s == "Unavailable") {
+        return ReservationStatus::Unavailable;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReservationStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ReservationStatus& reservation_status) {
+    os << conversions::reservation_status_to_string(reservation_status);
+    return os;
+}
+
+// from: ResetRequest
+namespace conversions {
+const std::string reset_type_to_string(ResetType e) {
+    switch (e) {
+    case ResetType::Hard:
+        return "Hard";
+    case ResetType::Soft:
+        return "Soft";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ResetType");
+}
+
+const ResetType string_to_reset_type(std::string s) {
+    if (s == "Hard") {
+        return ResetType::Hard;
+    }
+    if (s == "Soft") {
+        return ResetType::Soft;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ResetType");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ResetType& reset_type) {
+    os << conversions::reset_type_to_string(reset_type);
+    return os;
+}
+
+// from: ResetResponse
+namespace conversions {
+const std::string reset_status_to_string(ResetStatus e) {
+    switch (e) {
+    case ResetStatus::Accepted:
+        return "Accepted";
+    case ResetStatus::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ResetStatus");
+}
+
+const ResetStatus string_to_reset_status(std::string s) {
+    if (s == "Accepted") {
+        return ResetStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return ResetStatus::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ResetStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ResetStatus& reset_status) {
+    os << conversions::reset_status_to_string(reset_status);
+    return os;
+}
+
+// from: SendLocalListRequest
+namespace conversions {
+const std::string update_type_to_string(UpdateType e) {
+    switch (e) {
+    case UpdateType::Differential:
+        return "Differential";
+    case UpdateType::Full:
+        return "Full";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type UpdateType");
+}
+
+const UpdateType string_to_update_type(std::string s) {
+    if (s == "Differential") {
+        return UpdateType::Differential;
+    }
+    if (s == "Full") {
+        return UpdateType::Full;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UpdateType");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const UpdateType& update_type) {
+    os << conversions::update_type_to_string(update_type);
+    return os;
+}
+
+// from: SendLocalListResponse
+namespace conversions {
+const std::string update_status_to_string(UpdateStatus e) {
+    switch (e) {
+    case UpdateStatus::Accepted:
+        return "Accepted";
+    case UpdateStatus::Failed:
+        return "Failed";
+    case UpdateStatus::NotSupported:
+        return "NotSupported";
+    case UpdateStatus::VersionMismatch:
+        return "VersionMismatch";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type UpdateStatus");
+}
+
+const UpdateStatus string_to_update_status(std::string s) {
+    if (s == "Accepted") {
+        return UpdateStatus::Accepted;
+    }
+    if (s == "Failed") {
+        return UpdateStatus::Failed;
+    }
+    if (s == "NotSupported") {
+        return UpdateStatus::NotSupported;
+    }
+    if (s == "VersionMismatch") {
+        return UpdateStatus::VersionMismatch;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UpdateStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const UpdateStatus& update_status) {
+    os << conversions::update_status_to_string(update_status);
+    return os;
+}
+
+// from: SetChargingProfileResponse
+namespace conversions {
+const std::string charging_profile_status_to_string(ChargingProfileStatus e) {
+    switch (e) {
+    case ChargingProfileStatus::Accepted:
+        return "Accepted";
+    case ChargingProfileStatus::Rejected:
+        return "Rejected";
+    case ChargingProfileStatus::NotSupported:
+        return "NotSupported";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileStatus");
+}
+
+const ChargingProfileStatus string_to_charging_profile_status(std::string s) {
+    if (s == "Accepted") {
+        return ChargingProfileStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return ChargingProfileStatus::Rejected;
+    }
+    if (s == "NotSupported") {
+        return ChargingProfileStatus::NotSupported;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingProfileStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargingProfileStatus& charging_profile_status) {
+    os << conversions::charging_profile_status_to_string(charging_profile_status);
+    return os;
+}
+
+// from: StatusNotificationRequest
+namespace conversions {
+const std::string charge_point_error_code_to_string(ChargePointErrorCode e) {
+    switch (e) {
+    case ChargePointErrorCode::ConnectorLockFailure:
+        return "ConnectorLockFailure";
+    case ChargePointErrorCode::EVCommunicationError:
+        return "EVCommunicationError";
+    case ChargePointErrorCode::GroundFailure:
+        return "GroundFailure";
+    case ChargePointErrorCode::HighTemperature:
+        return "HighTemperature";
+    case ChargePointErrorCode::InternalError:
+        return "InternalError";
+    case ChargePointErrorCode::LocalListConflict:
+        return "LocalListConflict";
+    case ChargePointErrorCode::NoError:
+        return "NoError";
+    case ChargePointErrorCode::OtherError:
+        return "OtherError";
+    case ChargePointErrorCode::OverCurrentFailure:
+        return "OverCurrentFailure";
+    case ChargePointErrorCode::PowerMeterFailure:
+        return "PowerMeterFailure";
+    case ChargePointErrorCode::PowerSwitchFailure:
+        return "PowerSwitchFailure";
+    case ChargePointErrorCode::ReaderFailure:
+        return "ReaderFailure";
+    case ChargePointErrorCode::ResetFailure:
+        return "ResetFailure";
+    case ChargePointErrorCode::UnderVoltage:
+        return "UnderVoltage";
+    case ChargePointErrorCode::OverVoltage:
+        return "OverVoltage";
+    case ChargePointErrorCode::WeakSignal:
+        return "WeakSignal";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargePointErrorCode");
+}
+
+const ChargePointErrorCode string_to_charge_point_error_code(std::string s) {
+    if (s == "ConnectorLockFailure") {
+        return ChargePointErrorCode::ConnectorLockFailure;
+    }
+    if (s == "EVCommunicationError") {
+        return ChargePointErrorCode::EVCommunicationError;
+    }
+    if (s == "GroundFailure") {
+        return ChargePointErrorCode::GroundFailure;
+    }
+    if (s == "HighTemperature") {
+        return ChargePointErrorCode::HighTemperature;
+    }
+    if (s == "InternalError") {
+        return ChargePointErrorCode::InternalError;
+    }
+    if (s == "LocalListConflict") {
+        return ChargePointErrorCode::LocalListConflict;
+    }
+    if (s == "NoError") {
+        return ChargePointErrorCode::NoError;
+    }
+    if (s == "OtherError") {
+        return ChargePointErrorCode::OtherError;
+    }
+    if (s == "OverCurrentFailure") {
+        return ChargePointErrorCode::OverCurrentFailure;
+    }
+    if (s == "PowerMeterFailure") {
+        return ChargePointErrorCode::PowerMeterFailure;
+    }
+    if (s == "PowerSwitchFailure") {
+        return ChargePointErrorCode::PowerSwitchFailure;
+    }
+    if (s == "ReaderFailure") {
+        return ChargePointErrorCode::ReaderFailure;
+    }
+    if (s == "ResetFailure") {
+        return ChargePointErrorCode::ResetFailure;
+    }
+    if (s == "UnderVoltage") {
+        return ChargePointErrorCode::UnderVoltage;
+    }
+    if (s == "OverVoltage") {
+        return ChargePointErrorCode::OverVoltage;
+    }
+    if (s == "WeakSignal") {
+        return ChargePointErrorCode::WeakSignal;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargePointErrorCode");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargePointErrorCode& charge_point_error_code) {
+    os << conversions::charge_point_error_code_to_string(charge_point_error_code);
+    return os;
+}
+
+// from: StatusNotificationRequest
+namespace conversions {
+const std::string charge_point_status_to_string(ChargePointStatus e) {
+    switch (e) {
+    case ChargePointStatus::Available:
+        return "Available";
+    case ChargePointStatus::Preparing:
+        return "Preparing";
+    case ChargePointStatus::Charging:
+        return "Charging";
+    case ChargePointStatus::SuspendedEVSE:
+        return "SuspendedEVSE";
+    case ChargePointStatus::SuspendedEV:
+        return "SuspendedEV";
+    case ChargePointStatus::Finishing:
+        return "Finishing";
+    case ChargePointStatus::Reserved:
+        return "Reserved";
+    case ChargePointStatus::Unavailable:
+        return "Unavailable";
+    case ChargePointStatus::Faulted:
+        return "Faulted";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargePointStatus");
+}
+
+const ChargePointStatus string_to_charge_point_status(std::string s) {
+    if (s == "Available") {
+        return ChargePointStatus::Available;
+    }
+    if (s == "Preparing") {
+        return ChargePointStatus::Preparing;
+    }
+    if (s == "Charging") {
+        return ChargePointStatus::Charging;
+    }
+    if (s == "SuspendedEVSE") {
+        return ChargePointStatus::SuspendedEVSE;
+    }
+    if (s == "SuspendedEV") {
+        return ChargePointStatus::SuspendedEV;
+    }
+    if (s == "Finishing") {
+        return ChargePointStatus::Finishing;
+    }
+    if (s == "Reserved") {
+        return ChargePointStatus::Reserved;
+    }
+    if (s == "Unavailable") {
+        return ChargePointStatus::Unavailable;
+    }
+    if (s == "Faulted") {
+        return ChargePointStatus::Faulted;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargePointStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargePointStatus& charge_point_status) {
+    os << conversions::charge_point_status_to_string(charge_point_status);
+    return os;
+}
+
+// from: StopTransactionRequest
+namespace conversions {
+const std::string reason_to_string(Reason e) {
+    switch (e) {
+    case Reason::EmergencyStop:
+        return "EmergencyStop";
+    case Reason::EVDisconnected:
+        return "EVDisconnected";
+    case Reason::HardReset:
+        return "HardReset";
+    case Reason::Local:
+        return "Local";
+    case Reason::Other:
+        return "Other";
+    case Reason::PowerLoss:
+        return "PowerLoss";
+    case Reason::Reboot:
+        return "Reboot";
+    case Reason::Remote:
+        return "Remote";
+    case Reason::SoftReset:
+        return "SoftReset";
+    case Reason::UnlockCommand:
+        return "UnlockCommand";
+    case Reason::DeAuthorized:
+        return "DeAuthorized";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type Reason");
+}
+
+const Reason string_to_reason(std::string s) {
+    if (s == "EmergencyStop") {
+        return Reason::EmergencyStop;
+    }
+    if (s == "EVDisconnected") {
+        return Reason::EVDisconnected;
+    }
+    if (s == "HardReset") {
+        return Reason::HardReset;
+    }
+    if (s == "Local") {
+        return Reason::Local;
+    }
+    if (s == "Other") {
+        return Reason::Other;
+    }
+    if (s == "PowerLoss") {
+        return Reason::PowerLoss;
+    }
+    if (s == "Reboot") {
+        return Reason::Reboot;
+    }
+    if (s == "Remote") {
+        return Reason::Remote;
+    }
+    if (s == "SoftReset") {
+        return Reason::SoftReset;
+    }
+    if (s == "UnlockCommand") {
+        return Reason::UnlockCommand;
+    }
+    if (s == "DeAuthorized") {
+        return Reason::DeAuthorized;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Reason");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const Reason& reason) {
+    os << conversions::reason_to_string(reason);
+    return os;
+}
+
+// from: TriggerMessageRequest
+namespace conversions {
+const std::string message_trigger_to_string(MessageTrigger e) {
+    switch (e) {
+    case MessageTrigger::BootNotification:
+        return "BootNotification";
+    case MessageTrigger::DiagnosticsStatusNotification:
+        return "DiagnosticsStatusNotification";
+    case MessageTrigger::FirmwareStatusNotification:
+        return "FirmwareStatusNotification";
+    case MessageTrigger::Heartbeat:
+        return "Heartbeat";
+    case MessageTrigger::MeterValues:
+        return "MeterValues";
+    case MessageTrigger::StatusNotification:
+        return "StatusNotification";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type MessageTrigger");
+}
+
+const MessageTrigger string_to_message_trigger(std::string s) {
+    if (s == "BootNotification") {
+        return MessageTrigger::BootNotification;
+    }
+    if (s == "DiagnosticsStatusNotification") {
+        return MessageTrigger::DiagnosticsStatusNotification;
+    }
+    if (s == "FirmwareStatusNotification") {
+        return MessageTrigger::FirmwareStatusNotification;
+    }
+    if (s == "Heartbeat") {
+        return MessageTrigger::Heartbeat;
+    }
+    if (s == "MeterValues") {
+        return MessageTrigger::MeterValues;
+    }
+    if (s == "StatusNotification") {
+        return MessageTrigger::StatusNotification;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageTrigger");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const MessageTrigger& message_trigger) {
+    os << conversions::message_trigger_to_string(message_trigger);
+    return os;
+}
+
+// from: TriggerMessageResponse
+namespace conversions {
+const std::string trigger_message_status_to_string(TriggerMessageStatus e) {
+    switch (e) {
+    case TriggerMessageStatus::Accepted:
+        return "Accepted";
+    case TriggerMessageStatus::Rejected:
+        return "Rejected";
+    case TriggerMessageStatus::NotImplemented:
+        return "NotImplemented";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type TriggerMessageStatus");
+}
+
+const TriggerMessageStatus string_to_trigger_message_status(std::string s) {
+    if (s == "Accepted") {
+        return TriggerMessageStatus::Accepted;
+    }
+    if (s == "Rejected") {
+        return TriggerMessageStatus::Rejected;
+    }
+    if (s == "NotImplemented") {
+        return TriggerMessageStatus::NotImplemented;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type TriggerMessageStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const TriggerMessageStatus& trigger_message_status) {
+    os << conversions::trigger_message_status_to_string(trigger_message_status);
+    return os;
+}
+
+// from: UnlockConnectorResponse
+namespace conversions {
+const std::string unlock_status_to_string(UnlockStatus e) {
+    switch (e) {
+    case UnlockStatus::Unlocked:
+        return "Unlocked";
+    case UnlockStatus::UnlockFailed:
+        return "UnlockFailed";
+    case UnlockStatus::NotSupported:
+        return "NotSupported";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type UnlockStatus");
+}
+
+const UnlockStatus string_to_unlock_status(std::string s) {
+    if (s == "Unlocked") {
+        return UnlockStatus::Unlocked;
+    }
+    if (s == "UnlockFailed") {
+        return UnlockStatus::UnlockFailed;
+    }
+    if (s == "NotSupported") {
+        return UnlockStatus::NotSupported;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UnlockStatus");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const UnlockStatus& unlock_status) {
+    os << conversions::unlock_status_to_string(unlock_status);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/enums.cpp
+++ b/lib/ocpp1_6/enums.cpp
@@ -8,7 +8,7 @@ namespace ocpp1_6 {
 
 // from: AuthorizeResponse
 namespace conversions {
-const std::string authorization_status_to_string(AuthorizationStatus e) {
+std::string authorization_status_to_string(AuthorizationStatus e) {
     switch (e) {
     case AuthorizationStatus::Accepted:
         return "Accepted";
@@ -25,7 +25,7 @@ const std::string authorization_status_to_string(AuthorizationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type AuthorizationStatus");
 }
 
-const AuthorizationStatus string_to_authorization_status(std::string s) {
+AuthorizationStatus string_to_authorization_status(std::string s) {
     if (s == "Accepted") {
         return AuthorizationStatus::Accepted;
     }
@@ -53,7 +53,7 @@ std::ostream& operator<<(std::ostream& os, const AuthorizationStatus& authorizat
 
 // from: BootNotificationResponse
 namespace conversions {
-const std::string registration_status_to_string(RegistrationStatus e) {
+std::string registration_status_to_string(RegistrationStatus e) {
     switch (e) {
     case RegistrationStatus::Accepted:
         return "Accepted";
@@ -66,7 +66,7 @@ const std::string registration_status_to_string(RegistrationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type RegistrationStatus");
 }
 
-const RegistrationStatus string_to_registration_status(std::string s) {
+RegistrationStatus string_to_registration_status(std::string s) {
     if (s == "Accepted") {
         return RegistrationStatus::Accepted;
     }
@@ -88,7 +88,7 @@ std::ostream& operator<<(std::ostream& os, const RegistrationStatus& registratio
 
 // from: CancelReservationResponse
 namespace conversions {
-const std::string cancel_reservation_status_to_string(CancelReservationStatus e) {
+std::string cancel_reservation_status_to_string(CancelReservationStatus e) {
     switch (e) {
     case CancelReservationStatus::Accepted:
         return "Accepted";
@@ -99,7 +99,7 @@ const std::string cancel_reservation_status_to_string(CancelReservationStatus e)
     throw std::out_of_range("No known string conversion for provided enum of type CancelReservationStatus");
 }
 
-const CancelReservationStatus string_to_cancel_reservation_status(std::string s) {
+CancelReservationStatus string_to_cancel_reservation_status(std::string s) {
     if (s == "Accepted") {
         return CancelReservationStatus::Accepted;
     }
@@ -118,7 +118,7 @@ std::ostream& operator<<(std::ostream& os, const CancelReservationStatus& cancel
 
 // from: ChangeAvailabilityRequest
 namespace conversions {
-const std::string availability_type_to_string(AvailabilityType e) {
+std::string availability_type_to_string(AvailabilityType e) {
     switch (e) {
     case AvailabilityType::Inoperative:
         return "Inoperative";
@@ -129,7 +129,7 @@ const std::string availability_type_to_string(AvailabilityType e) {
     throw std::out_of_range("No known string conversion for provided enum of type AvailabilityType");
 }
 
-const AvailabilityType string_to_availability_type(std::string s) {
+AvailabilityType string_to_availability_type(std::string s) {
     if (s == "Inoperative") {
         return AvailabilityType::Inoperative;
     }
@@ -148,7 +148,7 @@ std::ostream& operator<<(std::ostream& os, const AvailabilityType& availability_
 
 // from: ChangeAvailabilityResponse
 namespace conversions {
-const std::string availability_status_to_string(AvailabilityStatus e) {
+std::string availability_status_to_string(AvailabilityStatus e) {
     switch (e) {
     case AvailabilityStatus::Accepted:
         return "Accepted";
@@ -161,7 +161,7 @@ const std::string availability_status_to_string(AvailabilityStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type AvailabilityStatus");
 }
 
-const AvailabilityStatus string_to_availability_status(std::string s) {
+AvailabilityStatus string_to_availability_status(std::string s) {
     if (s == "Accepted") {
         return AvailabilityStatus::Accepted;
     }
@@ -183,7 +183,7 @@ std::ostream& operator<<(std::ostream& os, const AvailabilityStatus& availabilit
 
 // from: ChangeConfigurationResponse
 namespace conversions {
-const std::string configuration_status_to_string(ConfigurationStatus e) {
+std::string configuration_status_to_string(ConfigurationStatus e) {
     switch (e) {
     case ConfigurationStatus::Accepted:
         return "Accepted";
@@ -198,7 +198,7 @@ const std::string configuration_status_to_string(ConfigurationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ConfigurationStatus");
 }
 
-const ConfigurationStatus string_to_configuration_status(std::string s) {
+ConfigurationStatus string_to_configuration_status(std::string s) {
     if (s == "Accepted") {
         return ConfigurationStatus::Accepted;
     }
@@ -223,7 +223,7 @@ std::ostream& operator<<(std::ostream& os, const ConfigurationStatus& configurat
 
 // from: ClearCacheResponse
 namespace conversions {
-const std::string clear_cache_status_to_string(ClearCacheStatus e) {
+std::string clear_cache_status_to_string(ClearCacheStatus e) {
     switch (e) {
     case ClearCacheStatus::Accepted:
         return "Accepted";
@@ -234,7 +234,7 @@ const std::string clear_cache_status_to_string(ClearCacheStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ClearCacheStatus");
 }
 
-const ClearCacheStatus string_to_clear_cache_status(std::string s) {
+ClearCacheStatus string_to_clear_cache_status(std::string s) {
     if (s == "Accepted") {
         return ClearCacheStatus::Accepted;
     }
@@ -253,7 +253,7 @@ std::ostream& operator<<(std::ostream& os, const ClearCacheStatus& clear_cache_s
 
 // from: ClearChargingProfileRequest
 namespace conversions {
-const std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e) {
+std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e) {
     switch (e) {
     case ChargingProfilePurposeType::ChargePointMaxProfile:
         return "ChargePointMaxProfile";
@@ -266,7 +266,7 @@ const std::string charging_profile_purpose_type_to_string(ChargingProfilePurpose
     throw std::out_of_range("No known string conversion for provided enum of type ChargingProfilePurposeType");
 }
 
-const ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s) {
+ChargingProfilePurposeType string_to_charging_profile_purpose_type(std::string s) {
     if (s == "ChargePointMaxProfile") {
         return ChargingProfilePurposeType::ChargePointMaxProfile;
     }
@@ -289,7 +289,7 @@ std::ostream& operator<<(std::ostream& os, const ChargingProfilePurposeType& cha
 
 // from: ClearChargingProfileResponse
 namespace conversions {
-const std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e) {
+std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e) {
     switch (e) {
     case ClearChargingProfileStatus::Accepted:
         return "Accepted";
@@ -300,7 +300,7 @@ const std::string clear_charging_profile_status_to_string(ClearChargingProfileSt
     throw std::out_of_range("No known string conversion for provided enum of type ClearChargingProfileStatus");
 }
 
-const ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s) {
+ClearChargingProfileStatus string_to_clear_charging_profile_status(std::string s) {
     if (s == "Accepted") {
         return ClearChargingProfileStatus::Accepted;
     }
@@ -320,7 +320,7 @@ std::ostream& operator<<(std::ostream& os, const ClearChargingProfileStatus& cle
 
 // from: DataTransferResponse
 namespace conversions {
-const std::string data_transfer_status_to_string(DataTransferStatus e) {
+std::string data_transfer_status_to_string(DataTransferStatus e) {
     switch (e) {
     case DataTransferStatus::Accepted:
         return "Accepted";
@@ -335,7 +335,7 @@ const std::string data_transfer_status_to_string(DataTransferStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type DataTransferStatus");
 }
 
-const DataTransferStatus string_to_data_transfer_status(std::string s) {
+DataTransferStatus string_to_data_transfer_status(std::string s) {
     if (s == "Accepted") {
         return DataTransferStatus::Accepted;
     }
@@ -360,7 +360,7 @@ std::ostream& operator<<(std::ostream& os, const DataTransferStatus& data_transf
 
 // from: DiagnosticsStatusNotificationRequest
 namespace conversions {
-const std::string diagnostics_status_to_string(DiagnosticsStatus e) {
+std::string diagnostics_status_to_string(DiagnosticsStatus e) {
     switch (e) {
     case DiagnosticsStatus::Idle:
         return "Idle";
@@ -375,7 +375,7 @@ const std::string diagnostics_status_to_string(DiagnosticsStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type DiagnosticsStatus");
 }
 
-const DiagnosticsStatus string_to_diagnostics_status(std::string s) {
+DiagnosticsStatus string_to_diagnostics_status(std::string s) {
     if (s == "Idle") {
         return DiagnosticsStatus::Idle;
     }
@@ -400,7 +400,7 @@ std::ostream& operator<<(std::ostream& os, const DiagnosticsStatus& diagnostics_
 
 // from: FirmwareStatusNotificationRequest
 namespace conversions {
-const std::string firmware_status_to_string(FirmwareStatus e) {
+std::string firmware_status_to_string(FirmwareStatus e) {
     switch (e) {
     case FirmwareStatus::Downloaded:
         return "Downloaded";
@@ -421,7 +421,7 @@ const std::string firmware_status_to_string(FirmwareStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type FirmwareStatus");
 }
 
-const FirmwareStatus string_to_firmware_status(std::string s) {
+FirmwareStatus string_to_firmware_status(std::string s) {
     if (s == "Downloaded") {
         return FirmwareStatus::Downloaded;
     }
@@ -455,7 +455,7 @@ std::ostream& operator<<(std::ostream& os, const FirmwareStatus& firmware_status
 
 // from: GetCompositeScheduleRequest
 namespace conversions {
-const std::string charging_rate_unit_to_string(ChargingRateUnit e) {
+std::string charging_rate_unit_to_string(ChargingRateUnit e) {
     switch (e) {
     case ChargingRateUnit::A:
         return "A";
@@ -466,7 +466,7 @@ const std::string charging_rate_unit_to_string(ChargingRateUnit e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargingRateUnit");
 }
 
-const ChargingRateUnit string_to_charging_rate_unit(std::string s) {
+ChargingRateUnit string_to_charging_rate_unit(std::string s) {
     if (s == "A") {
         return ChargingRateUnit::A;
     }
@@ -485,7 +485,7 @@ std::ostream& operator<<(std::ostream& os, const ChargingRateUnit& charging_rate
 
 // from: GetCompositeScheduleResponse
 namespace conversions {
-const std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e) {
+std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e) {
     switch (e) {
     case GetCompositeScheduleStatus::Accepted:
         return "Accepted";
@@ -496,7 +496,7 @@ const std::string get_composite_schedule_status_to_string(GetCompositeScheduleSt
     throw std::out_of_range("No known string conversion for provided enum of type GetCompositeScheduleStatus");
 }
 
-const GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s) {
+GetCompositeScheduleStatus string_to_get_composite_schedule_status(std::string s) {
     if (s == "Accepted") {
         return GetCompositeScheduleStatus::Accepted;
     }
@@ -516,7 +516,7 @@ std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleStatus& get
 
 // from: MeterValuesRequest
 namespace conversions {
-const std::string reading_context_to_string(ReadingContext e) {
+std::string reading_context_to_string(ReadingContext e) {
     switch (e) {
     case ReadingContext::Interruption_Begin:
         return "Interruption.Begin";
@@ -539,7 +539,7 @@ const std::string reading_context_to_string(ReadingContext e) {
     throw std::out_of_range("No known string conversion for provided enum of type ReadingContext");
 }
 
-const ReadingContext string_to_reading_context(std::string s) {
+ReadingContext string_to_reading_context(std::string s) {
     if (s == "Interruption.Begin") {
         return ReadingContext::Interruption_Begin;
     }
@@ -576,7 +576,7 @@ std::ostream& operator<<(std::ostream& os, const ReadingContext& reading_context
 
 // from: MeterValuesRequest
 namespace conversions {
-const std::string value_format_to_string(ValueFormat e) {
+std::string value_format_to_string(ValueFormat e) {
     switch (e) {
     case ValueFormat::Raw:
         return "Raw";
@@ -587,7 +587,7 @@ const std::string value_format_to_string(ValueFormat e) {
     throw std::out_of_range("No known string conversion for provided enum of type ValueFormat");
 }
 
-const ValueFormat string_to_value_format(std::string s) {
+ValueFormat string_to_value_format(std::string s) {
     if (s == "Raw") {
         return ValueFormat::Raw;
     }
@@ -606,7 +606,7 @@ std::ostream& operator<<(std::ostream& os, const ValueFormat& value_format) {
 
 // from: MeterValuesRequest
 namespace conversions {
-const std::string measurand_to_string(Measurand e) {
+std::string measurand_to_string(Measurand e) {
     switch (e) {
     case Measurand::Energy_Active_Export_Register:
         return "Energy.Active.Export.Register";
@@ -657,7 +657,7 @@ const std::string measurand_to_string(Measurand e) {
     throw std::out_of_range("No known string conversion for provided enum of type Measurand");
 }
 
-const Measurand string_to_measurand(std::string s) {
+Measurand string_to_measurand(std::string s) {
     if (s == "Energy.Active.Export.Register") {
         return Measurand::Energy_Active_Export_Register;
     }
@@ -736,7 +736,7 @@ std::ostream& operator<<(std::ostream& os, const Measurand& measurand) {
 
 // from: MeterValuesRequest
 namespace conversions {
-const std::string phase_to_string(Phase e) {
+std::string phase_to_string(Phase e) {
     switch (e) {
     case Phase::L1:
         return "L1";
@@ -763,7 +763,7 @@ const std::string phase_to_string(Phase e) {
     throw std::out_of_range("No known string conversion for provided enum of type Phase");
 }
 
-const Phase string_to_phase(std::string s) {
+Phase string_to_phase(std::string s) {
     if (s == "L1") {
         return Phase::L1;
     }
@@ -806,7 +806,7 @@ std::ostream& operator<<(std::ostream& os, const Phase& phase) {
 
 // from: MeterValuesRequest
 namespace conversions {
-const std::string location_to_string(Location e) {
+std::string location_to_string(Location e) {
     switch (e) {
     case Location::Cable:
         return "Cable";
@@ -823,7 +823,7 @@ const std::string location_to_string(Location e) {
     throw std::out_of_range("No known string conversion for provided enum of type Location");
 }
 
-const Location string_to_location(std::string s) {
+Location string_to_location(std::string s) {
     if (s == "Cable") {
         return Location::Cable;
     }
@@ -851,7 +851,7 @@ std::ostream& operator<<(std::ostream& os, const Location& location) {
 
 // from: MeterValuesRequest
 namespace conversions {
-const std::string unit_of_measure_to_string(UnitOfMeasure e) {
+std::string unit_of_measure_to_string(UnitOfMeasure e) {
     switch (e) {
     case UnitOfMeasure::Wh:
         return "Wh";
@@ -892,7 +892,7 @@ const std::string unit_of_measure_to_string(UnitOfMeasure e) {
     throw std::out_of_range("No known string conversion for provided enum of type UnitOfMeasure");
 }
 
-const UnitOfMeasure string_to_unit_of_measure(std::string s) {
+UnitOfMeasure string_to_unit_of_measure(std::string s) {
     if (s == "Wh") {
         return UnitOfMeasure::Wh;
     }
@@ -956,7 +956,7 @@ std::ostream& operator<<(std::ostream& os, const UnitOfMeasure& unit_of_measure)
 
 // from: RemoteStartTransactionRequest
 namespace conversions {
-const std::string charging_profile_kind_type_to_string(ChargingProfileKindType e) {
+std::string charging_profile_kind_type_to_string(ChargingProfileKindType e) {
     switch (e) {
     case ChargingProfileKindType::Absolute:
         return "Absolute";
@@ -969,7 +969,7 @@ const std::string charging_profile_kind_type_to_string(ChargingProfileKindType e
     throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileKindType");
 }
 
-const ChargingProfileKindType string_to_charging_profile_kind_type(std::string s) {
+ChargingProfileKindType string_to_charging_profile_kind_type(std::string s) {
     if (s == "Absolute") {
         return ChargingProfileKindType::Absolute;
     }
@@ -991,7 +991,7 @@ std::ostream& operator<<(std::ostream& os, const ChargingProfileKindType& chargi
 
 // from: RemoteStartTransactionRequest
 namespace conversions {
-const std::string recurrency_kind_type_to_string(RecurrencyKindType e) {
+std::string recurrency_kind_type_to_string(RecurrencyKindType e) {
     switch (e) {
     case RecurrencyKindType::Daily:
         return "Daily";
@@ -1002,7 +1002,7 @@ const std::string recurrency_kind_type_to_string(RecurrencyKindType e) {
     throw std::out_of_range("No known string conversion for provided enum of type RecurrencyKindType");
 }
 
-const RecurrencyKindType string_to_recurrency_kind_type(std::string s) {
+RecurrencyKindType string_to_recurrency_kind_type(std::string s) {
     if (s == "Daily") {
         return RecurrencyKindType::Daily;
     }
@@ -1021,7 +1021,7 @@ std::ostream& operator<<(std::ostream& os, const RecurrencyKindType& recurrency_
 
 // from: RemoteStartTransactionResponse
 namespace conversions {
-const std::string remote_start_stop_status_to_string(RemoteStartStopStatus e) {
+std::string remote_start_stop_status_to_string(RemoteStartStopStatus e) {
     switch (e) {
     case RemoteStartStopStatus::Accepted:
         return "Accepted";
@@ -1032,7 +1032,7 @@ const std::string remote_start_stop_status_to_string(RemoteStartStopStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type RemoteStartStopStatus");
 }
 
-const RemoteStartStopStatus string_to_remote_start_stop_status(std::string s) {
+RemoteStartStopStatus string_to_remote_start_stop_status(std::string s) {
     if (s == "Accepted") {
         return RemoteStartStopStatus::Accepted;
     }
@@ -1051,7 +1051,7 @@ std::ostream& operator<<(std::ostream& os, const RemoteStartStopStatus& remote_s
 
 // from: ReserveNowResponse
 namespace conversions {
-const std::string reservation_status_to_string(ReservationStatus e) {
+std::string reservation_status_to_string(ReservationStatus e) {
     switch (e) {
     case ReservationStatus::Accepted:
         return "Accepted";
@@ -1068,7 +1068,7 @@ const std::string reservation_status_to_string(ReservationStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ReservationStatus");
 }
 
-const ReservationStatus string_to_reservation_status(std::string s) {
+ReservationStatus string_to_reservation_status(std::string s) {
     if (s == "Accepted") {
         return ReservationStatus::Accepted;
     }
@@ -1096,7 +1096,7 @@ std::ostream& operator<<(std::ostream& os, const ReservationStatus& reservation_
 
 // from: ResetRequest
 namespace conversions {
-const std::string reset_type_to_string(ResetType e) {
+std::string reset_type_to_string(ResetType e) {
     switch (e) {
     case ResetType::Hard:
         return "Hard";
@@ -1107,7 +1107,7 @@ const std::string reset_type_to_string(ResetType e) {
     throw std::out_of_range("No known string conversion for provided enum of type ResetType");
 }
 
-const ResetType string_to_reset_type(std::string s) {
+ResetType string_to_reset_type(std::string s) {
     if (s == "Hard") {
         return ResetType::Hard;
     }
@@ -1126,7 +1126,7 @@ std::ostream& operator<<(std::ostream& os, const ResetType& reset_type) {
 
 // from: ResetResponse
 namespace conversions {
-const std::string reset_status_to_string(ResetStatus e) {
+std::string reset_status_to_string(ResetStatus e) {
     switch (e) {
     case ResetStatus::Accepted:
         return "Accepted";
@@ -1137,7 +1137,7 @@ const std::string reset_status_to_string(ResetStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ResetStatus");
 }
 
-const ResetStatus string_to_reset_status(std::string s) {
+ResetStatus string_to_reset_status(std::string s) {
     if (s == "Accepted") {
         return ResetStatus::Accepted;
     }
@@ -1156,7 +1156,7 @@ std::ostream& operator<<(std::ostream& os, const ResetStatus& reset_status) {
 
 // from: SendLocalListRequest
 namespace conversions {
-const std::string update_type_to_string(UpdateType e) {
+std::string update_type_to_string(UpdateType e) {
     switch (e) {
     case UpdateType::Differential:
         return "Differential";
@@ -1167,7 +1167,7 @@ const std::string update_type_to_string(UpdateType e) {
     throw std::out_of_range("No known string conversion for provided enum of type UpdateType");
 }
 
-const UpdateType string_to_update_type(std::string s) {
+UpdateType string_to_update_type(std::string s) {
     if (s == "Differential") {
         return UpdateType::Differential;
     }
@@ -1186,7 +1186,7 @@ std::ostream& operator<<(std::ostream& os, const UpdateType& update_type) {
 
 // from: SendLocalListResponse
 namespace conversions {
-const std::string update_status_to_string(UpdateStatus e) {
+std::string update_status_to_string(UpdateStatus e) {
     switch (e) {
     case UpdateStatus::Accepted:
         return "Accepted";
@@ -1201,7 +1201,7 @@ const std::string update_status_to_string(UpdateStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type UpdateStatus");
 }
 
-const UpdateStatus string_to_update_status(std::string s) {
+UpdateStatus string_to_update_status(std::string s) {
     if (s == "Accepted") {
         return UpdateStatus::Accepted;
     }
@@ -1226,7 +1226,7 @@ std::ostream& operator<<(std::ostream& os, const UpdateStatus& update_status) {
 
 // from: SetChargingProfileResponse
 namespace conversions {
-const std::string charging_profile_status_to_string(ChargingProfileStatus e) {
+std::string charging_profile_status_to_string(ChargingProfileStatus e) {
     switch (e) {
     case ChargingProfileStatus::Accepted:
         return "Accepted";
@@ -1239,7 +1239,7 @@ const std::string charging_profile_status_to_string(ChargingProfileStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileStatus");
 }
 
-const ChargingProfileStatus string_to_charging_profile_status(std::string s) {
+ChargingProfileStatus string_to_charging_profile_status(std::string s) {
     if (s == "Accepted") {
         return ChargingProfileStatus::Accepted;
     }
@@ -1261,7 +1261,7 @@ std::ostream& operator<<(std::ostream& os, const ChargingProfileStatus& charging
 
 // from: StatusNotificationRequest
 namespace conversions {
-const std::string charge_point_error_code_to_string(ChargePointErrorCode e) {
+std::string charge_point_error_code_to_string(ChargePointErrorCode e) {
     switch (e) {
     case ChargePointErrorCode::ConnectorLockFailure:
         return "ConnectorLockFailure";
@@ -1300,7 +1300,7 @@ const std::string charge_point_error_code_to_string(ChargePointErrorCode e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargePointErrorCode");
 }
 
-const ChargePointErrorCode string_to_charge_point_error_code(std::string s) {
+ChargePointErrorCode string_to_charge_point_error_code(std::string s) {
     if (s == "ConnectorLockFailure") {
         return ChargePointErrorCode::ConnectorLockFailure;
     }
@@ -1361,7 +1361,7 @@ std::ostream& operator<<(std::ostream& os, const ChargePointErrorCode& charge_po
 
 // from: StatusNotificationRequest
 namespace conversions {
-const std::string charge_point_status_to_string(ChargePointStatus e) {
+std::string charge_point_status_to_string(ChargePointStatus e) {
     switch (e) {
     case ChargePointStatus::Available:
         return "Available";
@@ -1386,7 +1386,7 @@ const std::string charge_point_status_to_string(ChargePointStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type ChargePointStatus");
 }
 
-const ChargePointStatus string_to_charge_point_status(std::string s) {
+ChargePointStatus string_to_charge_point_status(std::string s) {
     if (s == "Available") {
         return ChargePointStatus::Available;
     }
@@ -1426,7 +1426,7 @@ std::ostream& operator<<(std::ostream& os, const ChargePointStatus& charge_point
 
 // from: StopTransactionRequest
 namespace conversions {
-const std::string reason_to_string(Reason e) {
+std::string reason_to_string(Reason e) {
     switch (e) {
     case Reason::EmergencyStop:
         return "EmergencyStop";
@@ -1455,7 +1455,7 @@ const std::string reason_to_string(Reason e) {
     throw std::out_of_range("No known string conversion for provided enum of type Reason");
 }
 
-const Reason string_to_reason(std::string s) {
+Reason string_to_reason(std::string s) {
     if (s == "EmergencyStop") {
         return Reason::EmergencyStop;
     }
@@ -1501,7 +1501,7 @@ std::ostream& operator<<(std::ostream& os, const Reason& reason) {
 
 // from: TriggerMessageRequest
 namespace conversions {
-const std::string message_trigger_to_string(MessageTrigger e) {
+std::string message_trigger_to_string(MessageTrigger e) {
     switch (e) {
     case MessageTrigger::BootNotification:
         return "BootNotification";
@@ -1520,7 +1520,7 @@ const std::string message_trigger_to_string(MessageTrigger e) {
     throw std::out_of_range("No known string conversion for provided enum of type MessageTrigger");
 }
 
-const MessageTrigger string_to_message_trigger(std::string s) {
+MessageTrigger string_to_message_trigger(std::string s) {
     if (s == "BootNotification") {
         return MessageTrigger::BootNotification;
     }
@@ -1551,7 +1551,7 @@ std::ostream& operator<<(std::ostream& os, const MessageTrigger& message_trigger
 
 // from: TriggerMessageResponse
 namespace conversions {
-const std::string trigger_message_status_to_string(TriggerMessageStatus e) {
+std::string trigger_message_status_to_string(TriggerMessageStatus e) {
     switch (e) {
     case TriggerMessageStatus::Accepted:
         return "Accepted";
@@ -1564,7 +1564,7 @@ const std::string trigger_message_status_to_string(TriggerMessageStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type TriggerMessageStatus");
 }
 
-const TriggerMessageStatus string_to_trigger_message_status(std::string s) {
+TriggerMessageStatus string_to_trigger_message_status(std::string s) {
     if (s == "Accepted") {
         return TriggerMessageStatus::Accepted;
     }
@@ -1586,7 +1586,7 @@ std::ostream& operator<<(std::ostream& os, const TriggerMessageStatus& trigger_m
 
 // from: UnlockConnectorResponse
 namespace conversions {
-const std::string unlock_status_to_string(UnlockStatus e) {
+std::string unlock_status_to_string(UnlockStatus e) {
     switch (e) {
     case UnlockStatus::Unlocked:
         return "Unlocked";
@@ -1599,7 +1599,7 @@ const std::string unlock_status_to_string(UnlockStatus e) {
     throw std::out_of_range("No known string conversion for provided enum of type UnlockStatus");
 }
 
-const UnlockStatus string_to_unlock_status(std::string s) {
+UnlockStatus string_to_unlock_status(std::string s) {
     if (s == "Unlocked") {
         return UnlockStatus::Unlocked;
     }

--- a/lib/ocpp1_6/message_queue.cpp
+++ b/lib/ocpp1_6/message_queue.cpp
@@ -2,6 +2,8 @@
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include <ocpp1_6/message_queue.hpp>
 
+#include <everest/logging.hpp>
+
 namespace ocpp1_6 {
 
 MessageQueue::MessageQueue(std::shared_ptr<ChargePointConfiguration> configuration,

--- a/lib/ocpp1_6/message_queue.cpp
+++ b/lib/ocpp1_6/message_queue.cpp
@@ -136,8 +136,7 @@ MessageQueue::MessageQueue(std::shared_ptr<ChargePointConfiguration> configurati
 }
 
 MessageId MessageQueue::getMessageId(const json::array_t& json_message) {
-    std::string messageId = json_message.at(MESSAGE_ID);
-    return messageId;
+    return MessageId(json_message.at(MESSAGE_ID));
 }
 
 MessageTypeId MessageQueue::getMessageTypeId(const json::array_t& json_message) {

--- a/lib/ocpp1_6/message_queue.cpp
+++ b/lib/ocpp1_6/message_queue.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/message_queue.hpp>
 
 #include <everest/logging.hpp>

--- a/lib/ocpp1_6/messages/Authorize.cpp
+++ b/lib/ocpp1_6/messages/Authorize.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/Authorize.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string AuthorizeRequest::get_type() const {
+    return "Authorize";
+}
+
+void to_json(json& j, const AuthorizeRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"idTag", k.idTag},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, AuthorizeRequest& k) {
+    // the required parts of the message
+    k.idTag = j.at("idTag");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given AuthorizeRequest \p k to the given output stream \p os
+/// \returns an output stream with the AuthorizeRequest written to
+std::ostream& operator<<(std::ostream& os, const AuthorizeRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string AuthorizeResponse::get_type() const {
+    return "AuthorizeResponse";
+}
+
+void to_json(json& j, const AuthorizeResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"idTagInfo", k.idTagInfo},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, AuthorizeResponse& k) {
+    // the required parts of the message
+    k.idTagInfo = j.at("idTagInfo");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given AuthorizeResponse \p k to the given output stream \p os
+/// \returns an output stream with the AuthorizeResponse written to
+std::ostream& operator<<(std::ostream& os, const AuthorizeResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/BootNotification.cpp
+++ b/lib/ocpp1_6/messages/BootNotification.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/BootNotification.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string BootNotificationRequest::get_type() const {
+    return "BootNotification";
+}
+
+void to_json(json& j, const BootNotificationRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"chargePointVendor", k.chargePointVendor},
+        {"chargePointModel", k.chargePointModel},
+    };
+    // the optional parts of the message
+    if (k.chargePointSerialNumber) {
+        j["chargePointSerialNumber"] = k.chargePointSerialNumber.value();
+    }
+    if (k.chargeBoxSerialNumber) {
+        j["chargeBoxSerialNumber"] = k.chargeBoxSerialNumber.value();
+    }
+    if (k.firmwareVersion) {
+        j["firmwareVersion"] = k.firmwareVersion.value();
+    }
+    if (k.iccid) {
+        j["iccid"] = k.iccid.value();
+    }
+    if (k.imsi) {
+        j["imsi"] = k.imsi.value();
+    }
+    if (k.meterType) {
+        j["meterType"] = k.meterType.value();
+    }
+    if (k.meterSerialNumber) {
+        j["meterSerialNumber"] = k.meterSerialNumber.value();
+    }
+}
+
+void from_json(const json& j, BootNotificationRequest& k) {
+    // the required parts of the message
+    k.chargePointVendor = j.at("chargePointVendor");
+    k.chargePointModel = j.at("chargePointModel");
+
+    // the optional parts of the message
+    if (j.contains("chargePointSerialNumber")) {
+        k.chargePointSerialNumber.emplace(j.at("chargePointSerialNumber"));
+    }
+    if (j.contains("chargeBoxSerialNumber")) {
+        k.chargeBoxSerialNumber.emplace(j.at("chargeBoxSerialNumber"));
+    }
+    if (j.contains("firmwareVersion")) {
+        k.firmwareVersion.emplace(j.at("firmwareVersion"));
+    }
+    if (j.contains("iccid")) {
+        k.iccid.emplace(j.at("iccid"));
+    }
+    if (j.contains("imsi")) {
+        k.imsi.emplace(j.at("imsi"));
+    }
+    if (j.contains("meterType")) {
+        k.meterType.emplace(j.at("meterType"));
+    }
+    if (j.contains("meterSerialNumber")) {
+        k.meterSerialNumber.emplace(j.at("meterSerialNumber"));
+    }
+}
+
+/// \brief Writes the string representation of the given BootNotificationRequest \p k to the given output stream \p os
+/// \returns an output stream with the BootNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const BootNotificationRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string BootNotificationResponse::get_type() const {
+    return "BootNotificationResponse";
+}
+
+void to_json(json& j, const BootNotificationResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::registration_status_to_string(k.status)},
+        {"currentTime", k.currentTime.to_rfc3339()},
+        {"interval", k.interval},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, BootNotificationResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_registration_status(j.at("status"));
+    k.currentTime = DateTime(std::string(j.at("currentTime")));
+    ;
+    k.interval = j.at("interval");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given BootNotificationResponse \p k to the given output stream \p os
+/// \returns an output stream with the BootNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const BootNotificationResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/CMakeLists.txt
+++ b/lib/ocpp1_6/messages/CMakeLists.txt
@@ -1,0 +1,32 @@
+
+target_sources(ocpp
+    PRIVATE
+        Authorize.cpp
+        BootNotification.cpp
+        CancelReservation.cpp
+        ChangeAvailability.cpp
+        ChangeConfiguration.cpp
+        ClearCache.cpp
+        ClearChargingProfile.cpp
+        DataTransfer.cpp
+        DiagnosticsStatusNotification.cpp
+        FirmwareStatusNotification.cpp
+        GetCompositeSchedule.cpp
+        GetConfiguration.cpp
+        GetDiagnostics.cpp
+        GetLocalListVersion.cpp
+        Heartbeat.cpp
+        MeterValues.cpp
+        RemoteStartTransaction.cpp
+        RemoteStopTransaction.cpp
+        ReserveNow.cpp
+        Reset.cpp
+        SendLocalList.cpp
+        SetChargingProfile.cpp
+        StartTransaction.cpp
+        StatusNotification.cpp
+        StopTransaction.cpp
+        TriggerMessage.cpp
+        UnlockConnector.cpp
+        UpdateFirmware.cpp
+    )

--- a/lib/ocpp1_6/messages/CancelReservation.cpp
+++ b/lib/ocpp1_6/messages/CancelReservation.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/CancelReservation.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string CancelReservationRequest::get_type() const {
+    return "CancelReservation";
+}
+
+void to_json(json& j, const CancelReservationRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"reservationId", k.reservationId},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, CancelReservationRequest& k) {
+    // the required parts of the message
+    k.reservationId = j.at("reservationId");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given CancelReservationRequest \p k to the given output stream \p os
+/// \returns an output stream with the CancelReservationRequest written to
+std::ostream& operator<<(std::ostream& os, const CancelReservationRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string CancelReservationResponse::get_type() const {
+    return "CancelReservationResponse";
+}
+
+void to_json(json& j, const CancelReservationResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::cancel_reservation_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, CancelReservationResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_cancel_reservation_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given CancelReservationResponse \p k to the given output stream \p os
+/// \returns an output stream with the CancelReservationResponse written to
+std::ostream& operator<<(std::ostream& os, const CancelReservationResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/ChangeAvailability.cpp
+++ b/lib/ocpp1_6/messages/ChangeAvailability.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/ChangeAvailability.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string ChangeAvailabilityRequest::get_type() const {
+    return "ChangeAvailability";
+}
+
+void to_json(json& j, const ChangeAvailabilityRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+        {"type", conversions::availability_type_to_string(k.type)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ChangeAvailabilityRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+    k.type = conversions::string_to_availability_type(j.at("type"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ChangeAvailabilityRequest \p k to the given output stream \p os
+/// \returns an output stream with the ChangeAvailabilityRequest written to
+std::ostream& operator<<(std::ostream& os, const ChangeAvailabilityRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string ChangeAvailabilityResponse::get_type() const {
+    return "ChangeAvailabilityResponse";
+}
+
+void to_json(json& j, const ChangeAvailabilityResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::availability_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ChangeAvailabilityResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_availability_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ChangeAvailabilityResponse \p k to the given output stream \p
+/// os \returns an output stream with the ChangeAvailabilityResponse written to
+std::ostream& operator<<(std::ostream& os, const ChangeAvailabilityResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/ChangeConfiguration.cpp
+++ b/lib/ocpp1_6/messages/ChangeConfiguration.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/ChangeConfiguration.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string ChangeConfigurationRequest::get_type() const {
+    return "ChangeConfiguration";
+}
+
+void to_json(json& j, const ChangeConfigurationRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"key", k.key},
+        {"value", k.value},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ChangeConfigurationRequest& k) {
+    // the required parts of the message
+    k.key = j.at("key");
+    k.value = j.at("value");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ChangeConfigurationRequest \p k to the given output stream \p
+/// os \returns an output stream with the ChangeConfigurationRequest written to
+std::ostream& operator<<(std::ostream& os, const ChangeConfigurationRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string ChangeConfigurationResponse::get_type() const {
+    return "ChangeConfigurationResponse";
+}
+
+void to_json(json& j, const ChangeConfigurationResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::configuration_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ChangeConfigurationResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_configuration_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ChangeConfigurationResponse \p k to the given output stream \p
+/// os \returns an output stream with the ChangeConfigurationResponse written to
+std::ostream& operator<<(std::ostream& os, const ChangeConfigurationResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/ClearCache.cpp
+++ b/lib/ocpp1_6/messages/ClearCache.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/ClearCache.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string ClearCacheRequest::get_type() const {
+    return "ClearCache";
+}
+
+void to_json(json& j, const ClearCacheRequest& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ClearCacheRequest& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ClearCacheRequest \p k to the given output stream \p os
+/// \returns an output stream with the ClearCacheRequest written to
+std::ostream& operator<<(std::ostream& os, const ClearCacheRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string ClearCacheResponse::get_type() const {
+    return "ClearCacheResponse";
+}
+
+void to_json(json& j, const ClearCacheResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::clear_cache_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ClearCacheResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_clear_cache_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ClearCacheResponse \p k to the given output stream \p os
+/// \returns an output stream with the ClearCacheResponse written to
+std::ostream& operator<<(std::ostream& os, const ClearCacheResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/ClearChargingProfile.cpp
+++ b/lib/ocpp1_6/messages/ClearChargingProfile.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/ClearChargingProfile.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string ClearChargingProfileRequest::get_type() const {
+    return "ClearChargingProfile";
+}
+
+void to_json(json& j, const ClearChargingProfileRequest& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+    if (k.id) {
+        j["id"] = k.id.value();
+    }
+    if (k.connectorId) {
+        j["connectorId"] = k.connectorId.value();
+    }
+    if (k.chargingProfilePurpose) {
+        j["chargingProfilePurpose"] =
+            conversions::charging_profile_purpose_type_to_string(k.chargingProfilePurpose.value());
+    }
+    if (k.stackLevel) {
+        j["stackLevel"] = k.stackLevel.value();
+    }
+}
+
+void from_json(const json& j, ClearChargingProfileRequest& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+    if (j.contains("id")) {
+        k.id.emplace(j.at("id"));
+    }
+    if (j.contains("connectorId")) {
+        k.connectorId.emplace(j.at("connectorId"));
+    }
+    if (j.contains("chargingProfilePurpose")) {
+        k.chargingProfilePurpose.emplace(
+            conversions::string_to_charging_profile_purpose_type(j.at("chargingProfilePurpose")));
+    }
+    if (j.contains("stackLevel")) {
+        k.stackLevel.emplace(j.at("stackLevel"));
+    }
+}
+
+/// \brief Writes the string representation of the given ClearChargingProfileRequest \p k to the given output stream \p
+/// os \returns an output stream with the ClearChargingProfileRequest written to
+std::ostream& operator<<(std::ostream& os, const ClearChargingProfileRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string ClearChargingProfileResponse::get_type() const {
+    return "ClearChargingProfileResponse";
+}
+
+void to_json(json& j, const ClearChargingProfileResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::clear_charging_profile_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ClearChargingProfileResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_clear_charging_profile_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ClearChargingProfileResponse \p k to the given output stream \p
+/// os \returns an output stream with the ClearChargingProfileResponse written to
+std::ostream& operator<<(std::ostream& os, const ClearChargingProfileResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/DataTransfer.cpp
+++ b/lib/ocpp1_6/messages/DataTransfer.cpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/DataTransfer.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string DataTransferRequest::get_type() const {
+    return "DataTransfer";
+}
+
+void to_json(json& j, const DataTransferRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"vendorId", k.vendorId},
+    };
+    // the optional parts of the message
+    if (k.messageId) {
+        j["messageId"] = k.messageId.value();
+    }
+    if (k.data) {
+        j["data"] = k.data.value();
+    }
+}
+
+void from_json(const json& j, DataTransferRequest& k) {
+    // the required parts of the message
+    k.vendorId = j.at("vendorId");
+
+    // the optional parts of the message
+    if (j.contains("messageId")) {
+        k.messageId.emplace(j.at("messageId"));
+    }
+    if (j.contains("data")) {
+        k.data.emplace(j.at("data"));
+    }
+}
+
+/// \brief Writes the string representation of the given DataTransferRequest \p k to the given output stream \p os
+/// \returns an output stream with the DataTransferRequest written to
+std::ostream& operator<<(std::ostream& os, const DataTransferRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string DataTransferResponse::get_type() const {
+    return "DataTransferResponse";
+}
+
+void to_json(json& j, const DataTransferResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::data_transfer_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+    if (k.data) {
+        j["data"] = k.data.value();
+    }
+}
+
+void from_json(const json& j, DataTransferResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_data_transfer_status(j.at("status"));
+
+    // the optional parts of the message
+    if (j.contains("data")) {
+        k.data.emplace(j.at("data"));
+    }
+}
+
+/// \brief Writes the string representation of the given DataTransferResponse \p k to the given output stream \p os
+/// \returns an output stream with the DataTransferResponse written to
+std::ostream& operator<<(std::ostream& os, const DataTransferResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/DiagnosticsStatusNotification.cpp
+++ b/lib/ocpp1_6/messages/DiagnosticsStatusNotification.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/DiagnosticsStatusNotification.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string DiagnosticsStatusNotificationRequest::get_type() const {
+    return "DiagnosticsStatusNotification";
+}
+
+void to_json(json& j, const DiagnosticsStatusNotificationRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::diagnostics_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, DiagnosticsStatusNotificationRequest& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_diagnostics_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given DiagnosticsStatusNotificationRequest \p k to the given output
+/// stream \p os \returns an output stream with the DiagnosticsStatusNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const DiagnosticsStatusNotificationRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string DiagnosticsStatusNotificationResponse::get_type() const {
+    return "DiagnosticsStatusNotificationResponse";
+}
+
+void to_json(json& j, const DiagnosticsStatusNotificationResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, DiagnosticsStatusNotificationResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given DiagnosticsStatusNotificationResponse \p k to the given output
+/// stream \p os \returns an output stream with the DiagnosticsStatusNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const DiagnosticsStatusNotificationResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/FirmwareStatusNotification.cpp
+++ b/lib/ocpp1_6/messages/FirmwareStatusNotification.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/FirmwareStatusNotification.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string FirmwareStatusNotificationRequest::get_type() const {
+    return "FirmwareStatusNotification";
+}
+
+void to_json(json& j, const FirmwareStatusNotificationRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::firmware_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, FirmwareStatusNotificationRequest& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_firmware_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given FirmwareStatusNotificationRequest \p k to the given output
+/// stream \p os \returns an output stream with the FirmwareStatusNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const FirmwareStatusNotificationRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string FirmwareStatusNotificationResponse::get_type() const {
+    return "FirmwareStatusNotificationResponse";
+}
+
+void to_json(json& j, const FirmwareStatusNotificationResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, FirmwareStatusNotificationResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given FirmwareStatusNotificationResponse \p k to the given output
+/// stream \p os \returns an output stream with the FirmwareStatusNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const FirmwareStatusNotificationResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/GetCompositeSchedule.cpp
+++ b/lib/ocpp1_6/messages/GetCompositeSchedule.cpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/GetCompositeSchedule.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string GetCompositeScheduleRequest::get_type() const {
+    return "GetCompositeSchedule";
+}
+
+void to_json(json& j, const GetCompositeScheduleRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+        {"duration", k.duration},
+    };
+    // the optional parts of the message
+    if (k.chargingRateUnit) {
+        j["chargingRateUnit"] = conversions::charging_rate_unit_to_string(k.chargingRateUnit.value());
+    }
+}
+
+void from_json(const json& j, GetCompositeScheduleRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+    k.duration = j.at("duration");
+
+    // the optional parts of the message
+    if (j.contains("chargingRateUnit")) {
+        k.chargingRateUnit.emplace(conversions::string_to_charging_rate_unit(j.at("chargingRateUnit")));
+    }
+}
+
+/// \brief Writes the string representation of the given GetCompositeScheduleRequest \p k to the given output stream \p
+/// os \returns an output stream with the GetCompositeScheduleRequest written to
+std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string GetCompositeScheduleResponse::get_type() const {
+    return "GetCompositeScheduleResponse";
+}
+
+void to_json(json& j, const GetCompositeScheduleResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::get_composite_schedule_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+    if (k.connectorId) {
+        j["connectorId"] = k.connectorId.value();
+    }
+    if (k.scheduleStart) {
+        j["scheduleStart"] = k.scheduleStart.value().to_rfc3339();
+    }
+    if (k.chargingSchedule) {
+        j["chargingSchedule"] = k.chargingSchedule.value();
+    }
+}
+
+void from_json(const json& j, GetCompositeScheduleResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_get_composite_schedule_status(j.at("status"));
+
+    // the optional parts of the message
+    if (j.contains("connectorId")) {
+        k.connectorId.emplace(j.at("connectorId"));
+    }
+    if (j.contains("scheduleStart")) {
+        k.scheduleStart.emplace(DateTime(std::string(j.at("scheduleStart"))));
+    }
+    if (j.contains("chargingSchedule")) {
+        k.chargingSchedule.emplace(j.at("chargingSchedule"));
+    }
+}
+
+/// \brief Writes the string representation of the given GetCompositeScheduleResponse \p k to the given output stream \p
+/// os \returns an output stream with the GetCompositeScheduleResponse written to
+std::ostream& operator<<(std::ostream& os, const GetCompositeScheduleResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/GetConfiguration.cpp
+++ b/lib/ocpp1_6/messages/GetConfiguration.cpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/GetConfiguration.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string GetConfigurationRequest::get_type() const {
+    return "GetConfiguration";
+}
+
+void to_json(json& j, const GetConfigurationRequest& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+    if (k.key) {
+        if (j.size() == 0) {
+            j = json{{"key", json::array()}};
+        } else {
+            j["key"] = json::array();
+        }
+        for (auto val : k.key.value()) {
+            j["key"].push_back(val);
+        }
+    }
+}
+
+void from_json(const json& j, GetConfigurationRequest& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+    if (j.contains("key")) {
+        json arr = j.at("key");
+        std::vector<CiString50Type> vec;
+        for (auto val : arr) {
+            vec.push_back(val);
+        }
+        k.key.emplace(vec);
+    }
+}
+
+/// \brief Writes the string representation of the given GetConfigurationRequest \p k to the given output stream \p os
+/// \returns an output stream with the GetConfigurationRequest written to
+std::ostream& operator<<(std::ostream& os, const GetConfigurationRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string GetConfigurationResponse::get_type() const {
+    return "GetConfigurationResponse";
+}
+
+void to_json(json& j, const GetConfigurationResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+    if (k.configurationKey) {
+        if (j.size() == 0) {
+            j = json{{"configurationKey", json::array()}};
+        } else {
+            j["configurationKey"] = json::array();
+        }
+        for (auto val : k.configurationKey.value()) {
+            j["configurationKey"].push_back(val);
+        }
+    }
+    if (k.unknownKey) {
+        if (j.size() == 0) {
+            j = json{{"unknownKey", json::array()}};
+        } else {
+            j["unknownKey"] = json::array();
+        }
+        for (auto val : k.unknownKey.value()) {
+            j["unknownKey"].push_back(val);
+        }
+    }
+}
+
+void from_json(const json& j, GetConfigurationResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+    if (j.contains("configurationKey")) {
+        json arr = j.at("configurationKey");
+        std::vector<KeyValue> vec;
+        for (auto val : arr) {
+            vec.push_back(val);
+        }
+        k.configurationKey.emplace(vec);
+    }
+    if (j.contains("unknownKey")) {
+        json arr = j.at("unknownKey");
+        std::vector<CiString50Type> vec;
+        for (auto val : arr) {
+            vec.push_back(val);
+        }
+        k.unknownKey.emplace(vec);
+    }
+}
+
+/// \brief Writes the string representation of the given GetConfigurationResponse \p k to the given output stream \p os
+/// \returns an output stream with the GetConfigurationResponse written to
+std::ostream& operator<<(std::ostream& os, const GetConfigurationResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/GetDiagnostics.cpp
+++ b/lib/ocpp1_6/messages/GetDiagnostics.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/GetDiagnostics.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string GetDiagnosticsRequest::get_type() const {
+    return "GetDiagnostics";
+}
+
+void to_json(json& j, const GetDiagnosticsRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"location", k.location},
+    };
+    // the optional parts of the message
+    if (k.retries) {
+        j["retries"] = k.retries.value();
+    }
+    if (k.retryInterval) {
+        j["retryInterval"] = k.retryInterval.value();
+    }
+    if (k.startTime) {
+        j["startTime"] = k.startTime.value().to_rfc3339();
+    }
+    if (k.stopTime) {
+        j["stopTime"] = k.stopTime.value().to_rfc3339();
+    }
+}
+
+void from_json(const json& j, GetDiagnosticsRequest& k) {
+    // the required parts of the message
+    k.location = j.at("location");
+
+    // the optional parts of the message
+    if (j.contains("retries")) {
+        k.retries.emplace(j.at("retries"));
+    }
+    if (j.contains("retryInterval")) {
+        k.retryInterval.emplace(j.at("retryInterval"));
+    }
+    if (j.contains("startTime")) {
+        k.startTime.emplace(DateTime(std::string(j.at("startTime"))));
+    }
+    if (j.contains("stopTime")) {
+        k.stopTime.emplace(DateTime(std::string(j.at("stopTime"))));
+    }
+}
+
+/// \brief Writes the string representation of the given GetDiagnosticsRequest \p k to the given output stream \p os
+/// \returns an output stream with the GetDiagnosticsRequest written to
+std::ostream& operator<<(std::ostream& os, const GetDiagnosticsRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string GetDiagnosticsResponse::get_type() const {
+    return "GetDiagnosticsResponse";
+}
+
+void to_json(json& j, const GetDiagnosticsResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+    if (k.fileName) {
+        j["fileName"] = k.fileName.value();
+    }
+}
+
+void from_json(const json& j, GetDiagnosticsResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+    if (j.contains("fileName")) {
+        k.fileName.emplace(j.at("fileName"));
+    }
+}
+
+/// \brief Writes the string representation of the given GetDiagnosticsResponse \p k to the given output stream \p os
+/// \returns an output stream with the GetDiagnosticsResponse written to
+std::ostream& operator<<(std::ostream& os, const GetDiagnosticsResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/GetLocalListVersion.cpp
+++ b/lib/ocpp1_6/messages/GetLocalListVersion.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/GetLocalListVersion.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string GetLocalListVersionRequest::get_type() const {
+    return "GetLocalListVersion";
+}
+
+void to_json(json& j, const GetLocalListVersionRequest& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, GetLocalListVersionRequest& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given GetLocalListVersionRequest \p k to the given output stream \p
+/// os \returns an output stream with the GetLocalListVersionRequest written to
+std::ostream& operator<<(std::ostream& os, const GetLocalListVersionRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string GetLocalListVersionResponse::get_type() const {
+    return "GetLocalListVersionResponse";
+}
+
+void to_json(json& j, const GetLocalListVersionResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"listVersion", k.listVersion},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, GetLocalListVersionResponse& k) {
+    // the required parts of the message
+    k.listVersion = j.at("listVersion");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given GetLocalListVersionResponse \p k to the given output stream \p
+/// os \returns an output stream with the GetLocalListVersionResponse written to
+std::ostream& operator<<(std::ostream& os, const GetLocalListVersionResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/Heartbeat.cpp
+++ b/lib/ocpp1_6/messages/Heartbeat.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/Heartbeat.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string HeartbeatRequest::get_type() const {
+    return "Heartbeat";
+}
+
+void to_json(json& j, const HeartbeatRequest& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, HeartbeatRequest& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given HeartbeatRequest \p k to the given output stream \p os
+/// \returns an output stream with the HeartbeatRequest written to
+std::ostream& operator<<(std::ostream& os, const HeartbeatRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string HeartbeatResponse::get_type() const {
+    return "HeartbeatResponse";
+}
+
+void to_json(json& j, const HeartbeatResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"currentTime", k.currentTime.to_rfc3339()},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, HeartbeatResponse& k) {
+    // the required parts of the message
+    k.currentTime = DateTime(std::string(j.at("currentTime")));
+    ;
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given HeartbeatResponse \p k to the given output stream \p os
+/// \returns an output stream with the HeartbeatResponse written to
+std::ostream& operator<<(std::ostream& os, const HeartbeatResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/MeterValues.cpp
+++ b/lib/ocpp1_6/messages/MeterValues.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/MeterValues.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string MeterValuesRequest::get_type() const {
+    return "MeterValues";
+}
+
+void to_json(json& j, const MeterValuesRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+        {"meterValue", k.meterValue},
+    };
+    // the optional parts of the message
+    if (k.transactionId) {
+        j["transactionId"] = k.transactionId.value();
+    }
+}
+
+void from_json(const json& j, MeterValuesRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+    for (auto val : j.at("meterValue")) {
+        k.meterValue.push_back(val);
+    }
+
+    // the optional parts of the message
+    if (j.contains("transactionId")) {
+        k.transactionId.emplace(j.at("transactionId"));
+    }
+}
+
+/// \brief Writes the string representation of the given MeterValuesRequest \p k to the given output stream \p os
+/// \returns an output stream with the MeterValuesRequest written to
+std::ostream& operator<<(std::ostream& os, const MeterValuesRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string MeterValuesResponse::get_type() const {
+    return "MeterValuesResponse";
+}
+
+void to_json(json& j, const MeterValuesResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, MeterValuesResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given MeterValuesResponse \p k to the given output stream \p os
+/// \returns an output stream with the MeterValuesResponse written to
+std::ostream& operator<<(std::ostream& os, const MeterValuesResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/RemoteStartTransaction.cpp
+++ b/lib/ocpp1_6/messages/RemoteStartTransaction.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/RemoteStartTransaction.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string RemoteStartTransactionRequest::get_type() const {
+    return "RemoteStartTransaction";
+}
+
+void to_json(json& j, const RemoteStartTransactionRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"idTag", k.idTag},
+    };
+    // the optional parts of the message
+    if (k.connectorId) {
+        j["connectorId"] = k.connectorId.value();
+    }
+    if (k.chargingProfile) {
+        j["chargingProfile"] = k.chargingProfile.value();
+    }
+}
+
+void from_json(const json& j, RemoteStartTransactionRequest& k) {
+    // the required parts of the message
+    k.idTag = j.at("idTag");
+
+    // the optional parts of the message
+    if (j.contains("connectorId")) {
+        k.connectorId.emplace(j.at("connectorId"));
+    }
+    if (j.contains("chargingProfile")) {
+        k.chargingProfile.emplace(j.at("chargingProfile"));
+    }
+}
+
+/// \brief Writes the string representation of the given RemoteStartTransactionRequest \p k to the given output stream
+/// \p os \returns an output stream with the RemoteStartTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const RemoteStartTransactionRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string RemoteStartTransactionResponse::get_type() const {
+    return "RemoteStartTransactionResponse";
+}
+
+void to_json(json& j, const RemoteStartTransactionResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::remote_start_stop_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, RemoteStartTransactionResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_remote_start_stop_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given RemoteStartTransactionResponse \p k to the given output stream
+/// \p os \returns an output stream with the RemoteStartTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const RemoteStartTransactionResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/RemoteStopTransaction.cpp
+++ b/lib/ocpp1_6/messages/RemoteStopTransaction.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/RemoteStopTransaction.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string RemoteStopTransactionRequest::get_type() const {
+    return "RemoteStopTransaction";
+}
+
+void to_json(json& j, const RemoteStopTransactionRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"transactionId", k.transactionId},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, RemoteStopTransactionRequest& k) {
+    // the required parts of the message
+    k.transactionId = j.at("transactionId");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given RemoteStopTransactionRequest \p k to the given output stream \p
+/// os \returns an output stream with the RemoteStopTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const RemoteStopTransactionRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string RemoteStopTransactionResponse::get_type() const {
+    return "RemoteStopTransactionResponse";
+}
+
+void to_json(json& j, const RemoteStopTransactionResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::remote_start_stop_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, RemoteStopTransactionResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_remote_start_stop_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given RemoteStopTransactionResponse \p k to the given output stream
+/// \p os \returns an output stream with the RemoteStopTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const RemoteStopTransactionResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/ReserveNow.cpp
+++ b/lib/ocpp1_6/messages/ReserveNow.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/ReserveNow.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string ReserveNowRequest::get_type() const {
+    return "ReserveNow";
+}
+
+void to_json(json& j, const ReserveNowRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+        {"expiryDate", k.expiryDate.to_rfc3339()},
+        {"idTag", k.idTag},
+        {"reservationId", k.reservationId},
+    };
+    // the optional parts of the message
+    if (k.parentIdTag) {
+        j["parentIdTag"] = k.parentIdTag.value();
+    }
+}
+
+void from_json(const json& j, ReserveNowRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+    k.expiryDate = DateTime(std::string(j.at("expiryDate")));
+    ;
+    k.idTag = j.at("idTag");
+    k.reservationId = j.at("reservationId");
+
+    // the optional parts of the message
+    if (j.contains("parentIdTag")) {
+        k.parentIdTag.emplace(j.at("parentIdTag"));
+    }
+}
+
+/// \brief Writes the string representation of the given ReserveNowRequest \p k to the given output stream \p os
+/// \returns an output stream with the ReserveNowRequest written to
+std::ostream& operator<<(std::ostream& os, const ReserveNowRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string ReserveNowResponse::get_type() const {
+    return "ReserveNowResponse";
+}
+
+void to_json(json& j, const ReserveNowResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::reservation_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ReserveNowResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_reservation_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ReserveNowResponse \p k to the given output stream \p os
+/// \returns an output stream with the ReserveNowResponse written to
+std::ostream& operator<<(std::ostream& os, const ReserveNowResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/Reset.cpp
+++ b/lib/ocpp1_6/messages/Reset.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/Reset.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string ResetRequest::get_type() const {
+    return "Reset";
+}
+
+void to_json(json& j, const ResetRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"type", conversions::reset_type_to_string(k.type)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ResetRequest& k) {
+    // the required parts of the message
+    k.type = conversions::string_to_reset_type(j.at("type"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ResetRequest \p k to the given output stream \p os
+/// \returns an output stream with the ResetRequest written to
+std::ostream& operator<<(std::ostream& os, const ResetRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string ResetResponse::get_type() const {
+    return "ResetResponse";
+}
+
+void to_json(json& j, const ResetResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::reset_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, ResetResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_reset_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given ResetResponse \p k to the given output stream \p os
+/// \returns an output stream with the ResetResponse written to
+std::ostream& operator<<(std::ostream& os, const ResetResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/SendLocalList.cpp
+++ b/lib/ocpp1_6/messages/SendLocalList.cpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/SendLocalList.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string SendLocalListRequest::get_type() const {
+    return "SendLocalList";
+}
+
+void to_json(json& j, const SendLocalListRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"listVersion", k.listVersion},
+        {"updateType", conversions::update_type_to_string(k.updateType)},
+    };
+    // the optional parts of the message
+    if (k.localAuthorizationList) {
+        j["localAuthorizationList"] = json::array();
+        for (auto val : k.localAuthorizationList.value()) {
+            j["localAuthorizationList"].push_back(val);
+        }
+    }
+}
+
+void from_json(const json& j, SendLocalListRequest& k) {
+    // the required parts of the message
+    k.listVersion = j.at("listVersion");
+    k.updateType = conversions::string_to_update_type(j.at("updateType"));
+
+    // the optional parts of the message
+    if (j.contains("localAuthorizationList")) {
+        json arr = j.at("localAuthorizationList");
+        std::vector<LocalAuthorizationList> vec;
+        for (auto val : arr) {
+            vec.push_back(val);
+        }
+        k.localAuthorizationList.emplace(vec);
+    }
+}
+
+/// \brief Writes the string representation of the given SendLocalListRequest \p k to the given output stream \p os
+/// \returns an output stream with the SendLocalListRequest written to
+std::ostream& operator<<(std::ostream& os, const SendLocalListRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string SendLocalListResponse::get_type() const {
+    return "SendLocalListResponse";
+}
+
+void to_json(json& j, const SendLocalListResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::update_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, SendLocalListResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_update_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given SendLocalListResponse \p k to the given output stream \p os
+/// \returns an output stream with the SendLocalListResponse written to
+std::ostream& operator<<(std::ostream& os, const SendLocalListResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/SetChargingProfile.cpp
+++ b/lib/ocpp1_6/messages/SetChargingProfile.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/SetChargingProfile.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string SetChargingProfileRequest::get_type() const {
+    return "SetChargingProfile";
+}
+
+void to_json(json& j, const SetChargingProfileRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+        {"csChargingProfiles", k.csChargingProfiles},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, SetChargingProfileRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+    k.csChargingProfiles = j.at("csChargingProfiles");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given SetChargingProfileRequest \p k to the given output stream \p os
+/// \returns an output stream with the SetChargingProfileRequest written to
+std::ostream& operator<<(std::ostream& os, const SetChargingProfileRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string SetChargingProfileResponse::get_type() const {
+    return "SetChargingProfileResponse";
+}
+
+void to_json(json& j, const SetChargingProfileResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::charging_profile_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, SetChargingProfileResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_charging_profile_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given SetChargingProfileResponse \p k to the given output stream \p
+/// os \returns an output stream with the SetChargingProfileResponse written to
+std::ostream& operator<<(std::ostream& os, const SetChargingProfileResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/StartTransaction.cpp
+++ b/lib/ocpp1_6/messages/StartTransaction.cpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/StartTransaction.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string StartTransactionRequest::get_type() const {
+    return "StartTransaction";
+}
+
+void to_json(json& j, const StartTransactionRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+        {"idTag", k.idTag},
+        {"meterStart", k.meterStart},
+        {"timestamp", k.timestamp.to_rfc3339()},
+    };
+    // the optional parts of the message
+    if (k.reservationId) {
+        j["reservationId"] = k.reservationId.value();
+    }
+}
+
+void from_json(const json& j, StartTransactionRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+    k.idTag = j.at("idTag");
+    k.meterStart = j.at("meterStart");
+    k.timestamp = DateTime(std::string(j.at("timestamp")));
+    ;
+
+    // the optional parts of the message
+    if (j.contains("reservationId")) {
+        k.reservationId.emplace(j.at("reservationId"));
+    }
+}
+
+/// \brief Writes the string representation of the given StartTransactionRequest \p k to the given output stream \p os
+/// \returns an output stream with the StartTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const StartTransactionRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string StartTransactionResponse::get_type() const {
+    return "StartTransactionResponse";
+}
+
+void to_json(json& j, const StartTransactionResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"idTagInfo", k.idTagInfo},
+        {"transactionId", k.transactionId},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, StartTransactionResponse& k) {
+    // the required parts of the message
+    k.idTagInfo = j.at("idTagInfo");
+    k.transactionId = j.at("transactionId");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given StartTransactionResponse \p k to the given output stream \p os
+/// \returns an output stream with the StartTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const StartTransactionResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/StatusNotification.cpp
+++ b/lib/ocpp1_6/messages/StatusNotification.cpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/StatusNotification.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string StatusNotificationRequest::get_type() const {
+    return "StatusNotification";
+}
+
+void to_json(json& j, const StatusNotificationRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+        {"errorCode", conversions::charge_point_error_code_to_string(k.errorCode)},
+        {"status", conversions::charge_point_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+    if (k.info) {
+        j["info"] = k.info.value();
+    }
+    if (k.timestamp) {
+        j["timestamp"] = k.timestamp.value().to_rfc3339();
+    }
+    if (k.vendorId) {
+        j["vendorId"] = k.vendorId.value();
+    }
+    if (k.vendorErrorCode) {
+        j["vendorErrorCode"] = k.vendorErrorCode.value();
+    }
+}
+
+void from_json(const json& j, StatusNotificationRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+    k.errorCode = conversions::string_to_charge_point_error_code(j.at("errorCode"));
+    k.status = conversions::string_to_charge_point_status(j.at("status"));
+
+    // the optional parts of the message
+    if (j.contains("info")) {
+        k.info.emplace(j.at("info"));
+    }
+    if (j.contains("timestamp")) {
+        k.timestamp.emplace(DateTime(std::string(j.at("timestamp"))));
+    }
+    if (j.contains("vendorId")) {
+        k.vendorId.emplace(j.at("vendorId"));
+    }
+    if (j.contains("vendorErrorCode")) {
+        k.vendorErrorCode.emplace(j.at("vendorErrorCode"));
+    }
+}
+
+/// \brief Writes the string representation of the given StatusNotificationRequest \p k to the given output stream \p os
+/// \returns an output stream with the StatusNotificationRequest written to
+std::ostream& operator<<(std::ostream& os, const StatusNotificationRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string StatusNotificationResponse::get_type() const {
+    return "StatusNotificationResponse";
+}
+
+void to_json(json& j, const StatusNotificationResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, StatusNotificationResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given StatusNotificationResponse \p k to the given output stream \p
+/// os \returns an output stream with the StatusNotificationResponse written to
+std::ostream& operator<<(std::ostream& os, const StatusNotificationResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/StopTransaction.cpp
+++ b/lib/ocpp1_6/messages/StopTransaction.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/StopTransaction.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string StopTransactionRequest::get_type() const {
+    return "StopTransaction";
+}
+
+void to_json(json& j, const StopTransactionRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"meterStop", k.meterStop},
+        {"timestamp", k.timestamp.to_rfc3339()},
+        {"transactionId", k.transactionId},
+    };
+    // the optional parts of the message
+    if (k.idTag) {
+        j["idTag"] = k.idTag.value();
+    }
+    if (k.reason) {
+        j["reason"] = conversions::reason_to_string(k.reason.value());
+    }
+    if (k.transactionData) {
+        j["transactionData"] = json::array();
+        for (auto val : k.transactionData.value()) {
+            j["transactionData"].push_back(val);
+        }
+    }
+}
+
+void from_json(const json& j, StopTransactionRequest& k) {
+    // the required parts of the message
+    k.meterStop = j.at("meterStop");
+    k.timestamp = DateTime(std::string(j.at("timestamp")));
+    ;
+    k.transactionId = j.at("transactionId");
+
+    // the optional parts of the message
+    if (j.contains("idTag")) {
+        k.idTag.emplace(j.at("idTag"));
+    }
+    if (j.contains("reason")) {
+        k.reason.emplace(conversions::string_to_reason(j.at("reason")));
+    }
+    if (j.contains("transactionData")) {
+        json arr = j.at("transactionData");
+        std::vector<TransactionData> vec;
+        for (auto val : arr) {
+            vec.push_back(val);
+        }
+        k.transactionData.emplace(vec);
+    }
+}
+
+/// \brief Writes the string representation of the given StopTransactionRequest \p k to the given output stream \p os
+/// \returns an output stream with the StopTransactionRequest written to
+std::ostream& operator<<(std::ostream& os, const StopTransactionRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string StopTransactionResponse::get_type() const {
+    return "StopTransactionResponse";
+}
+
+void to_json(json& j, const StopTransactionResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+    if (k.idTagInfo) {
+        j["idTagInfo"] = k.idTagInfo.value();
+    }
+}
+
+void from_json(const json& j, StopTransactionResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+    if (j.contains("idTagInfo")) {
+        k.idTagInfo.emplace(j.at("idTagInfo"));
+    }
+}
+
+/// \brief Writes the string representation of the given StopTransactionResponse \p k to the given output stream \p os
+/// \returns an output stream with the StopTransactionResponse written to
+std::ostream& operator<<(std::ostream& os, const StopTransactionResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/TriggerMessage.cpp
+++ b/lib/ocpp1_6/messages/TriggerMessage.cpp
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/TriggerMessage.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string TriggerMessageRequest::get_type() const {
+    return "TriggerMessage";
+}
+
+void to_json(json& j, const TriggerMessageRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"requestedMessage", conversions::message_trigger_to_string(k.requestedMessage)},
+    };
+    // the optional parts of the message
+    if (k.connectorId) {
+        j["connectorId"] = k.connectorId.value();
+    }
+}
+
+void from_json(const json& j, TriggerMessageRequest& k) {
+    // the required parts of the message
+    k.requestedMessage = conversions::string_to_message_trigger(j.at("requestedMessage"));
+
+    // the optional parts of the message
+    if (j.contains("connectorId")) {
+        k.connectorId.emplace(j.at("connectorId"));
+    }
+}
+
+/// \brief Writes the string representation of the given TriggerMessageRequest \p k to the given output stream \p os
+/// \returns an output stream with the TriggerMessageRequest written to
+std::ostream& operator<<(std::ostream& os, const TriggerMessageRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string TriggerMessageResponse::get_type() const {
+    return "TriggerMessageResponse";
+}
+
+void to_json(json& j, const TriggerMessageResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::trigger_message_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, TriggerMessageResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_trigger_message_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given TriggerMessageResponse \p k to the given output stream \p os
+/// \returns an output stream with the TriggerMessageResponse written to
+std::ostream& operator<<(std::ostream& os, const TriggerMessageResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/UnlockConnector.cpp
+++ b/lib/ocpp1_6/messages/UnlockConnector.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/UnlockConnector.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string UnlockConnectorRequest::get_type() const {
+    return "UnlockConnector";
+}
+
+void to_json(json& j, const UnlockConnectorRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"connectorId", k.connectorId},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, UnlockConnectorRequest& k) {
+    // the required parts of the message
+    k.connectorId = j.at("connectorId");
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given UnlockConnectorRequest \p k to the given output stream \p os
+/// \returns an output stream with the UnlockConnectorRequest written to
+std::ostream& operator<<(std::ostream& os, const UnlockConnectorRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string UnlockConnectorResponse::get_type() const {
+    return "UnlockConnectorResponse";
+}
+
+void to_json(json& j, const UnlockConnectorResponse& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::unlock_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+}
+
+void from_json(const json& j, UnlockConnectorResponse& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_unlock_status(j.at("status"));
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given UnlockConnectorResponse \p k to the given output stream \p os
+/// \returns an output stream with the UnlockConnectorResponse written to
+std::ostream& operator<<(std::ostream& os, const UnlockConnectorResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/messages/UpdateFirmware.cpp
+++ b/lib/ocpp1_6/messages/UpdateFirmware.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/UpdateFirmware.hpp>
+#include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
+
+namespace ocpp1_6 {
+
+std::string UpdateFirmwareRequest::get_type() const {
+    return "UpdateFirmware";
+}
+
+void to_json(json& j, const UpdateFirmwareRequest& k) {
+    // the required parts of the message
+    j = json{
+        {"location", k.location},
+        {"retrieveDate", k.retrieveDate.to_rfc3339()},
+    };
+    // the optional parts of the message
+    if (k.retries) {
+        j["retries"] = k.retries.value();
+    }
+    if (k.retryInterval) {
+        j["retryInterval"] = k.retryInterval.value();
+    }
+}
+
+void from_json(const json& j, UpdateFirmwareRequest& k) {
+    // the required parts of the message
+    k.location = j.at("location");
+    k.retrieveDate = DateTime(std::string(j.at("retrieveDate")));
+    ;
+
+    // the optional parts of the message
+    if (j.contains("retries")) {
+        k.retries.emplace(j.at("retries"));
+    }
+    if (j.contains("retryInterval")) {
+        k.retryInterval.emplace(j.at("retryInterval"));
+    }
+}
+
+/// \brief Writes the string representation of the given UpdateFirmwareRequest \p k to the given output stream \p os
+/// \returns an output stream with the UpdateFirmwareRequest written to
+std::ostream& operator<<(std::ostream& os, const UpdateFirmwareRequest& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+std::string UpdateFirmwareResponse::get_type() const {
+    return "UpdateFirmwareResponse";
+}
+
+void to_json(json& j, const UpdateFirmwareResponse& k) {
+    // the required parts of the message
+    j = json({});
+    // the optional parts of the message
+}
+
+void from_json(const json& j, UpdateFirmwareResponse& k) {
+    // the required parts of the message
+
+    // the optional parts of the message
+}
+
+/// \brief Writes the string representation of the given UpdateFirmwareResponse \p k to the given output stream \p os
+/// \returns an output stream with the UpdateFirmwareResponse written to
+std::ostream& operator<<(std::ostream& os, const UpdateFirmwareResponse& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/ocpp_types.cpp
+++ b/lib/ocpp1_6/ocpp_types.cpp
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <string>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/enums.hpp>
+#include <ocpp1_6/types.hpp>
+
+#include <ocpp1_6/ocpp_types.hpp>
+
+namespace ocpp1_6 {
+
+/// \brief Conversion from a given IdTagInfo \p k to a given json object \p j
+void to_json(json& j, const IdTagInfo& k) {
+    // the required parts of the message
+    j = json{
+        {"status", conversions::authorization_status_to_string(k.status)},
+    };
+    // the optional parts of the message
+    if (k.expiryDate) {
+        j["expiryDate"] = k.expiryDate.value().to_rfc3339();
+    }
+    if (k.parentIdTag) {
+        j["parentIdTag"] = k.parentIdTag.value();
+    }
+}
+
+/// \brief Conversion from a given json object \p j to a given IdTagInfo \p k
+void from_json(const json& j, IdTagInfo& k) {
+    // the required parts of the message
+    k.status = conversions::string_to_authorization_status(j.at("status"));
+
+    // the optional parts of the message
+    if (j.contains("expiryDate")) {
+        k.expiryDate.emplace(j.at("expiryDate"));
+    }
+    if (j.contains("parentIdTag")) {
+        k.parentIdTag.emplace(j.at("parentIdTag"));
+    }
+}
+
+// \brief Writes the string representation of the given IdTagInfo \p k to the given output stream \p os
+/// \returns an output stream with the IdTagInfo written to
+std::ostream& operator<<(std::ostream& os, const IdTagInfo& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given ChargingSchedulePeriod \p k to a given json object \p j
+void to_json(json& j, const ChargingSchedulePeriod& k) {
+    // the required parts of the message
+    j = json{
+        {"startPeriod", k.startPeriod},
+        {"limit", k.limit},
+    };
+    // the optional parts of the message
+    if (k.numberPhases) {
+        j["numberPhases"] = k.numberPhases.value();
+    }
+}
+
+/// \brief Conversion from a given json object \p j to a given ChargingSchedulePeriod \p k
+void from_json(const json& j, ChargingSchedulePeriod& k) {
+    // the required parts of the message
+    k.startPeriod = j.at("startPeriod");
+    k.limit = j.at("limit");
+
+    // the optional parts of the message
+    if (j.contains("numberPhases")) {
+        k.numberPhases.emplace(j.at("numberPhases"));
+    }
+}
+
+// \brief Writes the string representation of the given ChargingSchedulePeriod \p k to the given output stream \p os
+/// \returns an output stream with the ChargingSchedulePeriod written to
+std::ostream& operator<<(std::ostream& os, const ChargingSchedulePeriod& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given ChargingSchedule \p k to a given json object \p j
+void to_json(json& j, const ChargingSchedule& k) {
+    // the required parts of the message
+    j = json{
+        {"chargingRateUnit", conversions::charging_rate_unit_to_string(k.chargingRateUnit)},
+        {"chargingSchedulePeriod", k.chargingSchedulePeriod},
+    };
+    // the optional parts of the message
+    if (k.duration) {
+        j["duration"] = k.duration.value();
+    }
+    if (k.startSchedule) {
+        j["startSchedule"] = k.startSchedule.value().to_rfc3339();
+    }
+    if (k.minChargingRate) {
+        j["minChargingRate"] = k.minChargingRate.value();
+    }
+}
+
+/// \brief Conversion from a given json object \p j to a given ChargingSchedule \p k
+void from_json(const json& j, ChargingSchedule& k) {
+    // the required parts of the message
+    k.chargingRateUnit = conversions::string_to_charging_rate_unit(j.at("chargingRateUnit"));
+    for (auto val : j.at("chargingSchedulePeriod")) {
+        k.chargingSchedulePeriod.push_back(val);
+    }
+
+    // the optional parts of the message
+    if (j.contains("duration")) {
+        k.duration.emplace(j.at("duration"));
+    }
+    if (j.contains("startSchedule")) {
+        k.startSchedule.emplace(j.at("startSchedule"));
+    }
+    if (j.contains("minChargingRate")) {
+        k.minChargingRate.emplace(j.at("minChargingRate"));
+    }
+}
+
+// \brief Writes the string representation of the given ChargingSchedule \p k to the given output stream \p os
+/// \returns an output stream with the ChargingSchedule written to
+std::ostream& operator<<(std::ostream& os, const ChargingSchedule& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given KeyValue \p k to a given json object \p j
+void to_json(json& j, const KeyValue& k) {
+    // the required parts of the message
+    j = json{
+        {"key", k.key},
+        {"readonly", k.readonly},
+    };
+    // the optional parts of the message
+    if (k.value) {
+        j["value"] = k.value.value();
+    }
+}
+
+/// \brief Conversion from a given json object \p j to a given KeyValue \p k
+void from_json(const json& j, KeyValue& k) {
+    // the required parts of the message
+    k.key = j.at("key");
+    k.readonly = j.at("readonly");
+
+    // the optional parts of the message
+    if (j.contains("value")) {
+        k.value.emplace(j.at("value"));
+    }
+}
+
+// \brief Writes the string representation of the given KeyValue \p k to the given output stream \p os
+/// \returns an output stream with the KeyValue written to
+std::ostream& operator<<(std::ostream& os, const KeyValue& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given SampledValue \p k to a given json object \p j
+void to_json(json& j, const SampledValue& k) {
+    // the required parts of the message
+    j = json{
+        {"value", k.value},
+    };
+    // the optional parts of the message
+    if (k.context) {
+        j["context"] = conversions::reading_context_to_string(k.context.value());
+    }
+    if (k.format) {
+        j["format"] = conversions::value_format_to_string(k.format.value());
+    }
+    if (k.measurand) {
+        j["measurand"] = conversions::measurand_to_string(k.measurand.value());
+    }
+    if (k.phase) {
+        j["phase"] = conversions::phase_to_string(k.phase.value());
+    }
+    if (k.location) {
+        j["location"] = conversions::location_to_string(k.location.value());
+    }
+    if (k.unit) {
+        j["unit"] = conversions::unit_of_measure_to_string(k.unit.value());
+    }
+}
+
+/// \brief Conversion from a given json object \p j to a given SampledValue \p k
+void from_json(const json& j, SampledValue& k) {
+    // the required parts of the message
+    k.value = j.at("value");
+
+    // the optional parts of the message
+    if (j.contains("context")) {
+        k.context.emplace(j.at("context"));
+    }
+    if (j.contains("format")) {
+        k.format.emplace(j.at("format"));
+    }
+    if (j.contains("measurand")) {
+        k.measurand.emplace(j.at("measurand"));
+    }
+    if (j.contains("phase")) {
+        k.phase.emplace(j.at("phase"));
+    }
+    if (j.contains("location")) {
+        k.location.emplace(j.at("location"));
+    }
+    if (j.contains("unit")) {
+        k.unit.emplace(j.at("unit"));
+    }
+}
+
+// \brief Writes the string representation of the given SampledValue \p k to the given output stream \p os
+/// \returns an output stream with the SampledValue written to
+std::ostream& operator<<(std::ostream& os, const SampledValue& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given MeterValue \p k to a given json object \p j
+void to_json(json& j, const MeterValue& k) {
+    // the required parts of the message
+    j = json{
+        {"timestamp", k.timestamp.to_rfc3339()},
+        {"sampledValue", k.sampledValue},
+    };
+    // the optional parts of the message
+}
+
+/// \brief Conversion from a given json object \p j to a given MeterValue \p k
+void from_json(const json& j, MeterValue& k) {
+    // the required parts of the message
+    k.timestamp = DateTime(std::string(j.at("timestamp")));
+    ;
+    for (auto val : j.at("sampledValue")) {
+        k.sampledValue.push_back(val);
+    }
+
+    // the optional parts of the message
+}
+
+// \brief Writes the string representation of the given MeterValue \p k to the given output stream \p os
+/// \returns an output stream with the MeterValue written to
+std::ostream& operator<<(std::ostream& os, const MeterValue& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given ChargingProfile \p k to a given json object \p j
+void to_json(json& j, const ChargingProfile& k) {
+    // the required parts of the message
+    j = json{
+        {"chargingProfileId", k.chargingProfileId},
+        {"stackLevel", k.stackLevel},
+        {"chargingProfilePurpose", conversions::charging_profile_purpose_type_to_string(k.chargingProfilePurpose)},
+        {"chargingProfileKind", conversions::charging_profile_kind_type_to_string(k.chargingProfileKind)},
+        {"chargingSchedule", k.chargingSchedule},
+    };
+    // the optional parts of the message
+    if (k.transactionId) {
+        j["transactionId"] = k.transactionId.value();
+    }
+    if (k.recurrencyKind) {
+        j["recurrencyKind"] = conversions::recurrency_kind_type_to_string(k.recurrencyKind.value());
+    }
+    if (k.validFrom) {
+        j["validFrom"] = k.validFrom.value().to_rfc3339();
+    }
+    if (k.validTo) {
+        j["validTo"] = k.validTo.value().to_rfc3339();
+    }
+}
+
+/// \brief Conversion from a given json object \p j to a given ChargingProfile \p k
+void from_json(const json& j, ChargingProfile& k) {
+    // the required parts of the message
+    k.chargingProfileId = j.at("chargingProfileId");
+    k.stackLevel = j.at("stackLevel");
+    k.chargingProfilePurpose = conversions::string_to_charging_profile_purpose_type(j.at("chargingProfilePurpose"));
+    k.chargingProfileKind = conversions::string_to_charging_profile_kind_type(j.at("chargingProfileKind"));
+    k.chargingSchedule = j.at("chargingSchedule");
+
+    // the optional parts of the message
+    if (j.contains("transactionId")) {
+        k.transactionId.emplace(j.at("transactionId"));
+    }
+    if (j.contains("recurrencyKind")) {
+        k.recurrencyKind.emplace(j.at("recurrencyKind"));
+    }
+    if (j.contains("validFrom")) {
+        k.validFrom.emplace(j.at("validFrom"));
+    }
+    if (j.contains("validTo")) {
+        k.validTo.emplace(j.at("validTo"));
+    }
+}
+
+// \brief Writes the string representation of the given ChargingProfile \p k to the given output stream \p os
+/// \returns an output stream with the ChargingProfile written to
+std::ostream& operator<<(std::ostream& os, const ChargingProfile& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given LocalAuthorizationList \p k to a given json object \p j
+void to_json(json& j, const LocalAuthorizationList& k) {
+    // the required parts of the message
+    j = json{
+        {"idTag", k.idTag},
+    };
+    // the optional parts of the message
+    if (k.idTagInfo) {
+        j["idTagInfo"] = k.idTagInfo.value();
+    }
+}
+
+/// \brief Conversion from a given json object \p j to a given LocalAuthorizationList \p k
+void from_json(const json& j, LocalAuthorizationList& k) {
+    // the required parts of the message
+    k.idTag = j.at("idTag");
+
+    // the optional parts of the message
+    if (j.contains("idTagInfo")) {
+        k.idTagInfo.emplace(j.at("idTagInfo"));
+    }
+}
+
+// \brief Writes the string representation of the given LocalAuthorizationList \p k to the given output stream \p os
+/// \returns an output stream with the LocalAuthorizationList written to
+std::ostream& operator<<(std::ostream& os, const LocalAuthorizationList& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+/// \brief Conversion from a given TransactionData \p k to a given json object \p j
+void to_json(json& j, const TransactionData& k) {
+    // the required parts of the message
+    j = json{
+        {"timestamp", k.timestamp.to_rfc3339()},
+        {"sampledValue", k.sampledValue},
+    };
+    // the optional parts of the message
+}
+
+/// \brief Conversion from a given json object \p j to a given TransactionData \p k
+void from_json(const json& j, TransactionData& k) {
+    // the required parts of the message
+    k.timestamp = DateTime(std::string(j.at("timestamp")));
+    ;
+    for (auto val : j.at("sampledValue")) {
+        k.sampledValue.push_back(val);
+    }
+
+    // the optional parts of the message
+}
+
+// \brief Writes the string representation of the given TransactionData \p k to the given output stream \p os
+/// \returns an output stream with the TransactionData written to
+std::ostream& operator<<(std::ostream& os, const TransactionData& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/schemas.cpp
+++ b/lib/ocpp1_6/schemas.cpp
@@ -23,35 +23,24 @@ Schemas::Schemas(std::string main_dir) {
 
 void Schemas::load_root_schema() {
     boost::filesystem::path profile_path = this->profile_schemas_path / "Config.json";
-    std::string profile = profile_path.stem().string();
 
     EVLOG(debug) << "parsing root schema file: " << boost::filesystem::canonical(profile_path);
 
     std::ifstream ifs(profile_path.c_str());
     std::string schema_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-    json schema = json::parse(schema_file);
+    this->profile_schema = json::parse(schema_file);
 
-    this->profile_schemas[profile] = schema;
-
-    this->profile_validators[profile] = std::make_shared<json_validator>(
+    this->profile_validator = std::make_shared<json_validator>(
         [this](const json_uri& uri, json& schema) { this->loader(uri, schema); }, Schemas::format_checker);
-    this->profile_validators[profile]->set_root_schema(schema);
+    this->profile_validator->set_root_schema(this->profile_schema);
 }
 
 json Schemas::get_profile_schema() {
-    std::string profile = "Config";
-    if (this->profile_schemas.count(profile) == 0) {
-        throw std::runtime_error("No schema available for profile: " + profile);
-    }
-    return this->profile_schemas[profile];
+    return this->profile_schema;
 }
 
 std::shared_ptr<json_validator> Schemas::get_profile_validator() {
-    std::string profile = "Config";
-    if (this->profile_validators.count(profile) == 0) {
-        throw std::runtime_error("No validator available for profile: " + profile);
-    }
-    return this->profile_validators[profile];
+    return this->profile_validator;
 }
 
 void Schemas::loader(const json_uri& uri, json& schema) {

--- a/lib/ocpp1_6/types.cpp
+++ b/lib/ocpp1_6/types.cpp
@@ -125,6 +125,8 @@ const std::string messagetype_to_string(MessageType m) {
         return "UpdateFirmware";
     case MessageType::UpdateFirmwareResponse:
         return "UpdateFirmwareResponse";
+    case MessageType::InternalError:
+        throw std::out_of_range("No known string conversion for InternalError MessageType");
     }
 
     throw std::out_of_range("No known string conversion for provided enum of type MessageType");

--- a/lib/ocpp1_6/types.cpp
+++ b/lib/ocpp1_6/types.cpp
@@ -132,7 +132,7 @@ std::string messagetype_to_string(MessageType m) {
     throw std::out_of_range("No known string conversion for provided enum of type MessageType");
 }
 
-MessageType string_to_messagetype(std::string s) {
+MessageType string_to_messagetype(const std::string& s) {
     if (s == "Authorize") {
         return MessageType::Authorize;
     }
@@ -618,7 +618,7 @@ std::string charge_point_connection_state_to_string(ChargePointConnectionState e
     throw std::out_of_range("No known string conversion for provided enum of type ChargePointConnectionState");
 }
 
-ChargePointConnectionState string_to_charge_point_connection_state(std::string s) {
+ChargePointConnectionState string_to_charge_point_connection_state(const std::string& s) {
     if (s == "Disconnected") {
         return ChargePointConnectionState::Disconnected;
     }
@@ -669,7 +669,7 @@ std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
-SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s) {
+SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string& s) {
     if (s == "Core") {
         return SupportedFeatureProfiles::Core;
     }

--- a/lib/ocpp1_6/types.cpp
+++ b/lib/ocpp1_6/types.cpp
@@ -11,7 +11,7 @@
 namespace ocpp1_6 {
 
 namespace conversions {
-const std::string messagetype_to_string(MessageType m) {
+std::string messagetype_to_string(MessageType m) {
     switch (m) {
     case MessageType::Authorize:
         return "Authorize";
@@ -132,7 +132,7 @@ const std::string messagetype_to_string(MessageType m) {
     throw std::out_of_range("No known string conversion for provided enum of type MessageType");
 }
 
-const MessageType string_to_messagetype(std::string s) {
+MessageType string_to_messagetype(std::string s) {
     if (s == "Authorize") {
         return MessageType::Authorize;
     }
@@ -305,28 +305,28 @@ const MessageType string_to_messagetype(std::string s) {
     throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageType");
 }
 
-const std::string bool_to_string(bool b) {
+std::string bool_to_string(bool b) {
     if (b) {
         return "true";
     }
     return "false";
 }
 
-const bool string_to_bool(const std::string& s) {
+bool string_to_bool(const std::string& s) {
     if (s == "true") {
         return true;
     }
     return false;
 }
 
-const std::string double_to_string(double d, int precision) {
+std::string double_to_string(double d, int precision) {
     std::ostringstream str;
     str.precision(precision);
     str << std::fixed << d;
     return str.str();
 }
 
-const std::string double_to_string(double d) {
+std::string double_to_string(double d) {
     return conversions::double_to_string(d, 2);
 }
 } // namespace conversions
@@ -591,7 +591,7 @@ std::ostream& operator<<(std::ostream& os, const CallError& c) {
 }
 namespace conversions {
 
-const std::string charge_point_connection_state_to_string(ChargePointConnectionState e) {
+std::string charge_point_connection_state_to_string(ChargePointConnectionState e) {
     switch (e) {
     case ChargePointConnectionState::Disconnected:
         return "Disconnected";
@@ -608,7 +608,7 @@ const std::string charge_point_connection_state_to_string(ChargePointConnectionS
     throw std::out_of_range("No known string conversion for provided enum of type ChargePointConnectionState");
 }
 
-const ChargePointConnectionState string_to_charge_point_connection_state(std::string s) {
+ChargePointConnectionState string_to_charge_point_connection_state(std::string s) {
     if (s == "Disconnected") {
         return ChargePointConnectionState::Disconnected;
     }
@@ -638,7 +638,7 @@ std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& cha
 namespace conversions {
 /// \brief Converts the given SupportedFeatureProfiles \p e to std::string
 /// \returns a string representation of the SupportedFeatureProfiles
-const std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
+std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
     switch (e) {
     case SupportedFeatureProfiles::Core:
         return "Core";
@@ -659,7 +659,7 @@ const std::string supported_feature_profiles_to_string(SupportedFeatureProfiles 
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
-const SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s) {
+SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s) {
     if (s == "Core") {
         return SupportedFeatureProfiles::Core;
     }

--- a/lib/ocpp1_6/types.cpp
+++ b/lib/ocpp1_6/types.cpp
@@ -542,6 +542,16 @@ DateTime::DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint)
 DateTime::DateTime(const std::string& timepoint_str) : DateTimeImpl(timepoint_str) {
 }
 
+DateTime& DateTime::operator=(const std::string& s) {
+    this->from_rfc3339(s);
+    return *this;
+}
+
+DateTime& DateTime::operator=(const char* c) {
+    this->from_rfc3339(std::string(c));
+    return *this;
+}
+
 bool MeasurandWithPhase::operator==(MeasurandWithPhase measurand_with_phase) {
     if (this->measurand == measurand_with_phase.measurand) {
         if (this->phase || measurand_with_phase.phase) {

--- a/lib/ocpp1_6/types.cpp
+++ b/lib/ocpp1_6/types.cpp
@@ -1,0 +1,692 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <string>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/enums.hpp>
+#include <ocpp1_6/types.hpp>
+
+namespace ocpp1_6 {
+
+namespace conversions {
+const std::string messagetype_to_string(MessageType m) {
+    switch (m) {
+    case MessageType::Authorize:
+        return "Authorize";
+    case MessageType::AuthorizeResponse:
+        return "AuthorizeResponse";
+    case MessageType::BootNotification:
+        return "BootNotification";
+    case MessageType::BootNotificationResponse:
+        return "BootNotificationResponse";
+    case MessageType::CancelReservation:
+        return "CancelReservation";
+    case MessageType::CancelReservationResponse:
+        return "CancelReservationResponse";
+    case MessageType::ChangeAvailability:
+        return "ChangeAvailability";
+    case MessageType::ChangeAvailabilityResponse:
+        return "ChangeAvailabilityResponse";
+    case MessageType::ChangeConfiguration:
+        return "ChangeConfiguration";
+    case MessageType::ChangeConfigurationResponse:
+        return "ChangeConfigurationResponse";
+    case MessageType::ClearCache:
+        return "ClearCache";
+    case MessageType::ClearCacheResponse:
+        return "ClearCacheResponse";
+    case MessageType::ClearChargingProfile:
+        return "ClearChargingProfile";
+    case MessageType::ClearChargingProfileResponse:
+        return "ClearChargingProfileResponse";
+    case MessageType::DataTransfer:
+        return "DataTransfer";
+    case MessageType::DataTransferResponse:
+        return "DataTransferResponse";
+    case MessageType::DiagnosticsStatusNotification:
+        return "DiagnosticsStatusNotification";
+    case MessageType::DiagnosticsStatusNotificationResponse:
+        return "DiagnosticsStatusNotificationResponse";
+    case MessageType::FirmwareStatusNotification:
+        return "FirmwareStatusNotification";
+    case MessageType::FirmwareStatusNotificationResponse:
+        return "FirmwareStatusNotificationResponse";
+    case MessageType::GetCompositeSchedule:
+        return "GetCompositeSchedule";
+    case MessageType::GetCompositeScheduleResponse:
+        return "GetCompositeScheduleResponse";
+    case MessageType::GetConfiguration:
+        return "GetConfiguration";
+    case MessageType::GetConfigurationResponse:
+        return "GetConfigurationResponse";
+    case MessageType::GetDiagnostics:
+        return "GetDiagnostics";
+    case MessageType::GetDiagnosticsResponse:
+        return "GetDiagnosticsResponse";
+    case MessageType::GetLocalListVersion:
+        return "GetLocalListVersion";
+    case MessageType::GetLocalListVersionResponse:
+        return "GetLocalListVersionResponse";
+    case MessageType::Heartbeat:
+        return "Heartbeat";
+    case MessageType::HeartbeatResponse:
+        return "HeartbeatResponse";
+    case MessageType::MeterValues:
+        return "MeterValues";
+    case MessageType::MeterValuesResponse:
+        return "MeterValuesResponse";
+    case MessageType::RemoteStartTransaction:
+        return "RemoteStartTransaction";
+    case MessageType::RemoteStartTransactionResponse:
+        return "RemoteStartTransactionResponse";
+    case MessageType::RemoteStopTransaction:
+        return "RemoteStopTransaction";
+    case MessageType::RemoteStopTransactionResponse:
+        return "RemoteStopTransactionResponse";
+    case MessageType::ReserveNow:
+        return "ReserveNow";
+    case MessageType::ReserveNowResponse:
+        return "ReserveNowResponse";
+    case MessageType::Reset:
+        return "Reset";
+    case MessageType::ResetResponse:
+        return "ResetResponse";
+    case MessageType::SendLocalList:
+        return "SendLocalList";
+    case MessageType::SendLocalListResponse:
+        return "SendLocalListResponse";
+    case MessageType::SetChargingProfile:
+        return "SetChargingProfile";
+    case MessageType::SetChargingProfileResponse:
+        return "SetChargingProfileResponse";
+    case MessageType::StartTransaction:
+        return "StartTransaction";
+    case MessageType::StartTransactionResponse:
+        return "StartTransactionResponse";
+    case MessageType::StatusNotification:
+        return "StatusNotification";
+    case MessageType::StatusNotificationResponse:
+        return "StatusNotificationResponse";
+    case MessageType::StopTransaction:
+        return "StopTransaction";
+    case MessageType::StopTransactionResponse:
+        return "StopTransactionResponse";
+    case MessageType::TriggerMessage:
+        return "TriggerMessage";
+    case MessageType::TriggerMessageResponse:
+        return "TriggerMessageResponse";
+    case MessageType::UnlockConnector:
+        return "UnlockConnector";
+    case MessageType::UnlockConnectorResponse:
+        return "UnlockConnectorResponse";
+    case MessageType::UpdateFirmware:
+        return "UpdateFirmware";
+    case MessageType::UpdateFirmwareResponse:
+        return "UpdateFirmwareResponse";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type MessageType");
+}
+
+const MessageType string_to_messagetype(std::string s) {
+    if (s == "Authorize") {
+        return MessageType::Authorize;
+    }
+    if (s == "AuthorizeResponse") {
+        return MessageType::AuthorizeResponse;
+    }
+    if (s == "BootNotification") {
+        return MessageType::BootNotification;
+    }
+    if (s == "BootNotificationResponse") {
+        return MessageType::BootNotificationResponse;
+    }
+    if (s == "CancelReservation") {
+        return MessageType::CancelReservation;
+    }
+    if (s == "CancelReservationResponse") {
+        return MessageType::CancelReservationResponse;
+    }
+    if (s == "ChangeAvailability") {
+        return MessageType::ChangeAvailability;
+    }
+    if (s == "ChangeAvailabilityResponse") {
+        return MessageType::ChangeAvailabilityResponse;
+    }
+    if (s == "ChangeConfiguration") {
+        return MessageType::ChangeConfiguration;
+    }
+    if (s == "ChangeConfigurationResponse") {
+        return MessageType::ChangeConfigurationResponse;
+    }
+    if (s == "ClearCache") {
+        return MessageType::ClearCache;
+    }
+    if (s == "ClearCacheResponse") {
+        return MessageType::ClearCacheResponse;
+    }
+    if (s == "ClearChargingProfile") {
+        return MessageType::ClearChargingProfile;
+    }
+    if (s == "ClearChargingProfileResponse") {
+        return MessageType::ClearChargingProfileResponse;
+    }
+    if (s == "DataTransfer") {
+        return MessageType::DataTransfer;
+    }
+    if (s == "DataTransferResponse") {
+        return MessageType::DataTransferResponse;
+    }
+    if (s == "DiagnosticsStatusNotification") {
+        return MessageType::DiagnosticsStatusNotification;
+    }
+    if (s == "DiagnosticsStatusNotificationResponse") {
+        return MessageType::DiagnosticsStatusNotificationResponse;
+    }
+    if (s == "FirmwareStatusNotification") {
+        return MessageType::FirmwareStatusNotification;
+    }
+    if (s == "FirmwareStatusNotificationResponse") {
+        return MessageType::FirmwareStatusNotificationResponse;
+    }
+    if (s == "GetCompositeSchedule") {
+        return MessageType::GetCompositeSchedule;
+    }
+    if (s == "GetCompositeScheduleResponse") {
+        return MessageType::GetCompositeScheduleResponse;
+    }
+    if (s == "GetConfiguration") {
+        return MessageType::GetConfiguration;
+    }
+    if (s == "GetConfigurationResponse") {
+        return MessageType::GetConfigurationResponse;
+    }
+    if (s == "GetDiagnostics") {
+        return MessageType::GetDiagnostics;
+    }
+    if (s == "GetDiagnosticsResponse") {
+        return MessageType::GetDiagnosticsResponse;
+    }
+    if (s == "GetLocalListVersion") {
+        return MessageType::GetLocalListVersion;
+    }
+    if (s == "GetLocalListVersionResponse") {
+        return MessageType::GetLocalListVersionResponse;
+    }
+    if (s == "Heartbeat") {
+        return MessageType::Heartbeat;
+    }
+    if (s == "HeartbeatResponse") {
+        return MessageType::HeartbeatResponse;
+    }
+    if (s == "MeterValues") {
+        return MessageType::MeterValues;
+    }
+    if (s == "MeterValuesResponse") {
+        return MessageType::MeterValuesResponse;
+    }
+    if (s == "RemoteStartTransaction") {
+        return MessageType::RemoteStartTransaction;
+    }
+    if (s == "RemoteStartTransactionResponse") {
+        return MessageType::RemoteStartTransactionResponse;
+    }
+    if (s == "RemoteStopTransaction") {
+        return MessageType::RemoteStopTransaction;
+    }
+    if (s == "RemoteStopTransactionResponse") {
+        return MessageType::RemoteStopTransactionResponse;
+    }
+    if (s == "ReserveNow") {
+        return MessageType::ReserveNow;
+    }
+    if (s == "ReserveNowResponse") {
+        return MessageType::ReserveNowResponse;
+    }
+    if (s == "Reset") {
+        return MessageType::Reset;
+    }
+    if (s == "ResetResponse") {
+        return MessageType::ResetResponse;
+    }
+    if (s == "SendLocalList") {
+        return MessageType::SendLocalList;
+    }
+    if (s == "SendLocalListResponse") {
+        return MessageType::SendLocalListResponse;
+    }
+    if (s == "SetChargingProfile") {
+        return MessageType::SetChargingProfile;
+    }
+    if (s == "SetChargingProfileResponse") {
+        return MessageType::SetChargingProfileResponse;
+    }
+    if (s == "StartTransaction") {
+        return MessageType::StartTransaction;
+    }
+    if (s == "StartTransactionResponse") {
+        return MessageType::StartTransactionResponse;
+    }
+    if (s == "StatusNotification") {
+        return MessageType::StatusNotification;
+    }
+    if (s == "StatusNotificationResponse") {
+        return MessageType::StatusNotificationResponse;
+    }
+    if (s == "StopTransaction") {
+        return MessageType::StopTransaction;
+    }
+    if (s == "StopTransactionResponse") {
+        return MessageType::StopTransactionResponse;
+    }
+    if (s == "TriggerMessage") {
+        return MessageType::TriggerMessage;
+    }
+    if (s == "TriggerMessageResponse") {
+        return MessageType::TriggerMessageResponse;
+    }
+    if (s == "UnlockConnector") {
+        return MessageType::UnlockConnector;
+    }
+    if (s == "UnlockConnectorResponse") {
+        return MessageType::UnlockConnectorResponse;
+    }
+    if (s == "UpdateFirmware") {
+        return MessageType::UpdateFirmware;
+    }
+    if (s == "UpdateFirmwareResponse") {
+        return MessageType::UpdateFirmwareResponse;
+    }
+
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageType");
+}
+
+const std::string bool_to_string(bool b) {
+    if (b) {
+        return "true";
+    }
+    return "false";
+}
+
+const bool string_to_bool(const std::string& s) {
+    if (s == "true") {
+        return true;
+    }
+    return false;
+}
+
+const std::string double_to_string(double d, int precision) {
+    std::ostringstream str;
+    str.precision(precision);
+    str << std::fixed << d;
+    return str.str();
+}
+
+const std::string double_to_string(double d) {
+    return conversions::double_to_string(d, 2);
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const MessageType& message_type) {
+    os << conversions::messagetype_to_string(message_type);
+    return os;
+}
+
+CiString20Type::CiString20Type(const std::string& data) : CiString(data, 20) {
+}
+
+CiString20Type::CiString20Type(const json& data) : CiString(data.get<std::string>(), 20) {
+}
+
+CiString20Type::CiString20Type() : CiString(20) {
+}
+
+CiString20Type& CiString20Type::operator=(const std::string& s) {
+    this->set(s);
+    return *this;
+}
+
+CiString20Type& CiString20Type::operator=(const char* c) {
+    this->set(std::string(c));
+    return *this;
+}
+
+CiString20Type& CiString20Type::operator=(const json& j) {
+    this->set(j.get<std::string>());
+    return *this;
+}
+
+void to_json(json& j, const CiString20Type& k) {
+    j = json(k.get());
+}
+
+void from_json(const json& j, CiString20Type& k) {
+    k.set(j);
+}
+
+CiString25Type::CiString25Type(const std::string& data) : CiString(data, 25) {
+}
+
+CiString25Type::CiString25Type(const json& data) : CiString(data.get<std::string>(), 25) {
+}
+
+CiString25Type::CiString25Type() : CiString(25) {
+}
+
+CiString25Type& CiString25Type::operator=(const std::string& s) {
+    this->set(s);
+    return *this;
+}
+
+CiString25Type& CiString25Type::operator=(const char* c) {
+    this->set(std::string(c));
+    return *this;
+}
+
+CiString25Type& CiString25Type::operator=(const json& j) {
+    this->set(j.get<std::string>());
+    return *this;
+}
+
+void to_json(json& j, const CiString25Type& k) {
+    j = json(k.get());
+}
+
+void from_json(const json& j, CiString25Type& k) {
+    k.set(j);
+}
+
+CiString50Type::CiString50Type(const std::string& data) : CiString(data, 50) {
+}
+
+CiString50Type::CiString50Type(const json& data) : CiString(data.get<std::string>(), 50) {
+}
+
+CiString50Type::CiString50Type() : CiString(50) {
+}
+
+CiString50Type& CiString50Type::operator=(const std::string& s) {
+    this->set(s);
+    return *this;
+}
+
+CiString50Type& CiString50Type::operator=(const char* c) {
+    this->set(std::string(c));
+    return *this;
+}
+
+CiString50Type& CiString50Type::operator=(const json& j) {
+    this->set(j.get<std::string>());
+    return *this;
+}
+
+void to_json(json& j, const CiString50Type& k) {
+    j = json(k.get());
+}
+
+void from_json(const json& j, CiString50Type& k) {
+    k.set(j);
+}
+
+CiString255Type::CiString255Type(const std::string& data) : CiString(data, 255) {
+}
+
+CiString255Type::CiString255Type(const json& data) : CiString(data.get<std::string>(), 255) {
+}
+
+CiString255Type::CiString255Type() : CiString(255) {
+}
+
+CiString255Type& CiString255Type::operator=(const std::string& s) {
+    this->set(s);
+    return *this;
+}
+
+CiString255Type& CiString255Type::operator=(const char* c) {
+    this->set(std::string(c));
+    return *this;
+}
+
+CiString255Type& CiString255Type::operator=(const json& j) {
+    this->set(j.get<std::string>());
+    return *this;
+}
+
+void to_json(json& j, const CiString255Type& k) {
+    j = json(k.get());
+}
+
+void from_json(const json& j, CiString255Type& k) {
+    k.set(j);
+}
+
+CiString500Type::CiString500Type(const std::string& data) : CiString(data, 500) {
+}
+
+CiString500Type::CiString500Type(const json& data) : CiString(data.get<std::string>(), 500) {
+}
+
+CiString500Type::CiString500Type() : CiString(500) {
+}
+
+CiString500Type& CiString500Type::operator=(const std::string& s) {
+    this->set(s);
+    return *this;
+}
+
+CiString500Type& CiString500Type::operator=(const char* c) {
+    this->set(std::string(c));
+    return *this;
+}
+
+CiString500Type& CiString500Type::operator=(const json& j) {
+    this->set(j.get<std::string>());
+    return *this;
+}
+
+void to_json(json& j, const CiString500Type& k) {
+    j = json(k.get());
+}
+
+void from_json(const json& j, CiString500Type& k) {
+    k.set(j);
+}
+
+MessageId::MessageId(const std::string& data) : CiString(data, 36) {
+}
+
+MessageId::MessageId() : CiString(36) {
+}
+
+MessageId& MessageId::operator=(const std::string& s) {
+    this->set(s);
+    return *this;
+}
+
+MessageId& MessageId::operator=(const char* c) {
+    this->set(std::string(c));
+    return *this;
+}
+
+MessageId& MessageId::operator=(const json& j) {
+    this->set(j.get<std::string>());
+    return *this;
+}
+
+bool MessageId::operator<(const MessageId& rhs) {
+    return this->get() < rhs.get();
+}
+
+bool operator<(const MessageId& lhs, const MessageId& rhs) {
+    return lhs.get() < rhs.get();
+}
+
+void to_json(json& j, const MessageId& k) {
+    j = json(k.get());
+}
+
+void from_json(const json& j, MessageId& k) {
+    k.set(j);
+}
+
+DateTime::DateTime() : DateTimeImpl() {
+}
+
+DateTime::DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint) : DateTimeImpl(timepoint) {
+}
+
+DateTime::DateTime(const std::string& timepoint_str) : DateTimeImpl(timepoint_str) {
+}
+
+bool MeasurandWithPhase::operator==(MeasurandWithPhase measurand_with_phase) {
+    if (this->measurand == measurand_with_phase.measurand) {
+        if (this->phase || measurand_with_phase.phase) {
+            if (this->phase && measurand_with_phase.phase) {
+                if (this->phase.value() == measurand_with_phase.phase.value()) {
+                    return true;
+                }
+            }
+        } else {
+            return true;
+        }
+    }
+    return false;
+};
+
+CallError::CallError() {
+}
+
+CallError::CallError(const MessageId& uniqueId, const std::string& errorCode, const std::string& errorDescription,
+                     const json& errorDetails) {
+    this->uniqueId = uniqueId;
+    this->errorCode = errorCode;
+    this->errorDescription = errorDescription;
+    this->errorDetails = errorDetails;
+}
+
+void to_json(json& j, const CallError& c) {
+    j = json::array();
+    j.push_back(MessageTypeId::CALLERROR);
+    j.push_back(c.uniqueId.get());
+    j.push_back(c.errorCode);
+    j.push_back(c.errorDescription);
+    j.push_back(c.errorDetails);
+}
+
+void from_json(const json& j, CallError& c) {
+    // the required parts of the message
+    c.uniqueId.set(j.at(MESSAGE_ID));
+    c.errorCode = j.at(CALLERROR_ERROR_CODE);
+    c.errorDescription = j.at(CALLERROR_ERROR_DESCRIPTION);
+    c.errorDetails = j.at(CALLERROR_ERROR_DETAILS);
+}
+
+std::ostream& operator<<(std::ostream& os, const CallError& c) {
+    os << json(c).dump(4);
+    return os;
+}
+namespace conversions {
+
+const std::string charge_point_connection_state_to_string(ChargePointConnectionState e) {
+    switch (e) {
+    case ChargePointConnectionState::Disconnected:
+        return "Disconnected";
+    case ChargePointConnectionState::Connected:
+        return "Connected";
+    case ChargePointConnectionState::Booted:
+        return "Booted";
+    case ChargePointConnectionState::Pending:
+        return "Pending";
+    case ChargePointConnectionState::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargePointConnectionState");
+}
+
+const ChargePointConnectionState string_to_charge_point_connection_state(std::string s) {
+    if (s == "Disconnected") {
+        return ChargePointConnectionState::Disconnected;
+    }
+    if (s == "Connected") {
+        return ChargePointConnectionState::Connected;
+    }
+    if (s == "Booted") {
+        return ChargePointConnectionState::Booted;
+    }
+    if (s == "Pending") {
+        return ChargePointConnectionState::Pending;
+    }
+    if (s == "Rejected") {
+        return ChargePointConnectionState::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type ChargePointConnectionState");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state) {
+    os << conversions::charge_point_connection_state_to_string(charge_point_connection_state);
+    return os;
+}
+
+namespace conversions {
+/// \brief Converts the given SupportedFeatureProfiles \p e to std::string
+/// \returns a string representation of the SupportedFeatureProfiles
+const std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
+    switch (e) {
+    case SupportedFeatureProfiles::Core:
+        return "Core";
+    case SupportedFeatureProfiles::FirmwareManagement:
+        return "FirmwareManagement";
+    case SupportedFeatureProfiles::LocalAuthListManagement:
+        return "LocalAuthListManagement";
+    case SupportedFeatureProfiles::Reservation:
+        return "Reservation";
+    case SupportedFeatureProfiles::SmartCharging:
+        return "SmartCharging";
+    case SupportedFeatureProfiles::RemoteTrigger:
+        return "RemoteTrigger";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type SupportedFeatureProfiles");
+}
+
+/// \brief Converts the given std::string \p s to SupportedFeatureProfiles
+/// \returns a SupportedFeatureProfiles from a string representation
+const SupportedFeatureProfiles string_to_supported_feature_profiles(std::string s) {
+    if (s == "Core") {
+        return SupportedFeatureProfiles::Core;
+    }
+    if (s == "FirmwareManagement") {
+        return SupportedFeatureProfiles::FirmwareManagement;
+    }
+    if (s == "LocalAuthListManagement") {
+        return SupportedFeatureProfiles::LocalAuthListManagement;
+    }
+    if (s == "Reservation") {
+        return SupportedFeatureProfiles::Reservation;
+    }
+    if (s == "SmartCharging") {
+        return SupportedFeatureProfiles::SmartCharging;
+    }
+    if (s == "RemoteTrigger") {
+        return SupportedFeatureProfiles::RemoteTrigger;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type SupportedFeatureProfiles");
+}
+} // namespace conversions
+
+/// \brief Writes the string representation of the given \p supported_feature_profiles to the given output stream \p os
+/// \returns an output stream with the SupportedFeatureProfiles written to
+std::ostream& operator<<(std::ostream& os, const SupportedFeatureProfiles& supported_feature_profiles) {
+    os << conversions::supported_feature_profiles_to_string(supported_feature_profiles);
+    return os;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/types_internal.cpp
+++ b/lib/ocpp1_6/types_internal.cpp
@@ -55,7 +55,12 @@ DateTimeImpl::DateTimeImpl(const std::string& timepoint_str) {
         in.seekg(0);
         in >> date::parse("%FT%TZ", this->timepoint);
         if (in.fail()) {
-            EVLOG(error) << "timepoint string parsing failed";
+            in.clear();
+            in.seekg(0);
+            in >> date::parse("%FT%T", this->timepoint);
+            if (in.fail()) {
+                EVLOG(error) << "timepoint string parsing failed";
+            }
         }
     }
 }

--- a/lib/ocpp1_6/types_internal.cpp
+++ b/lib/ocpp1_6/types_internal.cpp
@@ -48,6 +48,14 @@ DateTimeImpl::DateTimeImpl(std::chrono::time_point<std::chrono::system_clock> ti
 }
 
 DateTimeImpl::DateTimeImpl(const std::string& timepoint_str) {
+    this->from_rfc3339(timepoint_str);
+}
+
+std::string DateTimeImpl::to_rfc3339() const {
+    return date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(this->timepoint));
+}
+
+void DateTimeImpl::from_rfc3339(const std::string& timepoint_str) {
     std::istringstream in{timepoint_str};
     in >> date::parse("%FT%T%Ez", this->timepoint);
     if (in.fail()) {
@@ -63,10 +71,6 @@ DateTimeImpl::DateTimeImpl(const std::string& timepoint_str) {
             }
         }
     }
-}
-
-std::string DateTimeImpl::to_rfc3339() const {
-    return date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(this->timepoint));
 }
 
 std::chrono::time_point<std::chrono::system_clock> DateTimeImpl::to_time_point() {

--- a/lib/ocpp1_6/websocket.cpp
+++ b/lib/ocpp1_6/websocket.cpp
@@ -7,419 +7,61 @@
 
 namespace ocpp1_6 {
 
-Websocket::Websocket(std::shared_ptr<ChargePointConfiguration> configuration) :
-    tls(false),
-    shutting_down(false),
-    reconnect_timer(nullptr),
-    connected_callback(nullptr),
-    disconnected_callback(nullptr),
-    message_callback(nullptr) {
-    this->reconnect_interval_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                      std::chrono::seconds(configuration->getWebsocketReconnectInterval()))
-                                      .count();
+Websocket::Websocket(std::shared_ptr<ChargePointConfiguration> configuration) : tls(false), shutting_down(false) {
+
     this->configuration = configuration;
+
+    this->websocket_plain = std::make_unique<WebsocketPlain>(configuration);
+    this->websocket_tls = std::make_unique<WebsocketTLS>(configuration);
 }
 
 bool Websocket::connect() {
-    if (!this->initialized()) {
-        return false;
-    }
     auto uri = this->configuration->getCentralSystemURI();
     EVLOG(info) << "Connecting to uri: " << uri;
     if (uri.find("ws://") == 0) {
-        EVLOG(info) << "Connecting plain websocket";
-        this->ws_client.clear_access_channels(websocketpp::log::alevel::all);
-        this->ws_client.clear_error_channels(websocketpp::log::elevel::all);
-        this->ws_client.init_asio();
-        this->ws_client.start_perpetual();
         this->tls = false;
-        this->uri = uri;
-
-        websocket_thread.reset(new websocketpp::lib::thread(&client::run, &this->ws_client));
-
-        this->reconnect_callback = [this](const websocketpp::lib::error_code& ec) {
-            EVLOG(info) << "Reconnecting plain websocket...";
-            {
-                std::lock_guard<std::mutex> lk(this->reconnect_mutex);
-                if (this->reconnect_timer) {
-                    this->reconnect_timer.get()->cancel();
-                }
-                this->reconnect_timer = nullptr;
-            }
-            this->connect_plain();
-        };
-
-        this->connect_plain();
-        return true;
+        return this->websocket_plain->connect();
     }
     if (uri.find("wss://") == 0) {
-        EVLOG(info) << "Connecting TLS websocket, hostname: " << this->get_hostname(uri);
-        this->wss_client.clear_access_channels(websocketpp::log::alevel::all);
-        this->wss_client.clear_error_channels(websocketpp::log::elevel::all);
-        this->wss_client.init_asio();
-        this->wss_client.start_perpetual();
         this->tls = true;
-        this->uri = uri;
-
-        this->wss_client.set_tls_init_handler(websocketpp::lib::bind(
-            &Websocket::on_tls_init, this, this->get_hostname(uri), websocketpp::lib::placeholders::_1));
-
-        std::string authentication_header = "";
-        auto authorization_key = this->configuration->getAuthorizationKey();
-        if (authorization_key != boost::none) {
-            EVLOG(debug) << "AuthorizationKey present, encoding authentication header";
-            std::string auth_header = this->configuration->getChargePointId() + ":" + authorization_key.value();
-            authentication_header = std::string("Basic ") + websocketpp::base64_encode(auth_header);
-        }
-
-        websocket_thread.reset(new websocketpp::lib::thread(&tls_client::run, &this->wss_client));
-
-        this->reconnect_callback = [this, authentication_header](const websocketpp::lib::error_code& ec) {
-            EVLOG(info) << "Reconnecting TLS websocket...";
-            {
-                std::lock_guard<std::mutex> lk(this->reconnect_mutex);
-                if (this->reconnect_timer) {
-                    this->reconnect_timer.get()->cancel();
-                }
-                this->reconnect_timer = nullptr;
-            }
-            this->connect_tls(authentication_header);
-        };
-
-        this->connect_tls(authentication_header);
-        return true;
+        return this->websocket_tls->connect();
     }
 
     return false;
 }
 
 void Websocket::disconnect() {
-    if (!this->initialized()) {
-        EVLOG(error) << "Cannot disconnect a websocket that was not initialized";
-        return;
-    }
     this->shutting_down = true; // FIXME(kai): this makes the websocket inoperable after a disconnect, however this
                                 // might not be a bad thing.
-    if (this->reconnect_timer) {
-        this->reconnect_timer.get()->cancel();
-    }
     if (this->tls) {
         EVLOG(info) << "Disconnecting TLS websocket...";
-
-        this->close_tls(websocketpp::close::status::normal, "");
+        this->websocket_tls->disconnect();
     } else {
         EVLOG(info) << "Disconnecting plain websocket...";
-        this->close_plain(websocketpp::close::status::normal, "");
+        this->websocket_plain->disconnect();
     }
 }
 void Websocket::register_connected_callback(const std::function<void()>& callback) {
-    this->connected_callback = callback;
+    this->websocket_plain->register_connected_callback(callback);
+    this->websocket_tls->register_connected_callback(callback);
 }
 void Websocket::register_disconnected_callback(const std::function<void()>& callback) {
-    this->disconnected_callback = callback;
+    this->websocket_plain->register_disconnected_callback(callback);
+    this->websocket_tls->register_disconnected_callback(callback);
 }
 void Websocket::register_message_callback(const std::function<void(const std::string& message)>& callback) {
-    this->message_callback = callback;
+    this->websocket_plain->register_message_callback(callback);
+    this->websocket_tls->register_message_callback(callback);
 }
 
 bool Websocket::send(const std::string& message) {
-    if (!this->initialized()) {
-        EVLOG(error) << "Could not send message because websocket is not properly initialized.";
-        return false;
-    }
-
-    websocketpp::lib::error_code ec;
-
     if (this->tls) {
-        this->wss_client.send(this->handle, message, websocketpp::frame::opcode::text, ec);
-        if (ec) {
-            EVLOG(error) << "Error sending message over TLS websocket: " << ec.message();
-
-            this->reconnect(ec);
-            EVLOG(info) << "(TLS) Called reconnect()";
-            return false;
-        }
-
-        EVLOG(debug) << "Sent message over TLS websocket: " << message;
+        return this->websocket_tls->send(message);
     } else {
-        this->ws_client.send(this->handle, message, websocketpp::frame::opcode::text, ec);
-        if (ec) {
-            EVLOG(error) << "Error sending message over plain websocket: " << ec.message();
-
-            this->reconnect(ec);
-            EVLOG(info) << "(plain) Called reconnect()";
-            return false;
-        }
-
-        EVLOG(debug) << "Sent message over plain websocket: " << message;
+        return this->websocket_plain->send(message);
     }
 
     return true;
-}
-
-bool Websocket::initialized() {
-    if (this->shutting_down) {
-        EVLOG(error) << "Not properly initialized: websocket already shutdown.";
-        return false;
-    }
-    if (this->connected_callback == nullptr) {
-        EVLOG(error) << "Not properly initialized: please register connected callback.";
-        return false;
-    }
-    if (this->disconnected_callback == nullptr) {
-        EVLOG(error) << "Not properly initialized: please register disconnected callback.";
-        return false;
-    }
-    if (this->message_callback == nullptr) {
-        EVLOG(error) << "Not properly initialized: please register message callback.";
-        return false;
-    }
-
-    return true;
-}
-
-void Websocket::reconnect(std::error_code reason) {
-    if (this->shutting_down) {
-        EVLOG(info) << "Not reconnecting because the websocket is being shutdown.";
-        return;
-    }
-
-    // TODO(kai): notify message queue that connection is down and a reconnect is imminent?
-    {
-        std::lock_guard<std::mutex> lk(this->reconnect_mutex);
-        if (!this->reconnect_timer) {
-            EVLOG(info) << "Reconnecting in: " << this->reconnect_interval_ms << "ms";
-            if (this->tls) {
-                this->reconnect_timer =
-                    this->wss_client.set_timer(this->reconnect_interval_ms, this->reconnect_callback);
-            } else {
-                this->reconnect_timer =
-                    this->ws_client.set_timer(this->reconnect_interval_ms, this->reconnect_callback);
-            }
-        } else {
-            EVLOG(debug) << "Reconnect timer already running";
-        }
-    }
-
-    // TODO(kai): complete error handling, especially making sure that a reconnect is only attempted in reasonable
-    // circumstances
-    switch (reason.value()) {
-    case websocketpp::close::status::force_tcp_drop:
-        /* code */
-        break;
-
-    default:
-        break;
-    }
-
-    // TODO: spec-conform reconnect, refer to status codes from:
-    // https://github.com/zaphoyd/websocketpp/blob/master/websocketpp/close.hpp
-}
-
-std::string Websocket::get_hostname(std::string uri) {
-    // FIXME(kai): This only works with a very limited subset of hostnames!
-    std::string start = "wss://";
-    std::string stop = "/";
-    std::string port = ":";
-    auto hostname_start_pos = start.length();
-    auto hostname_end_pos = uri.find_first_of(stop, hostname_start_pos);
-
-    auto hostname_with_port = uri.substr(hostname_start_pos, hostname_end_pos - hostname_start_pos);
-    auto port_pos = hostname_with_port.find_first_of(port);
-    if (port_pos != std::string::npos) {
-        return hostname_with_port.substr(0, port_pos);
-    }
-    return hostname_with_port;
-}
-
-// plaintext
-void Websocket::connect_plain() {
-    EVLOG(info) << "Connecting to plain websocket at: " << this->uri;
-    websocketpp::lib::error_code ec;
-
-    client::connection_ptr con = this->ws_client.get_connection(this->uri, ec);
-
-    if (ec) {
-        EVLOG(error) << "Connection initialization error for plain websocket: " << ec.message();
-        return;
-    }
-
-    this->handle = con->get_handle();
-
-    con->set_open_handler(
-        websocketpp::lib::bind(&Websocket::on_open_plain, this, &this->ws_client, websocketpp::lib::placeholders::_1));
-    con->set_fail_handler(
-        websocketpp::lib::bind(&Websocket::on_fail_plain, this, &this->ws_client, websocketpp::lib::placeholders::_1));
-    con->set_close_handler(
-        websocketpp::lib::bind(&Websocket::on_close_plain, this, &this->ws_client, websocketpp::lib::placeholders::_1));
-    con->set_message_handler(websocketpp::lib::bind(
-        &Websocket::on_message_plain, this, websocketpp::lib::placeholders::_1, websocketpp::lib::placeholders::_2));
-
-    con->add_subprotocol("ocpp1.6");
-
-    this->ws_client.connect(con);
-}
-void Websocket::on_open_plain(client* c, websocketpp::connection_hdl hdl) {
-    EVLOG(info) << "Connected to plain websocket successfully. Executing connected callback";
-    this->connected_callback();
-}
-void Websocket::on_message_plain(websocketpp::connection_hdl hdl, client::message_ptr msg) {
-    if (!this->initialized()) {
-        EVLOG(error) << "Message received but plain websocket has not been correctly initialized. Discarding message.";
-        return;
-    }
-    try {
-        auto message = msg->get_payload();
-        this->message_callback(message);
-    } catch (websocketpp::exception const& e) {
-        EVLOG(error) << "Plain websocket exception on receiving message: " << e.what();
-    }
-}
-void Websocket::on_close_plain(client* c, websocketpp::connection_hdl hdl) {
-    client::connection_ptr con = c->get_con_from_hdl(hdl);
-    auto error_code = con->get_ec();
-    EVLOG(info) << "Closed plain websocket connection with code: " << error_code << " ("
-                << websocketpp::close::status::get_string(con->get_remote_close_code())
-                << "), reason: " << con->get_remote_close_reason();
-    this->reconnect(error_code);
-}
-void Websocket::on_fail_plain(client* c, websocketpp::connection_hdl hdl) {
-    client::connection_ptr con = c->get_con_from_hdl(hdl);
-    auto error_code = con->get_ec();
-    EVLOG(error) << "Failed to connect to plain websocket server " << con->get_response_header("Server")
-                 << ", code: " << error_code.value() << ", reason: " << error_code.message();
-    this->reconnect(error_code);
-}
-void Websocket::close_plain(websocketpp::close::status::value code, const std::string& reason) {
-    EVLOG(info) << "Closing plain websocket.";
-    websocketpp::lib::error_code ec;
-
-    this->ws_client.stop_perpetual();
-    this->ws_client.close(this->handle, code, reason, ec);
-    if (ec) {
-        EVLOG(error) << "Error initiating close of plain websocket: " << ec.message();
-    }
-
-    EVLOG(info) << "Closed plain websocket successfully.";
-}
-
-// TLS
-bool Websocket::verify_certificate(std::string hostname, bool preverified, boost::asio::ssl::verify_context& context) {
-    // FIXME(kai): this does not verify anything at the moment!
-
-    EVLOG(critical) << "Faking certificate verification, always returning true";
-
-    return true;
-}
-tls_context Websocket::on_tls_init(std::string hostname, websocketpp::connection_hdl hdl) {
-    tls_context context = websocketpp::lib::make_shared<boost::asio::ssl::context>(boost::asio::ssl::context::sslv23);
-
-    try {
-        // FIXME(kai): choose reasonable defaults, they can probably be stricter than this set of options!
-        // it is recommended to only accept TLSv1.2+
-        context->set_options(boost::asio::ssl::context::default_workarounds | //
-                             boost::asio::ssl::context::no_sslv2 |            //
-                             boost::asio::ssl::context::no_sslv3 |            //
-                             boost::asio::ssl::context::no_tlsv1 |            //
-                             boost::asio::ssl::context::no_tlsv1_1 |          //
-                             boost::asio::ssl::context::single_dh_use);
-
-        EVLOG(debug) << "List of ciphers that will be accepted by this TLS connection: "
-                     << this->configuration->getSupportedCiphers();
-
-        // FIXME(kai): the following only applies to TSLv1.2, we should support TLSv1.3 here as well
-        // FIXME(kai): use SSL_CTX_set_ciphersuites for TLSv1.3
-        auto set_cipher_list_ret =
-            SSL_CTX_set_cipher_list(context->native_handle(), this->configuration->getSupportedCiphers().c_str());
-        if (set_cipher_list_ret != 1) {
-            EVLOG(critical) << "SSL_CTX_set_cipher_list return value: " << set_cipher_list_ret;
-            throw std::runtime_error("Could not set TLSv1.2 cipher list");
-        }
-
-        context->set_verify_mode(boost::asio::ssl::verify_peer);
-        context->set_verify_callback(websocketpp::lib::bind(&Websocket::verify_certificate, this, hostname,
-                                                            websocketpp::lib::placeholders::_1,
-                                                            websocketpp::lib::placeholders::_2));
-        context->set_default_verify_paths();
-    } catch (std::exception& e) {
-        EVLOG(error) << "Error on TLS init: " << e.what();
-        throw std::runtime_error("Could not properly initialize TLS connection.");
-    }
-    return context;
-}
-void Websocket::connect_tls(std::string authorization_header) {
-    EVLOG(info) << "Connecting to TLS websocket at: " << this->uri;
-    websocketpp::lib::error_code ec;
-
-    tls_client::connection_ptr con = this->wss_client.get_connection(this->uri, ec);
-
-    if (ec) {
-        EVLOG(error) << "Connection initialization error for TLS websocket: " << ec.message();
-        return;
-    }
-
-    this->handle = con->get_handle();
-
-    con->set_open_handler(
-        websocketpp::lib::bind(&Websocket::on_open_tls, this, &this->wss_client, websocketpp::lib::placeholders::_1));
-    con->set_fail_handler(
-        websocketpp::lib::bind(&Websocket::on_fail_tls, this, &this->wss_client, websocketpp::lib::placeholders::_1));
-    con->set_close_handler(
-        websocketpp::lib::bind(&Websocket::on_close_tls, this, &this->wss_client, websocketpp::lib::placeholders::_1));
-    con->set_message_handler(websocketpp::lib::bind(
-        &Websocket::on_message_tls, this, websocketpp::lib::placeholders::_1, websocketpp::lib::placeholders::_2));
-
-    con->add_subprotocol("ocpp1.6");
-
-    if (!authorization_header.empty()) {
-        EVLOG(debug) << "Authorization header provided, appending to HTTP header: " << authorization_header;
-        con->append_header("Authorization", authorization_header);
-    }
-
-    this->wss_client.connect(con);
-}
-void Websocket::on_open_tls(tls_client* c, websocketpp::connection_hdl hdl) {
-    EVLOG(info) << "Connected to TLS websocket successfully. Executing connected callback";
-    this->connected_callback();
-}
-void Websocket::on_message_tls(websocketpp::connection_hdl hdl, tls_client::message_ptr msg) {
-    if (!this->initialized()) {
-        EVLOG(error) << "Message received but TLS websocket has not been correctly initialized. Discarding message.";
-        return;
-    }
-    try {
-        auto message = msg->get_payload();
-        this->message_callback(message);
-    } catch (websocketpp::exception const& e) {
-        EVLOG(error) << "TLS websocket exception on receiving message: " << e.what();
-    }
-}
-void Websocket::on_close_tls(tls_client* c, websocketpp::connection_hdl hdl) {
-    tls_client::connection_ptr con = c->get_con_from_hdl(hdl);
-    auto error_code = con->get_ec();
-    EVLOG(info) << "Closed TLS websocket connection with code: " << error_code << " ("
-                << websocketpp::close::status::get_string(con->get_remote_close_code())
-                << "), reason: " << con->get_remote_close_reason();
-    this->reconnect(error_code);
-}
-void Websocket::on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl) {
-    tls_client::connection_ptr con = c->get_con_from_hdl(hdl);
-    auto error_code = con->get_ec();
-    EVLOG(error) << "Failed to connect to TLS websocket server " << con->get_response_header("Server")
-                 << ", code: " << error_code.value() << ", reason: " << error_code.message();
-    this->reconnect(error_code);
-}
-void Websocket::close_tls(websocketpp::close::status::value code, const std::string& reason) {
-    EVLOG(info) << "Closing TLS websocket.";
-    websocketpp::lib::error_code ec;
-
-    this->wss_client.stop_perpetual();
-    this->wss_client.close(this->handle, code, reason, ec);
-    if (ec) {
-        EVLOG(error) << "Error initiating close of TLS websocket: " << ec.message();
-    }
-
-    EVLOG(info) << "Closed TLS websocket successfully.";
 }
 
 } // namespace ocpp1_6

--- a/lib/ocpp1_6/websocket.cpp
+++ b/lib/ocpp1_6/websocket.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include <everest/logging.hpp>
 
+#include <ocpp1_6/charge_point_configuration.hpp>
 #include <ocpp1_6/websocket.hpp>
 
 namespace ocpp1_6 {

--- a/lib/ocpp1_6/websocket/CMakeLists.txt
+++ b/lib/ocpp1_6/websocket/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+target_sources(ocpp
+    PRIVATE
+        websocket_base.cpp
+        websocket_plain.cpp
+        websocket_tls.cpp
+        websocket.cpp
+)

--- a/lib/ocpp1_6/websocket/websocket.cpp
+++ b/lib/ocpp1_6/websocket/websocket.cpp
@@ -3,7 +3,7 @@
 #include <everest/logging.hpp>
 
 #include <ocpp1_6/charge_point_configuration.hpp>
-#include <ocpp1_6/websocket.hpp>
+#include <ocpp1_6/websocket/websocket.hpp>
 
 namespace ocpp1_6 {
 

--- a/lib/ocpp1_6/websocket/websocket.cpp
+++ b/lib/ocpp1_6/websocket/websocket.cpp
@@ -7,61 +7,41 @@
 
 namespace ocpp1_6 {
 
-Websocket::Websocket(std::shared_ptr<ChargePointConfiguration> configuration) : tls(false), shutting_down(false) {
+Websocket::Websocket(std::shared_ptr<ChargePointConfiguration> configuration) : shutting_down(false) {
 
-    this->configuration = configuration;
-
-    this->websocket_plain = std::make_unique<WebsocketPlain>(configuration);
-    this->websocket_tls = std::make_unique<WebsocketTLS>(configuration);
+    auto uri = configuration->getCentralSystemURI();
+    if (uri.find("ws://") == 0) {
+        EVLOG(debug) << "Creating plaintext websocket based on the provided URI: " << uri;
+        this->websocket = std::make_unique<WebsocketPlain>(configuration);
+    }
+    if (uri.find("wss://") == 0) {
+        EVLOG(debug) << "Creating TLS websocket based on the provided URI: " << uri;
+        this->websocket = std::make_unique<WebsocketTLS>(configuration);
+    }
 }
 
 bool Websocket::connect() {
-    auto uri = this->configuration->getCentralSystemURI();
-    EVLOG(info) << "Connecting to uri: " << uri;
-    if (uri.find("ws://") == 0) {
-        this->tls = false;
-        return this->websocket_plain->connect();
-    }
-    if (uri.find("wss://") == 0) {
-        this->tls = true;
-        return this->websocket_tls->connect();
-    }
-
-    return false;
+    return this->websocket->connect();
 }
 
 void Websocket::disconnect() {
     this->shutting_down = true; // FIXME(kai): this makes the websocket inoperable after a disconnect, however this
                                 // might not be a bad thing.
-    if (this->tls) {
-        EVLOG(info) << "Disconnecting TLS websocket...";
-        this->websocket_tls->disconnect();
-    } else {
-        EVLOG(info) << "Disconnecting plain websocket...";
-        this->websocket_plain->disconnect();
-    }
+
+    this->websocket->disconnect();
 }
 void Websocket::register_connected_callback(const std::function<void()>& callback) {
-    this->websocket_plain->register_connected_callback(callback);
-    this->websocket_tls->register_connected_callback(callback);
+    this->websocket->register_connected_callback(callback);
 }
 void Websocket::register_disconnected_callback(const std::function<void()>& callback) {
-    this->websocket_plain->register_disconnected_callback(callback);
-    this->websocket_tls->register_disconnected_callback(callback);
+    this->websocket->register_disconnected_callback(callback);
 }
 void Websocket::register_message_callback(const std::function<void(const std::string& message)>& callback) {
-    this->websocket_plain->register_message_callback(callback);
-    this->websocket_tls->register_message_callback(callback);
+    this->websocket->register_message_callback(callback);
 }
 
 bool Websocket::send(const std::string& message) {
-    if (this->tls) {
-        return this->websocket_tls->send(message);
-    } else {
-        return this->websocket_plain->send(message);
-    }
-
-    return true;
+    return this->websocket->send(message);
 }
 
 } // namespace ocpp1_6

--- a/lib/ocpp1_6/websocket/websocket_base.cpp
+++ b/lib/ocpp1_6/websocket/websocket_base.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <everest/logging.hpp>
+
+#include <ocpp1_6/charge_point_configuration.hpp>
+#include <ocpp1_6/websocket/websocket_base.hpp>
+
+namespace ocpp1_6 {
+
+WebsocketBase::WebsocketBase(std::shared_ptr<ChargePointConfiguration> configuration) :
+    shutting_down(false),
+    configuration(configuration),
+    connected_callback(nullptr),
+    disconnected_callback(nullptr),
+    message_callback(nullptr) {
+}
+
+void WebsocketBase::register_connected_callback(const std::function<void()>& callback) {
+    this->connected_callback = callback;
+}
+
+void WebsocketBase::register_disconnected_callback(const std::function<void()>& callback) {
+    this->disconnected_callback = callback;
+}
+
+void WebsocketBase::register_message_callback(const std::function<void(const std::string& message)>& callback) {
+    this->message_callback = callback;
+}
+
+bool WebsocketBase::initialized() {
+    if (this->shutting_down) {
+        EVLOG(error) << "Not properly initialized: websocket already shutdown.";
+        return false;
+    }
+    if (this->connected_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register connected callback.";
+        return false;
+    }
+    if (this->disconnected_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register disconnected callback.";
+        return false;
+    }
+    if (this->message_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register message callback.";
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/websocket_plain.cpp
+++ b/lib/ocpp1_6/websocket_plain.cpp
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <everest/logging.hpp>
+
+#include <ocpp1_6/charge_point_configuration.hpp>
+#include <ocpp1_6/websocket_plain.hpp>
+
+namespace ocpp1_6 {
+
+WebsocketPlain::WebsocketPlain(std::shared_ptr<ChargePointConfiguration> configuration) :
+    shutting_down(false),
+    reconnect_timer(nullptr),
+    connected_callback(nullptr),
+    disconnected_callback(nullptr),
+    message_callback(nullptr) {
+    this->reconnect_interval_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      std::chrono::seconds(configuration->getWebsocketReconnectInterval()))
+                                      .count();
+    this->configuration = configuration;
+}
+
+bool WebsocketPlain::connect() {
+    if (!this->initialized()) {
+        return false;
+    }
+    auto uri = this->configuration->getCentralSystemURI();
+
+    EVLOG(info) << "Connecting plain websocket";
+    this->ws_client.clear_access_channels(websocketpp::log::alevel::all);
+    this->ws_client.clear_error_channels(websocketpp::log::elevel::all);
+    this->ws_client.init_asio();
+    this->ws_client.start_perpetual();
+    this->uri = uri;
+
+    websocket_thread.reset(new websocketpp::lib::thread(&client::run, &this->ws_client));
+
+    this->reconnect_callback = [this](const websocketpp::lib::error_code& ec) {
+        EVLOG(info) << "Reconnecting plain websocket...";
+        {
+            std::lock_guard<std::mutex> lk(this->reconnect_mutex);
+            if (this->reconnect_timer) {
+                this->reconnect_timer.get()->cancel();
+            }
+            this->reconnect_timer = nullptr;
+        }
+        this->connect_plain();
+    };
+
+    this->connect_plain();
+    return true;
+}
+
+void WebsocketPlain::disconnect() {
+    if (!this->initialized()) {
+        EVLOG(error) << "Cannot disconnect a websocket that was not initialized";
+        return;
+    }
+    this->shutting_down = true; // FIXME(kai): this makes the websocket inoperable after a disconnect, however this
+                                // might not be a bad thing.
+    if (this->reconnect_timer) {
+        this->reconnect_timer.get()->cancel();
+    }
+
+    EVLOG(info) << "Disconnecting plain websocket...";
+    this->close_plain(websocketpp::close::status::normal, "");
+}
+void WebsocketPlain::register_connected_callback(const std::function<void()>& callback) {
+    this->connected_callback = callback;
+}
+void WebsocketPlain::register_disconnected_callback(const std::function<void()>& callback) {
+    this->disconnected_callback = callback;
+}
+void WebsocketPlain::register_message_callback(const std::function<void(const std::string& message)>& callback) {
+    this->message_callback = callback;
+}
+
+bool WebsocketPlain::send(const std::string& message) {
+    if (!this->initialized()) {
+        EVLOG(error) << "Could not send message because websocket is not properly initialized.";
+        return false;
+    }
+
+    websocketpp::lib::error_code ec;
+
+    this->ws_client.send(this->handle, message, websocketpp::frame::opcode::text, ec);
+    if (ec) {
+        EVLOG(error) << "Error sending message over plain websocket: " << ec.message();
+
+        this->reconnect(ec);
+        EVLOG(info) << "(plain) Called reconnect()";
+        return false;
+    }
+
+    EVLOG(debug) << "Sent message over plain websocket: " << message;
+
+    return true;
+}
+
+bool WebsocketPlain::initialized() {
+    if (this->shutting_down) {
+        EVLOG(error) << "Not properly initialized: websocket already shutdown.";
+        return false;
+    }
+    if (this->connected_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register connected callback.";
+        return false;
+    }
+    if (this->disconnected_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register disconnected callback.";
+        return false;
+    }
+    if (this->message_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register message callback.";
+        return false;
+    }
+
+    return true;
+}
+
+void WebsocketPlain::reconnect(std::error_code reason) {
+    if (this->shutting_down) {
+        EVLOG(info) << "Not reconnecting because the websocket is being shutdown.";
+        return;
+    }
+
+    // TODO(kai): notify message queue that connection is down and a reconnect is imminent?
+    {
+        std::lock_guard<std::mutex> lk(this->reconnect_mutex);
+        if (!this->reconnect_timer) {
+            EVLOG(info) << "Reconnecting in: " << this->reconnect_interval_ms << "ms";
+
+            this->reconnect_timer = this->ws_client.set_timer(this->reconnect_interval_ms, this->reconnect_callback);
+        } else {
+            EVLOG(debug) << "Reconnect timer already running";
+        }
+    }
+
+    // TODO(kai): complete error handling, especially making sure that a reconnect is only attempted in reasonable
+    // circumstances
+    switch (reason.value()) {
+    case websocketpp::close::status::force_tcp_drop:
+        /* code */
+        break;
+
+    default:
+        break;
+    }
+
+    // TODO: spec-conform reconnect, refer to status codes from:
+    // https://github.com/zaphoyd/websocketpp/blob/master/websocketpp/close.hpp
+}
+
+void WebsocketPlain::connect_plain() {
+    EVLOG(info) << "Connecting to plain websocket at: " << this->uri;
+    websocketpp::lib::error_code ec;
+
+    client::connection_ptr con = this->ws_client.get_connection(this->uri, ec);
+
+    if (ec) {
+        EVLOG(error) << "Connection initialization error for plain websocket: " << ec.message();
+        return;
+    }
+
+    this->handle = con->get_handle();
+
+    con->set_open_handler(websocketpp::lib::bind(&WebsocketPlain::on_open_plain, this, &this->ws_client,
+                                                 websocketpp::lib::placeholders::_1));
+    con->set_fail_handler(websocketpp::lib::bind(&WebsocketPlain::on_fail_plain, this, &this->ws_client,
+                                                 websocketpp::lib::placeholders::_1));
+    con->set_close_handler(websocketpp::lib::bind(&WebsocketPlain::on_close_plain, this, &this->ws_client,
+                                                  websocketpp::lib::placeholders::_1));
+    con->set_message_handler(websocketpp::lib::bind(&WebsocketPlain::on_message_plain, this,
+                                                    websocketpp::lib::placeholders::_1,
+                                                    websocketpp::lib::placeholders::_2));
+
+    con->add_subprotocol("ocpp1.6");
+
+    this->ws_client.connect(con);
+}
+
+void WebsocketPlain::on_open_plain(client* c, websocketpp::connection_hdl hdl) {
+    EVLOG(info) << "Connected to plain websocket successfully. Executing connected callback";
+    this->connected_callback();
+}
+
+void WebsocketPlain::on_message_plain(websocketpp::connection_hdl hdl, client::message_ptr msg) {
+    if (!this->initialized()) {
+        EVLOG(error) << "Message received but plain websocket has not been correctly initialized. Discarding message.";
+        return;
+    }
+    try {
+        auto message = msg->get_payload();
+        this->message_callback(message);
+    } catch (websocketpp::exception const& e) {
+        EVLOG(error) << "Plain websocket exception on receiving message: " << e.what();
+    }
+}
+
+void WebsocketPlain::on_close_plain(client* c, websocketpp::connection_hdl hdl) {
+    client::connection_ptr con = c->get_con_from_hdl(hdl);
+    auto error_code = con->get_ec();
+    EVLOG(info) << "Closed plain websocket connection with code: " << error_code << " ("
+                << websocketpp::close::status::get_string(con->get_remote_close_code())
+                << "), reason: " << con->get_remote_close_reason();
+    this->reconnect(error_code);
+}
+
+void WebsocketPlain::on_fail_plain(client* c, websocketpp::connection_hdl hdl) {
+    client::connection_ptr con = c->get_con_from_hdl(hdl);
+    auto error_code = con->get_ec();
+    EVLOG(error) << "Failed to connect to plain websocket server " << con->get_response_header("Server")
+                 << ", code: " << error_code.value() << ", reason: " << error_code.message();
+    this->reconnect(error_code);
+}
+
+void WebsocketPlain::close_plain(websocketpp::close::status::value code, const std::string& reason) {
+    EVLOG(info) << "Closing plain websocket.";
+    websocketpp::lib::error_code ec;
+
+    this->ws_client.stop_perpetual();
+    this->ws_client.close(this->handle, code, reason, ec);
+    if (ec) {
+        EVLOG(error) << "Error initiating close of plain websocket: " << ec.message();
+    }
+
+    EVLOG(info) << "Closed plain websocket successfully.";
+}
+
+} // namespace ocpp1_6

--- a/lib/ocpp1_6/websocket_tls.cpp
+++ b/lib/ocpp1_6/websocket_tls.cpp
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
+#include <everest/logging.hpp>
+
+#include <ocpp1_6/charge_point_configuration.hpp>
+#include <ocpp1_6/websocket_tls.hpp>
+
+namespace ocpp1_6 {
+
+WebsocketTLS::WebsocketTLS(std::shared_ptr<ChargePointConfiguration> configuration) :
+    shutting_down(false),
+    reconnect_timer(nullptr),
+    connected_callback(nullptr),
+    disconnected_callback(nullptr),
+    message_callback(nullptr) {
+    this->reconnect_interval_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      std::chrono::seconds(configuration->getWebsocketReconnectInterval()))
+                                      .count();
+    this->configuration = configuration;
+}
+
+bool WebsocketTLS::connect() {
+    if (!this->initialized()) {
+        return false;
+    }
+    this->uri = this->configuration->getCentralSystemURI();
+    EVLOG(info) << "Connecting to uri: " << this->uri;
+
+    EVLOG(info) << "Connecting TLS websocket, hostname: " << this->get_hostname(uri);
+    this->wss_client.clear_access_channels(websocketpp::log::alevel::all);
+    this->wss_client.clear_error_channels(websocketpp::log::elevel::all);
+    this->wss_client.init_asio();
+    this->wss_client.start_perpetual();
+
+    this->wss_client.set_tls_init_handler(websocketpp::lib::bind(
+        &WebsocketTLS::on_tls_init, this, this->get_hostname(this->uri), websocketpp::lib::placeholders::_1));
+
+    std::string authentication_header = "";
+    auto authorization_key = this->configuration->getAuthorizationKey();
+    if (authorization_key != boost::none) {
+        EVLOG(debug) << "AuthorizationKey present, encoding authentication header";
+        std::string auth_header = this->configuration->getChargePointId() + ":" + authorization_key.value();
+        authentication_header = std::string("Basic ") + websocketpp::base64_encode(auth_header);
+    }
+
+    websocket_thread.reset(new websocketpp::lib::thread(&tls_client::run, &this->wss_client));
+
+    this->reconnect_callback = [this, authentication_header](const websocketpp::lib::error_code& ec) {
+        EVLOG(info) << "Reconnecting TLS websocket...";
+        {
+            std::lock_guard<std::mutex> lk(this->reconnect_mutex);
+            if (this->reconnect_timer) {
+                this->reconnect_timer.get()->cancel();
+            }
+            this->reconnect_timer = nullptr;
+        }
+        this->connect_tls(authentication_header);
+    };
+
+    this->connect_tls(authentication_header);
+    return true;
+}
+
+void WebsocketTLS::disconnect() {
+    if (!this->initialized()) {
+        EVLOG(error) << "Cannot disconnect a websocket that was not initialized";
+        return;
+    }
+    this->shutting_down = true; // FIXME(kai): this makes the websocket inoperable after a disconnect, however this
+                                // might not be a bad thing.
+    if (this->reconnect_timer) {
+        this->reconnect_timer.get()->cancel();
+    }
+    EVLOG(info) << "Disconnecting TLS websocket...";
+
+    this->close_tls(websocketpp::close::status::normal, "");
+}
+void WebsocketTLS::register_connected_callback(const std::function<void()>& callback) {
+    this->connected_callback = callback;
+}
+void WebsocketTLS::register_disconnected_callback(const std::function<void()>& callback) {
+    this->disconnected_callback = callback;
+}
+void WebsocketTLS::register_message_callback(const std::function<void(const std::string& message)>& callback) {
+    this->message_callback = callback;
+}
+
+bool WebsocketTLS::send(const std::string& message) {
+    if (!this->initialized()) {
+        EVLOG(error) << "Could not send message because websocket is not properly initialized.";
+        return false;
+    }
+
+    websocketpp::lib::error_code ec;
+
+    this->wss_client.send(this->handle, message, websocketpp::frame::opcode::text, ec);
+    if (ec) {
+        EVLOG(error) << "Error sending message over TLS websocket: " << ec.message();
+
+        this->reconnect(ec);
+        EVLOG(info) << "(TLS) Called reconnect()";
+        return false;
+    }
+
+    EVLOG(debug) << "Sent message over TLS websocket: " << message;
+
+    return true;
+}
+
+bool WebsocketTLS::initialized() {
+    if (this->shutting_down) {
+        EVLOG(error) << "Not properly initialized: websocket already shutdown.";
+        return false;
+    }
+    if (this->connected_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register connected callback.";
+        return false;
+    }
+    if (this->disconnected_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register disconnected callback.";
+        return false;
+    }
+    if (this->message_callback == nullptr) {
+        EVLOG(error) << "Not properly initialized: please register message callback.";
+        return false;
+    }
+
+    return true;
+}
+
+void WebsocketTLS::reconnect(std::error_code reason) {
+    if (this->shutting_down) {
+        EVLOG(info) << "Not reconnecting because the websocket is being shutdown.";
+        return;
+    }
+
+    // TODO(kai): notify message queue that connection is down and a reconnect is imminent?
+    {
+        std::lock_guard<std::mutex> lk(this->reconnect_mutex);
+        if (!this->reconnect_timer) {
+            EVLOG(info) << "Reconnecting in: " << this->reconnect_interval_ms << "ms";
+            this->reconnect_timer = this->wss_client.set_timer(this->reconnect_interval_ms, this->reconnect_callback);
+        } else {
+            EVLOG(debug) << "Reconnect timer already running";
+        }
+    }
+
+    // TODO(kai): complete error handling, especially making sure that a reconnect is only attempted in reasonable
+    // circumstances
+    switch (reason.value()) {
+    case websocketpp::close::status::force_tcp_drop:
+        /* code */
+        break;
+
+    default:
+        break;
+    }
+
+    // TODO: spec-conform reconnect, refer to status codes from:
+    // https://github.com/zaphoyd/websocketpp/blob/master/websocketpp/close.hpp
+}
+
+std::string WebsocketTLS::get_hostname(std::string uri) {
+    // FIXME(kai): This only works with a very limited subset of hostnames!
+    std::string start = "wss://";
+    std::string stop = "/";
+    std::string port = ":";
+    auto hostname_start_pos = start.length();
+    auto hostname_end_pos = uri.find_first_of(stop, hostname_start_pos);
+
+    auto hostname_with_port = uri.substr(hostname_start_pos, hostname_end_pos - hostname_start_pos);
+    auto port_pos = hostname_with_port.find_first_of(port);
+    if (port_pos != std::string::npos) {
+        return hostname_with_port.substr(0, port_pos);
+    }
+    return hostname_with_port;
+}
+
+// TLS
+bool WebsocketTLS::verify_certificate(std::string hostname, bool preverified,
+                                      boost::asio::ssl::verify_context& context) {
+    // FIXME(kai): this does not verify anything at the moment!
+
+    EVLOG(critical) << "Faking certificate verification, always returning true";
+
+    return true;
+}
+tls_context WebsocketTLS::on_tls_init(std::string hostname, websocketpp::connection_hdl hdl) {
+    tls_context context = websocketpp::lib::make_shared<boost::asio::ssl::context>(boost::asio::ssl::context::sslv23);
+
+    try {
+        // FIXME(kai): choose reasonable defaults, they can probably be stricter than this set of options!
+        // it is recommended to only accept TLSv1.2+
+        context->set_options(boost::asio::ssl::context::default_workarounds | //
+                             boost::asio::ssl::context::no_sslv2 |            //
+                             boost::asio::ssl::context::no_sslv3 |            //
+                             boost::asio::ssl::context::no_tlsv1 |            //
+                             boost::asio::ssl::context::no_tlsv1_1 |          //
+                             boost::asio::ssl::context::single_dh_use);
+
+        EVLOG(debug) << "List of ciphers that will be accepted by this TLS connection: "
+                     << this->configuration->getSupportedCiphers();
+
+        // FIXME(kai): the following only applies to TSLv1.2, we should support TLSv1.3 here as well
+        // FIXME(kai): use SSL_CTX_set_ciphersuites for TLSv1.3
+        auto set_cipher_list_ret =
+            SSL_CTX_set_cipher_list(context->native_handle(), this->configuration->getSupportedCiphers().c_str());
+        if (set_cipher_list_ret != 1) {
+            EVLOG(critical) << "SSL_CTX_set_cipher_list return value: " << set_cipher_list_ret;
+            throw std::runtime_error("Could not set TLSv1.2 cipher list");
+        }
+
+        context->set_verify_mode(boost::asio::ssl::verify_peer);
+        context->set_verify_callback(websocketpp::lib::bind(&WebsocketTLS::verify_certificate, this, hostname,
+                                                            websocketpp::lib::placeholders::_1,
+                                                            websocketpp::lib::placeholders::_2));
+        context->set_default_verify_paths();
+    } catch (std::exception& e) {
+        EVLOG(error) << "Error on TLS init: " << e.what();
+        throw std::runtime_error("Could not properly initialize TLS connection.");
+    }
+    return context;
+}
+void WebsocketTLS::connect_tls(std::string authorization_header) {
+    EVLOG(info) << "Connecting to TLS websocket at: " << this->uri;
+    websocketpp::lib::error_code ec;
+
+    tls_client::connection_ptr con = this->wss_client.get_connection(this->uri, ec);
+
+    if (ec) {
+        EVLOG(error) << "Connection initialization error for TLS websocket: " << ec.message();
+        return;
+    }
+
+    this->handle = con->get_handle();
+
+    con->set_open_handler(websocketpp::lib::bind(&WebsocketTLS::on_open_tls, this, &this->wss_client,
+                                                 websocketpp::lib::placeholders::_1));
+    con->set_fail_handler(websocketpp::lib::bind(&WebsocketTLS::on_fail_tls, this, &this->wss_client,
+                                                 websocketpp::lib::placeholders::_1));
+    con->set_close_handler(websocketpp::lib::bind(&WebsocketTLS::on_close_tls, this, &this->wss_client,
+                                                  websocketpp::lib::placeholders::_1));
+    con->set_message_handler(websocketpp::lib::bind(
+        &WebsocketTLS::on_message_tls, this, websocketpp::lib::placeholders::_1, websocketpp::lib::placeholders::_2));
+
+    con->add_subprotocol("ocpp1.6");
+
+    if (!authorization_header.empty()) {
+        EVLOG(debug) << "Authorization header provided, appending to HTTP header: " << authorization_header;
+        con->append_header("Authorization", authorization_header);
+    }
+
+    this->wss_client.connect(con);
+}
+void WebsocketTLS::on_open_tls(tls_client* c, websocketpp::connection_hdl hdl) {
+    EVLOG(info) << "Connected to TLS websocket successfully. Executing connected callback";
+    this->connected_callback();
+}
+void WebsocketTLS::on_message_tls(websocketpp::connection_hdl hdl, tls_client::message_ptr msg) {
+    if (!this->initialized()) {
+        EVLOG(error) << "Message received but TLS websocket has not been correctly initialized. Discarding message.";
+        return;
+    }
+    try {
+        auto message = msg->get_payload();
+        this->message_callback(message);
+    } catch (websocketpp::exception const& e) {
+        EVLOG(error) << "TLS websocket exception on receiving message: " << e.what();
+    }
+}
+void WebsocketTLS::on_close_tls(tls_client* c, websocketpp::connection_hdl hdl) {
+    tls_client::connection_ptr con = c->get_con_from_hdl(hdl);
+    auto error_code = con->get_ec();
+    EVLOG(info) << "Closed TLS websocket connection with code: " << error_code << " ("
+                << websocketpp::close::status::get_string(con->get_remote_close_code())
+                << "), reason: " << con->get_remote_close_reason();
+    this->reconnect(error_code);
+}
+void WebsocketTLS::on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl) {
+    tls_client::connection_ptr con = c->get_con_from_hdl(hdl);
+    auto error_code = con->get_ec();
+    EVLOG(error) << "Failed to connect to TLS websocket server " << con->get_response_header("Server")
+                 << ", code: " << error_code.value() << ", reason: " << error_code.message();
+    this->reconnect(error_code);
+}
+void WebsocketTLS::close_tls(websocketpp::close::status::value code, const std::string& reason) {
+    EVLOG(info) << "Closing TLS websocket.";
+    websocketpp::lib::error_code ec;
+
+    this->wss_client.stop_perpetual();
+    this->wss_client.close(this->handle, code, reason, ec);
+    if (ec) {
+        EVLOG(error) << "Error initiating close of TLS websocket: " << ec.message();
+    }
+
+    EVLOG(info) << "Closed TLS websocket successfully.";
+}
+
+} // namespace ocpp1_6

--- a/src/charge_point.cpp
+++ b/src/charge_point.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
                 std::cout << std::endl;
                 if (command == "auth") {
                     EVLOG(info) << "authorize_id_tag command";
-                    auto result = charge_point->authorize_id_tag(std::string("123"));
+                    auto result = charge_point->authorize_id_tag(ocpp1_6::CiString20Type(std::string("123")));
                     if (result == ocpp1_6::AuthorizationStatus::Accepted) {
                         EVLOG(info) << "Authorized";
                     } else {
@@ -120,7 +120,8 @@ int main(int argc, char* argv[]) {
                 } else if (command == "data_transfer") {
                     EVLOG(info) << "data_transfer command";
                     ocpp1_6::DataTransferResponse result =
-                        charge_point->data_transfer(std::string("Pionix"), std::string("Test"), "Hello there");
+                        charge_point->data_transfer(ocpp1_6::CiString255Type(std::string("Pionix")),
+                                                    ocpp1_6::CiString50Type(std::string("Test")), "Hello there");
                     if (result.status == ocpp1_6::DataTransferStatus::Accepted) {
                         EVLOG(info) << "Data transfer accepted";
                     } else {

--- a/src/code_generator/generate_cpp.py
+++ b/src/code_generator/generate_cpp.py
@@ -446,7 +446,7 @@ def parse_schemas(version: str, schema_dir: Path = Path('schemas/json/'),
     subprocess.run(["clang-format", "-style=file",  "-i",
                    enums_hpp_fn, ocpp_types_hpp_fn], cwd=generated_header_dir)
     subprocess.run(["clang-format", "-style=file",  "-i",
-                   enums_hpp_fn, ocpp_types_cpp_fn], cwd=generated_source_dir)
+                   enums_cpp_fn, ocpp_types_cpp_fn], cwd=generated_source_dir)
     subprocess.run(["clang-format", "-style=file",  "-i",
                    enums_cpp_fn], cwd=generated_source_dir)
 

--- a/src/code_generator/templates/enums.cpp.jinja
+++ b/src/code_generator/templates/enums.cpp.jinja
@@ -12,7 +12,7 @@ namespace ocpp1_6 {
 
 // from: {{action.class_name}}
 namespace conversions {
-    const std::string {{ enum_type.name | snake_case }}_to_string({{ enum_type.name }} e) {
+    std::string {{ enum_type.name | snake_case }}_to_string({{ enum_type.name }} e) {
         switch (e) {
             {% for enum in enum_type.enums %}
             case {{ enum_type.name }}::{{ enum.replace('.', '_').replace('-', '_') }}: return "{{enum}}";
@@ -22,7 +22,7 @@ namespace conversions {
         throw std::out_of_range("No known string conversion for provided enum of type {{ enum_type.name }}");
     }
 
-    const {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s) {
+    {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s) {
         {% for enum in enum_type.enums %}
         if(s == "{{enum}}") {
             return {{ enum_type.name }}::{{ enum.replace('.', '_').replace('-', '_') }};

--- a/src/code_generator/templates/enums.cpp.jinja
+++ b/src/code_generator/templates/enums.cpp.jinja
@@ -22,7 +22,7 @@ namespace conversions {
         throw std::out_of_range("No known string conversion for provided enum of type {{ enum_type.name }}");
     }
 
-    {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s) {
+    {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(const std::string& s) {
         {% for enum in enum_type.enums %}
         if(s == "{{enum}}") {
             return {{ enum_type.name }}::{{ enum.replace('.', '_').replace('-', '_') }};

--- a/src/code_generator/templates/enums.cpp.jinja
+++ b/src/code_generator/templates/enums.cpp.jinja
@@ -1,0 +1,46 @@
+{% if first %}
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
+#include <stdexcept>
+#include <string>
+#include <ocpp1_6/enums.hpp>
+
+namespace ocpp1_6 {
+{% endif %}
+{%- if enum_types|length %}
+{%- for enum_type in enum_types %}
+
+// from: {{action.class_name}}
+namespace conversions {
+    const std::string {{ enum_type.name | snake_case }}_to_string({{ enum_type.name }} e) {
+        switch (e) {
+            {% for enum in enum_type.enums %}
+            case {{ enum_type.name }}::{{ enum.replace('.', '_').replace('-', '_') }}: return "{{enum}}";
+            {% endfor %}
+        }
+
+        throw std::out_of_range("No known string conversion for provided enum of type {{ enum_type.name }}");
+    }
+
+    const {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s) {
+        {% for enum in enum_type.enums %}
+        if(s == "{{enum}}") {
+            return {{ enum_type.name }}::{{ enum.replace('.', '_').replace('-', '_') }};
+        }
+        {% endfor %}
+
+        throw std::out_of_range("Provided string " + s + " could not be converted to enum of type {{ enum_type.name }}");
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const {{ enum_type.name }}& {{ enum_type.name | snake_case }}) {
+    os << conversions::{{ enum_type.name | snake_case }}_to_string({{ enum_type.name | snake_case }});
+    return os;
+}
+
+{% endfor %}
+{%- endif %}
+{% if last %}
+} // namespace ocpp1_6
+
+{% endif %}

--- a/src/code_generator/templates/enums.hpp.jinja
+++ b/src/code_generator/templates/enums.hpp.jinja
@@ -22,11 +22,11 @@ enum class {{ enum_type.name }}
 namespace conversions {
     /// \brief Converts the given {{ enum_type.name }} \p e to human readable string
     /// \returns a string representation of the {{ enum_type.name }}
-    const std::string {{ enum_type.name | snake_case }}_to_string({{ enum_type.name }} e);
+    std::string {{ enum_type.name | snake_case }}_to_string({{ enum_type.name }} e);
 
     /// \brief Converts the given std::string \p s to {{ enum_type.name }}
     /// \returns a {{ enum_type.name }} from a string representation
-    const {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s);
+    {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s);
 }
 
 /// \brief Writes the string representation of the given {{ enum_type.name }} \p {{ enum_type.name | snake_case }} to the given output stream \p os

--- a/src/code_generator/templates/enums.hpp.jinja
+++ b/src/code_generator/templates/enums.hpp.jinja
@@ -26,7 +26,7 @@ namespace conversions {
 
     /// \brief Converts the given std::string \p s to {{ enum_type.name }}
     /// \returns a {{ enum_type.name }} from a string representation
-    {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s);
+    {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(const std::string& s);
 }
 
 /// \brief Writes the string representation of the given {{ enum_type.name }} \p {{ enum_type.name | snake_case }} to the given output stream \p os

--- a/src/code_generator/templates/enums.hpp.jinja
+++ b/src/code_generator/templates/enums.hpp.jinja
@@ -4,7 +4,6 @@
 #ifndef OCPP1_6_ENUMS_HPP
 #define OCPP1_6_ENUMS_HPP
 
-#include <map>
 #include <string>
 
 namespace ocpp1_6 {
@@ -19,37 +18,20 @@ enum class {{ enum_type.name }}
     {{ enum.replace('.', '_').replace('-', '_') }},
 {% endfor %}
 };
-namespace conversions {
-    static const std::map<{{ enum_type.name }}, std::string> {{ enum_type.name }}Strings {
-{% for enum in enum_type.enums %}
-        {{'{'+ enum_type.name }}::{{ enum.replace('.', '_').replace('-', '_') }}, "{{enum}}"},
-{% endfor %}
-    };
-    static const std::map<std::string, {{ enum_type.name }}> {{ enum_type.name }}Values {
-{% for enum in enum_type.enums %}
-        {"{{enum}}", {{ enum_type.name }}::{{ enum.replace('.', '_').replace('-', '_') + '}' }},
-{% endfor %}
-    };
 
+namespace conversions {
     /// \brief Converts the given {{ enum_type.name }} \p e to human readable string
     /// \returns a string representation of the {{ enum_type.name }}
-    static const std::string {{ enum_type.name | snake_case }}_to_string({{ enum_type.name }} e) {
-        return {{ enum_type.name }}Strings.at(e);
-    }
+    const std::string {{ enum_type.name | snake_case }}_to_string({{ enum_type.name }} e);
 
     /// \brief Converts the given std::string \p s to {{ enum_type.name }}
     /// \returns a {{ enum_type.name }} from a string representation
-    static const {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s) {
-        return {{ enum_type.name }}Values.at(s);
-    }
+    const {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(std::string s);
 }
 
 /// \brief Writes the string representation of the given {{ enum_type.name }} \p {{ enum_type.name | snake_case }} to the given output stream \p os
 /// \returns an output stream with the {{ enum_type.name }} written to
-inline std::ostream& operator<<(std::ostream& os, const {{ enum_type.name }}& {{ enum_type.name | snake_case }}) {
-    os << conversions::{{ enum_type.name | snake_case }}_to_string({{ enum_type.name | snake_case }});
-    return os;
-}
+std::ostream& operator<<(std::ostream& os, const {{ enum_type.name }}& {{ enum_type.name | snake_case }});
 {% endfor %}
 {%- endif %}
 {% if last %}

--- a/src/code_generator/templates/message.cpp.jinja
+++ b/src/code_generator/templates/message.cpp.jinja
@@ -1,45 +1,29 @@
 {% if action.is_request %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
-#ifndef OCPP1_6_{{ action.name|upper }}_HPP
-#define OCPP1_6_{{ action.name|upper }}_HPP
 
+#include <ostream>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/messages/{{action.name}}.hpp>
 #include <ocpp1_6/ocpp_types.hpp>
+
+using json = nlohmann::json;
 
 namespace ocpp1_6 {
 {% endif %}
-{#
-{% if enum_types|length and action.is_request %}
-# enums
-{% for enum_type in enum_types %}
-class {{ enum_type.name }}(str, Enum):
-{% for enum in enum_type.enums %}
-    {{ enum }} = '{{ enum }}'
-{% endfor %}
-{% endfor %}
-{% endif %}
-#}
+
 {% for type in types %}
 {% if type.name == action.class_name %}
 
-/// \brief Contains a OCPP 1.6 {{ type.name | replace('Request', '') }} message
-struct {{ type.name }} : public Message {
-{% for property in type.properties %}
-    {{ 'boost::optional<' if not property.required -}}
-    {{ property.type -}}
-    {{ '>' if not property.required -}}
-    {{ ' ' + property.name + ';' }}
-{% endfor %}
 {% if loop.last %}
-
-    /// \brief Provides the type of this {{ type.name | replace('Request', '') }} message as a human readable string
-    /// \returns the message type as a human readable string
-    std::string get_type() const {
+    std::string {{ type.name }}::get_type() const {
         return "{{ type.name | replace('Request', '') }}";
     }
 
-    /// \brief Conversion from a given {{ type.name }} \p k to a given json object \p j
-    friend void to_json(json& j, const {{ type.name }}& k) {
+    void to_json(json& j, const {{ type.name }}& k) {
         // the required parts of the message
 {% if type.properties|selectattr('required')|list|length %}
         j = json{
@@ -98,8 +82,7 @@ j["{{property.name}}"] = k.{{property.name}}.value();
 {% endfor %}
     }
 
-    /// \brief Conversion from a given json object \p j to a given {{ type.name }} \p k
-    friend void from_json(const json& j, {{ type.name }}& k) {
+    void from_json(const json& j, {{ type.name }}& k) {
         // the required parts of the message
 {% for property in type.properties %}
 {% if property.required %}
@@ -149,13 +132,13 @@ j["{{property.name}}"] = k.{{property.name}}.value();
 {% endfor %}
     }
 
-    /// \brief Writes the string representation of the given {{ type.name }} \p k to the given output stream \p os
-    /// \returns an output stream with the {{ type.name }} written to
-    friend std::ostream& operator<<(std::ostream& os, const {{ type.name }}& k) {
-        os << json(k).dump(4);
-        return os;
-    }
-};
+/// \brief Writes the string representation of the given {{ type.name }} \p k to the given output stream \p os
+/// \returns an output stream with the {{ type.name }} written to
+std::ostream& operator<<(std::ostream& os, const {{ type.name }}& k) {
+    os << json(k).dump(4);
+    return os;
+}
+
 {% endif %}
 
 {% endif %}
@@ -164,5 +147,4 @@ j["{{property.name}}"] = k.{{property.name}}.value();
 {% if not action.is_request %}
 } // namespace ocpp1_6
 
-#endif // OCPP1_6_{{ action.name|upper }}_HPP
 {% endif %}

--- a/src/code_generator/templates/message.hpp.jinja
+++ b/src/code_generator/templates/message.hpp.jinja
@@ -1,0 +1,49 @@
+{% if action.is_request %}
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
+#ifndef OCPP1_6_{{ action.name|upper }}_HPP
+#define OCPP1_6_{{ action.name|upper }}_HPP
+
+#include <ocpp1_6/ocpp_types.hpp>
+
+namespace ocpp1_6 {
+{% endif %}
+{% for type in types %}
+{% if type.name == action.class_name %}
+
+/// \brief Contains a OCPP 1.6 {{ type.name | replace('Request', '') }} message
+struct {{ type.name }} : public Message {
+{% for property in type.properties %}
+    {{ 'boost::optional<' if not property.required -}}
+    {{ property.type -}}
+    {{ '>' if not property.required -}}
+    {{ ' ' + property.name + ';' }}
+{% endfor %}
+
+{% if loop.last %}
+
+    /// \brief Provides the type of this {{ type.name | replace('Request', '') }} message as a human readable string
+    /// \returns the message type as a human readable string
+    std::string get_type() const;
+};
+
+/// \brief Conversion from a given {{ type.name }} \p k to a given json object \p j
+void to_json(json& j, const {{ type.name }}& k);
+
+/// \brief Conversion from a given json object \p j to a given {{ type.name }} \p k
+void from_json(const json& j, {{ type.name }}& k);
+
+/// \brief Writes the string representation of the given {{ type.name }} \p k to the given output stream \p os
+/// \returns an output stream with the {{ type.name }} written to
+std::ostream& operator<<(std::ostream& os, const {{ type.name }}& k);
+
+{% endif %}
+
+{% endif %}
+{% endfor %}
+
+{% if not action.is_request %}
+} // namespace ocpp1_6
+
+#endif // OCPP1_6_{{ action.name|upper }}_HPP
+{% endif %}

--- a/src/code_generator/templates/messages.cmakelists.txt.jinja
+++ b/src/code_generator/templates/messages.cmakelists.txt.jinja
@@ -1,0 +1,7 @@
+
+target_sources(ocpp
+    PRIVATE
+    {% for message in messages %}
+    {{message}}.cpp
+    {% endfor %}
+)

--- a/src/code_generator/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/templates/ocpp_types.cpp.jinja
@@ -1,18 +1,16 @@
 {% if first %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
-#ifndef OCPP1_6_OCPP_TYPES_HPP
-#define OCPP1_6_OCPP_TYPES_HPP
-
 #include <map>
 #include <string>
 
 #include <boost/optional.hpp>
-#include <nlohmann/json-schema.hpp>
 #include <nlohmann/json.hpp>
 
 #include <ocpp1_6/enums.hpp>
 #include <ocpp1_6/types.hpp>
+
+#include <ocpp1_6/ocpp_types.hpp>
 
 namespace ocpp1_6 {
 {% endif %}
@@ -20,16 +18,8 @@ namespace ocpp1_6 {
 {%- for type in parsed_types %}
 {% if not type.name.endswith('Request') and not type.name.endswith('Response') %}
 
-struct {{type.name}} {
-{% for property in type.properties %}
-    {{ 'boost::optional<' if not property.required -}}
-    {{ property.type -}}
-    {{ '>' if not property.required -}}
-    {{ ' ' + property.name + ';' }}
-{% endfor %}
-
     /// \brief Conversion from a given {{ type.name }} \p k to a given json object \p j
-    friend void to_json(json& j, const {{ type.name }}& k) {
+    void to_json(json& j, const {{ type.name }}& k) {
         // the required parts of the message
 {% if type.properties|selectattr('required')|list|length %}
         j = json{
@@ -90,7 +80,7 @@ j["{{property.name}}"] = k.{{property.name}}.value();
     }
 
     /// \brief Conversion from a given json object \p j to a given {{ type.name }} \p k
-    friend void from_json(const json& j, {{ type.name }}& k) {
+    void from_json(const json& j, {{ type.name }}& k) {
         // the required parts of the message
 {% for property in type.properties %}
 {% if property.required %}
@@ -134,16 +124,15 @@ j["{{property.name}}"] = k.{{property.name}}.value();
 
     // \brief Writes the string representation of the given {{ type.name }} \p k to the given output stream \p os
     /// \returns an output stream with the {{ type.name }} written to
-    friend std::ostream& operator<<(std::ostream& os, const {{ type.name }}& k) {
+    std::ostream& operator<<(std::ostream& os, const {{ type.name }}& k) {
         os << json(k).dump(4);
         return os;
     }
-};
+
 {% endif %}
 {% endfor %}
 {%- endif %}
 {% if last %}
 } // namespace ocpp1_6
 
-#endif // OCPP1_6_OCPP_TYPES_HPP
 {% endif %}

--- a/src/code_generator/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/templates/ocpp_types.cpp.jinja
@@ -1,7 +1,6 @@
 {% if first %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
-#include <map>
 #include <string>
 
 #include <boost/optional.hpp>

--- a/src/code_generator/templates/ocpp_types.hpp.jinja
+++ b/src/code_generator/templates/ocpp_types.hpp.jinja
@@ -1,0 +1,47 @@
+{% if first %}
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
+#ifndef OCPP1_6_OCPP_TYPES_HPP
+#define OCPP1_6_OCPP_TYPES_HPP
+
+#include <map>
+#include <string>
+
+#include <boost/optional.hpp>
+#include <nlohmann/json.hpp>
+
+#include <ocpp1_6/enums.hpp>
+#include <ocpp1_6/types.hpp>
+
+namespace ocpp1_6 {
+{% endif %}
+{%- if parsed_types|length %}
+{%- for type in parsed_types %}
+{% if not type.name.endswith('Request') and not type.name.endswith('Response') %}
+
+struct {{type.name}} {
+{% for property in type.properties %}
+    {{ 'boost::optional<' if not property.required -}}
+    {{ property.type -}}
+    {{ '>' if not property.required -}}
+    {{ ' ' + property.name + ';' }}
+{% endfor %}
+};
+    /// \brief Conversion from a given {{ type.name }} \p k to a given json object \p j
+    void to_json(json& j, const {{ type.name }}& k);
+
+    /// \brief Conversion from a given json object \p j to a given {{ type.name }} \p k
+    void from_json(const json& j, {{ type.name }}& k);
+
+    // \brief Writes the string representation of the given {{ type.name }} \p k to the given output stream \p os
+    /// \returns an output stream with the {{ type.name }} written to
+    std::ostream& operator<<(std::ostream& os, const {{ type.name }}& k);
+
+{% endif %}
+{% endfor %}
+{%- endif %}
+{% if last %}
+} // namespace ocpp1_6
+
+#endif // OCPP1_6_OCPP_TYPES_HPP
+{% endif %}

--- a/src/code_generator/templates/ocpp_types.hpp.jinja
+++ b/src/code_generator/templates/ocpp_types.hpp.jinja
@@ -4,7 +4,6 @@
 #ifndef OCPP1_6_OCPP_TYPES_HPP
 #define OCPP1_6_OCPP_TYPES_HPP
 
-#include <map>
 #include <string>
 
 #include <boost/optional.hpp>


### PR DESCRIPTION
- Add DataTransfer callbacks
- Disable building of example binaries by default
- Add set max current callback
- Fix DateTime parsing on some central systems
- Add a part of the SmartCharging profile
- Restructure header only code into hpp and cpp files
- Enable compiler warnings
- Various bugfixes