### PR TITLE
Passing on reservation requests to EvseManager

### DIFF
--- a/aux/config-docker-tls.json
+++ b/aux/config-docker-tls.json
@@ -24,7 +24,7 @@
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",
-        "SupportedFeatureProfiles": "Core,FirmwareManagement,RemoteTrigger",
+        "SupportedFeatureProfiles": "Core,FirmwareManagement,Reservation,RemoteTrigger",
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true

--- a/aux/config-docker.json
+++ b/aux/config-docker.json
@@ -24,7 +24,7 @@
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",
-        "SupportedFeatureProfiles": "Core,FirmwareManagement,RemoteTrigger",
+        "SupportedFeatureProfiles": "Core,FirmwareManagement,RemoteTrigger,Reservation",
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true

--- a/aux/config.json
+++ b/aux/config.json
@@ -24,7 +24,7 @@
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",
-        "SupportedFeatureProfiles": "Core,FirmwareManagement,RemoteTrigger",
+        "SupportedFeatureProfiles": "Core,FirmwareManagement,RemoteTrigger,Reservation",
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -25,7 +25,8 @@ libtimer:
 date:
   git: https://github.com/HowardHinnant/date.git
   git_tag: v3.0.1
-  options: []
+  options: ["BUILD_TZ_LIB ON", "HAS_REMOTE_API 0", "USE_AUTOLOAD 0", "USE_OS_TZDB 1"]
+
 websocketpp:
   git: https://github.com/zaphoyd/websocketpp.git
   git_tag: 0.8.2

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
 #include <chrono>
+#include <date/date.h>
+#include <date/tz.h>
 #include <future>
 #include <iostream>
 #include <mutex>
@@ -16,6 +18,7 @@
 #include <ocpp1_6/message_queue.hpp>
 #include <ocpp1_6/messages/Authorize.hpp>
 #include <ocpp1_6/messages/BootNotification.hpp>
+#include <ocpp1_6/messages/CancelReservation.hpp>
 #include <ocpp1_6/messages/ChangeAvailability.hpp>
 #include <ocpp1_6/messages/ChangeConfiguration.hpp>
 #include <ocpp1_6/messages/ClearCache.hpp>
@@ -30,6 +33,7 @@
 #include <ocpp1_6/messages/MeterValues.hpp>
 #include <ocpp1_6/messages/RemoteStartTransaction.hpp>
 #include <ocpp1_6/messages/RemoteStopTransaction.hpp>
+#include <ocpp1_6/messages/ReserveNow.hpp>
 #include <ocpp1_6/messages/Reset.hpp>
 #include <ocpp1_6/messages/SetChargingProfile.hpp>
 #include <ocpp1_6/messages/StartTransaction.hpp>
@@ -50,7 +54,7 @@ private:
     std::unique_ptr<MessageQueue> message_queue;
     int32_t heartbeat_interval;
     bool initialized;
-    std::chrono::system_clock::time_point boot_time;
+    std::chrono::time_point<date::utc_clock> boot_time;
     std::set<MessageType> allowed_message_types;
     std::mutex allowed_message_types_mutex;
     RegistrationStatus registration_status;
@@ -58,8 +62,11 @@ private:
     std::shared_ptr<ChargePointConfiguration> configuration;
     std::unique_ptr<Everest::SteadyTimer> heartbeat_timer;
     std::unique_ptr<Everest::SteadyTimer> boot_notification_timer;
+    // Everest::SteadyTimer* meter_values_sample_timer; // TODO(kai): decide if we need a continuous sampling of meter
+    // values independent of transactions - maybe on connector 0, but that could be done in the chargingsession as
+    // well...
     std::unique_ptr<Everest::SystemTimer> clock_aligned_meter_values_timer;
-    std::chrono::time_point<std::chrono::system_clock> clock_aligned_meter_values_time_point;
+    std::chrono::time_point<date::utc_clock> clock_aligned_meter_values_time_point;
     std::map<int32_t, std::vector<MeterValue>> meter_values;
     std::mutex meter_values_mutex;
     std::map<int32_t, json> power_meter;
