### PR TITLE
Implemented missing error code for fault state

### DIFF
--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -328,7 +328,7 @@ public:
 
     /// EV/EVSE indicates that an error with the given \p error_code occured
     /// \returns true if this state change was possible
-    bool error(int32_t connector, ChargePointErrorCode error_code);
+    bool error(int32_t connector, const ChargePointErrorCode& error);
 
     /// EV/EVSE indicates that a vendor specific error with the given \p vendor_error_code occured on the given \p
     /// connector \returns true if this state change was possible

--- a/lib/ocpp1_6/charge_point_state_machine.cpp
+++ b/lib/ocpp1_6/charge_point_state_machine.cpp
@@ -11,8 +11,7 @@
 #include <fsm/async.hpp>
 
 namespace ocpp1_6 {
-ChargePointStateMachine::ChargePointStateMachine(
-    const std::function<void(ChargePointStatus status)>& status_notification_callback) :
+ChargePointStateMachine::ChargePointStateMachine(const StatusNotificationCallback& status_notification_callback) :
     status_notification_callback(status_notification_callback) {
     this->sd_available.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
         switch (ev.id) {
@@ -29,14 +28,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_available.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::Available;
-        this->status_notification_callback(ChargePointStatus::Available);
+        this->status_notification_callback(ChargePointStatus::Available, ChargePointErrorCode::NoError);
     };
 
     this->sd_preparing.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -52,14 +52,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::TransactionStoppedAndUserActionRequired:
             return trans.set(this->sd_finishing);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_preparing.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::Preparing;
-        this->status_notification_callback(ChargePointStatus::Preparing);
+        this->status_notification_callback(ChargePointStatus::Preparing, ChargePointErrorCode::NoError);
     };
 
     this->sd_charging.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -75,14 +76,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_charging.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::Charging;
-        this->status_notification_callback(ChargePointStatus::Charging);
+        this->status_notification_callback(ChargePointStatus::Charging, ChargePointErrorCode::NoError);
     };
 
     this->sd_suspended_ev.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -98,14 +100,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_suspended_ev.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::SuspendedEV;
-        this->status_notification_callback(ChargePointStatus::SuspendedEV);
+        this->status_notification_callback(ChargePointStatus::SuspendedEV, ChargePointErrorCode::NoError);
     };
 
     this->sd_suspended_evse.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -121,14 +124,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_suspended_evse.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::SuspendedEVSE;
-        this->status_notification_callback(ChargePointStatus::SuspendedEVSE);
+        this->status_notification_callback(ChargePointStatus::SuspendedEVSE, ChargePointErrorCode::NoError);
     };
 
     this->sd_finishing.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -140,14 +144,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_finishing.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::Finishing;
-        this->status_notification_callback(ChargePointStatus::Finishing);
+        this->status_notification_callback(ChargePointStatus::Finishing, ChargePointErrorCode::NoError);
     };
 
     this->sd_reserved.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -159,14 +164,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::ChangeAvailabilityToUnavailable:
             return trans.set(this->sd_unavailable);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_reserved.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::Reserved;
-        this->status_notification_callback(ChargePointStatus::Reserved);
+        this->status_notification_callback(ChargePointStatus::Reserved, ChargePointErrorCode::NoError);
     };
 
     this->sd_unavailable.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -182,14 +188,15 @@ ChargePointStateMachine::ChargePointStateMachine(
         case ChargePointStatusTransition::PauseChargingEVSE:
             return trans.set(this->sd_suspended_evse);
         case ChargePointStatusTransition::FaultDetected:
-            return trans.set(this->sd_faulted);
+            return trans.set<Event_FaultDetected, ChargePointStateMachine, &ChargePointStateMachine::t_faulted>(ev,
+                                                                                                                this);
         default:
             return;
         }
     };
     this->sd_unavailable.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::Unavailable;
-        this->status_notification_callback(ChargePointStatus::Unavailable);
+        this->status_notification_callback(ChargePointStatus::Unavailable, ChargePointErrorCode::NoError);
     };
 
     this->sd_faulted.transitions = [this](const EventBaseType& ev, TransitionType& trans) {
@@ -216,12 +223,18 @@ ChargePointStateMachine::ChargePointStateMachine(
     };
     this->sd_faulted.state_fun = [this](FSMContextType& ctx) {
         this->state = ChargePointStatus::Faulted;
-        this->status_notification_callback(ChargePointStatus::Faulted);
+        this->status_notification_callback(ChargePointStatus::Faulted, sd_faulted.error_code);
     };
 }
 
 ChargePointStatus ChargePointStateMachine::get_state() {
     return this->state;
+}
+
+// custom transitions
+ChargePointStateMachine::StateHandleType& ChargePointStateMachine::t_faulted(const Event_FaultDetected& fault_ev) {
+    sd_faulted.error_code = fault_ev.data;
+    return sd_faulted;
 }
 
 ChargePointStates::ChargePointStates(
@@ -231,9 +244,10 @@ ChargePointStates::ChargePointStates(
     status_notification_callback(status_notification_callback) {
     for (int32_t connector = 0; connector < number_of_connectors + 1; connector++) {
         // TODO special state machine for connector 0
-        auto state_machine = std::make_shared<ChargePointStateMachine>([this, connector](ChargePointStatus status) {
-            this->status_notification_callback(connector, ChargePointErrorCode::NoError, status);
-        });
+        auto state_machine = std::make_shared<ChargePointStateMachine>(
+            [this, connector](ChargePointStatus status, ChargePointErrorCode error_code) {
+                this->status_notification_callback(connector, error_code, status);
+            });
         auto controller = std::make_shared<ChargePointStateMachineController>();
         this->state_machines.push_back(
             std::make_shared<ChargePointStateMachineWithController>(state_machine, controller));
@@ -256,7 +270,8 @@ void ChargePointStates::run(std::map<int32_t, ocpp1_6::AvailabilityType> connect
     }
 }
 
-void ChargePointStates::submit_event(int32_t connector, EventBaseType event) {
+void ChargePointStates::submit_event(int32_t connector, const EventBaseType& event) {
+
     if (connector > 0 && connector < static_cast<int32_t>(this->state_machines.size())) {
         this->state_machines.at(connector)->controller->submit_event(event);
     }


### PR DESCRIPTION
When changing to state "Faulted" it was necessary to send a payload with the event to describe the error code.