### PR TITLE
Additional check before accessing LocalAuthListEnabled it config

### DIFF
--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -1905,8 +1905,13 @@ KeyValue ChargePointConfiguration::getSecurityProfileKeyValue() {
 
 // Local Auth List Management Profile
 bool ChargePointConfiguration::getLocalAuthListEnabled() {
-    return this->config["LocalAuthListManagement"]["LocalAuthListEnabled"];
+    if (this->config.contains("LocalAuthListManagement")) {
+        return this->config["LocalAuthListManagement"]["LocalAuthListEnabled"];
+    } else {
+        return false;
+    }
 }
+
 void ChargePointConfiguration::setLocalAuthListEnabled(bool local_auth_list_enabled) {
     this->config["LocalAuthListManagement"]["LocalAuthListEnabled"] = local_auth_list_enabled;
     this->setInUserConfig("LocalAuthListManagement", "LocalAuthListEnabled", local_auth_list_enabled);


### PR DESCRIPTION
checking if LocalAuthListManagement is present in config before accessing LocalAuthListEnabled

Signed-off-by: pietfried <piet.goempel@pionix.de>