@@ -100,6 +107,10 @@ private:
     std::function<bool(int32_t connector, double max_current)> set_max_current_callback;
     std::function<std::string(std::string location)> upload_diagnostics_callback;
     std::function<void(std::string location)> update_firmware_callback;
+    std::function<ReservationStatus(int32_t reservation_id, int32_t connector, ocpp1_6::DateTime expiryDate,
+                                    ocpp1_6::CiString20Type idTag, boost::optional<ocpp1_6::CiString20Type> parent_id)>
+        reserve_now_callback;
+    std::function<CancelReservationStatus(int32_t reservationId)> cancel_reservation_callback;
 
     /// \brief This function is called after a successful connection to the Websocket
     void connected_callback();
@@ -148,6 +159,14 @@ private:
     void handleSetChargingProfileRequest(Call<SetChargingProfileRequest> call);
     void handleGetCompositeScheduleRequest(Call<GetCompositeScheduleRequest> call);
     void handleClearChargingProfileRequest(Call<ClearChargingProfileRequest> call);
+
+    /// \brief ReserveNow.req(connectorId, expiryDate, idTag, reservationId, [parentIdTag]): tries to perform the
+    /// reservation and sends a reservation response. The reservation response: ReserveNow::Status
+    void handleReserveNowRequest(Call<ReserveNowRequest> call);
+
+    /// \brief Receives CancelReservation.req(reservationId)
+    /// The reservation response:  CancelReservationStatus: `Accepted` if the reservationId was found, else `Rejected`
+    void handleCancelReservationRequest(Call<CancelReservationRequest> call);
 
     // RemoteTrigger profile
     void handleTriggerMessageRequest(Call<TriggerMessageRequest> call);
@@ -221,6 +240,9 @@ public:
     /// \returns true if this state change was possible
     bool plug_disconnected(int32_t connector);
 
+    // /// EV/EVSE indicates that charging has finished
+    // bool stop_charging(int32_t connector);
+
     /// EV/EVSE indicates that an error with the given \p error_code occured
     /// \returns true if this state change was possible
     bool error(int32_t connector, ChargePointErrorCode error_code);
@@ -254,10 +276,13 @@ public:
     /// \brief registers a \p callback function that can be used to reserve a connector for a idTag until a timeout is
     /// reached
     void register_reserve_now_callback(
-        const std::function<bool(int32_t connector, CiString20Type idTag, std::chrono::seconds timeout)>& callback);
+        const std::function<ReservationStatus(int32_t reservation_id, int32_t connector, ocpp1_6::DateTime expiryDate,
+                                              ocpp1_6::CiString20Type idTag,
+                                              boost::optional<ocpp1_6::CiString20Type> parent_id)>& callback);
 
     /// \brief registers a \p callback function that can be used to cancel a reservation on a connector
-    void register_cancel_reservation_callback(const std::function<bool(int32_t connector)>& callback);
+    void
+    register_cancel_reservation_callback(const std::function<CancelReservationStatus(int32_t connector)>& callback);
 
     /// registers a \p callback function that can be used to unlock the connector
     void register_unlock_connector_callback(const std::function<bool(int32_t connector)>& callback);

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -62,9 +62,6 @@ private:
     std::shared_ptr<ChargePointConfiguration> configuration;
     std::unique_ptr<Everest::SteadyTimer> heartbeat_timer;
     std::unique_ptr<Everest::SteadyTimer> boot_notification_timer;
-    // Everest::SteadyTimer* meter_values_sample_timer; // TODO(kai): decide if we need a continuous sampling of meter
-    // values independent of transactions - maybe on connector 0, but that could be done in the chargingsession as
-    // well...
     std::unique_ptr<Everest::SystemTimer> clock_aligned_meter_values_timer;
     std::chrono::time_point<date::utc_clock> clock_aligned_meter_values_time_point;
     std::map<int32_t, std::vector<MeterValue>> meter_values;

--- a/include/ocpp1_6/charge_point_state_machine.hpp
+++ b/include/ocpp1_6/charge_point_state_machine.hpp
@@ -3,11 +3,11 @@
 #ifndef OCPP1_6_CHARGE_POINT_STATE_MACHINE_HPP
 #define OCPP1_6_CHARGE_POINT_STATE_MACHINE_HPP
 
-#include <stdint.h>
 #include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <stdint.h>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -21,7 +21,8 @@
 
 namespace ocpp1_6 {
 
-enum class ChargePointStatusTransition {
+enum class ChargePointStatusTransition
+{
     BecomeAvailable,
     UsageInitiated,
     StartCharging,
@@ -44,14 +45,10 @@ enum class ChargePointStatusTransition {
 using EventTypeFactory = fsm::utils::IdentifiableTypeFactory<ChargePointStatusTransition>;
 
 using Event_UsageInitiated = EventTypeFactory::Derived<ChargePointStatusTransition::UsageInitiated>;
-using Event_StartCharging =
-    EventTypeFactory::Derived<ChargePointStatusTransition::StartCharging>;
-using Event_PauseChargingEV =
-    EventTypeFactory::Derived<ChargePointStatusTransition::PauseChargingEV>;
-using Event_PauseChargingEVSE =
-    EventTypeFactory::Derived<ChargePointStatusTransition::PauseChargingEVSE>;
-using Event_ReserveConnector =
-    EventTypeFactory::Derived<ChargePointStatusTransition::ReserveConnector>;
+using Event_StartCharging = EventTypeFactory::Derived<ChargePointStatusTransition::StartCharging>;
+using Event_PauseChargingEV = EventTypeFactory::Derived<ChargePointStatusTransition::PauseChargingEV>;
+using Event_PauseChargingEVSE = EventTypeFactory::Derived<ChargePointStatusTransition::PauseChargingEVSE>;
+using Event_ReserveConnector = EventTypeFactory::Derived<ChargePointStatusTransition::ReserveConnector>;
 using Event_ChangeAvailabilityToUnavailable =
     EventTypeFactory::Derived<ChargePointStatusTransition::ChangeAvailabilityToUnavailable>;
 using Event_FaultDetected = EventTypeFactory::Derived<ChargePointStatusTransition::FaultDetected>;
@@ -70,7 +67,8 @@ using Event_I8_ReturnToUnavailable = EventTypeFactory::Derived<ChargePointStatus
 using EventBufferType = std::aligned_union_t<0, Event_UsageInitiated>;
 using EventBaseType = EventTypeFactory::Base;
 
-enum class State {
+enum class State
+{
     Available,
     Preparing,
     Charging,

--- a/include/ocpp1_6/charging_session.hpp
+++ b/include/ocpp1_6/charging_session.hpp
@@ -268,15 +268,6 @@ public:
     std::vector<MeterValue> get_clock_aligned_meter_values(int32_t connector);
 };
 
-// this manages reservations, while they are tied to a connector, this could still be connector 0 (if the appropriate
-// config key is set) aka any connector on the charge point a reservation can also be tied to a specific connector, but
-// there can be some "mobility" when the same reservation (with the identical id) changes to a different one
-class Reservations {
-private:
-public:
-    Reservations();
-};
-
 } // namespace ocpp1_6
 
 #endif // OCPP1_6_CHARGING_SESSION_HPP

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -8,6 +8,8 @@
 #include <boost/optional.hpp>
 #include <nlohmann/json.hpp>
 
+#include <date/date.h>
+#include <date/tz.h>
 #include <ocpp1_6/enums.hpp>
 #include <ocpp1_6/types_internal.hpp>
 
@@ -317,7 +319,7 @@ public:
     ~DateTime() = default;
 
     /// \brief Creates a new DateTime object from the given \p timepoint
-    explicit DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint);
+    explicit DateTime(std::chrono::time_point<date::utc_clock> timepoint);
 
     /// \brief Creates a new DateTime object from the given \p timepoint_str
     explicit DateTime(const std::string& timepoint_str);

--- a/include/ocpp1_6/types_internal.hpp
+++ b/include/ocpp1_6/types_internal.hpp
@@ -5,6 +5,8 @@
 
 #include <chrono>
 #include <cstddef>
+#include <date/date.h>
+#include <date/tz.h>
 #include <iostream>
 #include <string>
 
@@ -68,16 +70,16 @@ public:
 /// \brief Contains a DateTime implementation that can parse and create RFC 3339 compatible strings
 class DateTimeImpl {
 private:
-    std::chrono::time_point<std::chrono::system_clock> timepoint;
+    std::chrono::time_point<date::utc_clock> timepoint;
 
 public:
-    /// \brief Creates a new DateTimeImpl object with the current system time
+    /// \brief Creates a new DateTimeImpl object with the current utc time
     DateTimeImpl();
 
     ~DateTimeImpl() = default;
 
     /// \brief Creates a new DateTimeImpl object from the given \p timepoint
-    explicit DateTimeImpl(std::chrono::time_point<std::chrono::system_clock> timepoint);
+    explicit DateTimeImpl(std::chrono::time_point<date::utc_clock> timepoint);
 
     /// \brief Creates a new DateTimeImpl object from the given \p timepoint_str
     explicit DateTimeImpl(const std::string& timepoint_str);
@@ -91,7 +93,7 @@ public:
 
     /// \brief Converts this DateTimeImpl to a std::chrono::time_point
     /// \returns a std::chrono::time_point
-    std::chrono::time_point<std::chrono::system_clock> to_time_point();
+    std::chrono::time_point<date::utc_clock> to_time_point();
 
     /// \brief Writes the given DateTimeImpl \p dt to the given output stream \p os as a RFC 3339 compatible string
     /// \returns an output stream with the DateTimeImpl as a RFC 3339 compatible string written to

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,7 +29,8 @@ target_link_libraries(ocpp
         Boost::filesystem
         Boost::system
         Boost::thread
-        date
+        date::date
+        date::date-tz
         everest::log
         everest::timer
         fsm::fsm
@@ -65,9 +66,3 @@ source_group(
     TREE "${INCLUDE_DIR}"
     PREFIX "Headers"
     FILES ${HEADERS})
-
-target_link_libraries(ocpp
-    PRIVATE
-        date::date
-        date::date-tz
-)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -65,3 +65,9 @@ source_group(
     TREE "${INCLUDE_DIR}"
     PREFIX "Headers"
     FILES ${HEADERS})
+
+target_link_libraries(ocpp
+    PRIVATE
+        date::date
+        date::date-tz
+)

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -408,7 +408,7 @@ AvailabilityType ChargePointConfiguration::getConnectorAvailability(int32_t conn
         },
         (void*)sql_promise, &error);
 
-    std::chrono::system_clock::time_point sql_wait = std::chrono::system_clock::now() + ocpp1_6::future_wait_seconds;
+    std::chrono::time_point<date::utc_clock> sql_wait = date::utc_clock::now() + ocpp1_6::future_wait_seconds;
     std::future_status sql_future_status;
     do {
         sql_future_status = sql_future.wait_until(sql_wait);
@@ -446,7 +446,7 @@ std::map<int32_t, ocpp1_6::AvailabilityType> ChargePointConfiguration::getConnec
         },
         (void*)sql_promise, &error);
 
-    std::chrono::system_clock::time_point sql_wait = std::chrono::system_clock::now() + ocpp1_6::future_wait_seconds;
+    std::chrono::time_point<date::utc_clock> sql_wait = date::utc_clock::now() + ocpp1_6::future_wait_seconds;
     std::future_status sql_future_status;
     do {
         sql_future_status = sql_future.wait_until(sql_wait);

--- a/lib/ocpp1_6/charge_point_state_machine.cpp
+++ b/lib/ocpp1_6/charge_point_state_machine.cpp
@@ -3,8 +3,8 @@
 #include <ocpp1_6/charge_point_state_machine.hpp>
 #include <ocpp1_6/enums.hpp>
 
-#include <stddef.h>
 #include <cstdint>
+#include <stddef.h>
 #include <stdexcept>
 #include <utility>
 
@@ -265,7 +265,7 @@ void ChargePointStates::submit_event(int32_t connector, EventBaseType event) {
 ChargePointStatus ChargePointStates::get_state(int32_t connector) {
     if (connector > 0 && connector < static_cast<int32_t>(this->state_machines.size())) {
         return this->state_machines.at(connector)->state_machine->get_state();
-    }else if (connector == 0) {
+    } else if (connector == 0) {
         return ChargePointStatus::Available;
     }
     return ChargePointStatus::Unavailable;

--- a/lib/ocpp1_6/types.cpp
+++ b/lib/ocpp1_6/types.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2022 Pionix GmbH and Contributors to EVerest
-#include <string>
 #include <boost/optional/optional.hpp>
 #include <chrono>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 #include <nlohmann/json.hpp>
 
@@ -539,7 +539,7 @@ void from_json(const json& j, MessageId& k) {
 DateTime::DateTime() : DateTimeImpl() {
 }
 
-DateTime::DateTime(std::chrono::time_point<std::chrono::system_clock> timepoint) : DateTimeImpl(timepoint) {
+DateTime::DateTime(std::chrono::time_point<date::utc_clock> timepoint) : DateTimeImpl(timepoint) {
 }
 
 DateTime::DateTime(const std::string& timepoint_str) : DateTimeImpl(timepoint_str) {
@@ -568,7 +568,7 @@ bool MeasurandWithPhase::operator==(MeasurandWithPhase measurand_with_phase) {
         }
     }
     return false;
-};
+}
 
 CallError::CallError() {
 }

--- a/lib/ocpp1_6/types_internal.cpp
+++ b/lib/ocpp1_6/types_internal.cpp
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
+#include <everest/logging.hpp>
 #include <iostream>
 #include <ocpp1_6/types_internal.hpp>
 #include <sstream>
 #include <stdexcept>
-
-#include <date/date.h>
-#include <everest/logging.hpp>
 
 namespace ocpp1_6 {
 CiString::CiString(const std::string& data, size_t length) : length(length) {
@@ -41,10 +39,10 @@ std::ostream& operator<<(std::ostream& os, const CiString& str) {
 }
 
 DateTimeImpl::DateTimeImpl() {
-    this->timepoint = std::chrono::system_clock::now();
+    this->timepoint = date::utc_clock::now();
 }
 
-DateTimeImpl::DateTimeImpl(std::chrono::time_point<std::chrono::system_clock> timepoint) : timepoint(timepoint) {
+DateTimeImpl::DateTimeImpl(std::chrono::time_point<date::utc_clock> timepoint) : timepoint(timepoint) {
 }
 
 DateTimeImpl::DateTimeImpl(const std::string& timepoint_str) {
@@ -73,7 +71,7 @@ void DateTimeImpl::from_rfc3339(const std::string& timepoint_str) {
     }
 }
 
-std::chrono::time_point<std::chrono::system_clock> DateTimeImpl::to_time_point() {
+std::chrono::time_point<date::utc_clock> DateTimeImpl::to_time_point() {
     return this->timepoint;
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,8 @@ target_link_libraries(charge_point
         ocpp ${CMAKE_DL_LIBS}
         Boost::thread
         Boost::program_options
+        date::date
+        date::date-tz
         everest::log
         sqlite3
 )

--- a/src/central_system.cpp
+++ b/src/central_system.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2021 Pionix GmbH and Contributors to EVerest
 #include <chrono>
+#include <date/date.h>
+#include <date/tz.h>
 #include <iostream>
 #include <sys/prctl.h>
 #include <thread>

--- a/src/charge_point.cpp
+++ b/src/charge_point.cpp
@@ -3,6 +3,8 @@
 #include <chrono>
 #include <condition_variable>
 #include <csignal>
+#include <date/date.h>
+#include <date/tz.h>
 #include <fstream>
 #include <iostream>
 #include <mutex>


### PR DESCRIPTION
Introduced the reservation feature, without a reservations manager to cache the reservations. Instead, the only instance that tracks reservations is the Evse in `everest-core`.