### PR TITLE
Changed Arguments of GetDiagnostics.req and UpdateFirmware.req callbacks

### DIFF
--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -134,8 +134,8 @@ private:
     std::function<void(int32_t connector, ocpp1_6::CiString20Type idTag)> remote_start_transaction_callback;
     std::function<bool(int32_t connector)> unlock_connector_callback;
     std::function<bool(int32_t connector, double max_current)> set_max_current_callback;
-    std::function<std::string(std::string location)> upload_diagnostics_callback;
-    std::function<void(std::string location)> update_firmware_callback;
+    std::function<std::string(const ocpp1_6::GetDiagnosticsRequest& request)> upload_diagnostics_callback;
+    std::function<void(const ocpp1_6::UpdateFirmwareRequest msg)> update_firmware_callback;
     std::function<ReservationStatus(int32_t reservation_id, int32_t connector, ocpp1_6::DateTime expiryDate,
                                     ocpp1_6::CiString20Type idTag, boost::optional<ocpp1_6::CiString20Type> parent_id)>
         reserve_now_callback;
@@ -385,10 +385,12 @@ public:
     void register_set_max_current_callback(const std::function<bool(int32_t connector, double max_current)>& callback);
 
     /// \brief registers a \p callback function that can be used to trigger an upload of diagnostics
-    void register_upload_diagnostics_callback(const std::function<std::string(std::string location)>& callback);
+    void register_upload_diagnostics_callback(
+        const std::function<std::string(const ocpp1_6::GetDiagnosticsRequest& request)>& callback);
 
     /// \brief registers a \p callback function that can be used to trigger a firmware update
-    void register_update_firmware_callback(const std::function<void(std::string location)>& callback);
+    void
+    register_update_firmware_callback(const std::function<void(const ocpp1_6::UpdateFirmwareRequest msg)>& callback);
 
     /// \brief registers a \p callback function that can be used to upload logfiles
     void register_upload_logs_callback(const std::function<std::string(GetLogRequest req)>& callback);

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1756,7 +1756,7 @@ void ChargePoint::handleGetDiagnosticsRequest(Call<GetDiagnosticsRequest> call) 
     EVLOG_debug << "Received GetDiagnosticsRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
     GetDiagnosticsResponse response;
     if (this->upload_diagnostics_callback) {
-        response.fileName.emplace(this->upload_diagnostics_callback(call.msg.location));
+        response.fileName.emplace(this->upload_diagnostics_callback(call.msg));
     }
     CallResult<GetDiagnosticsResponse> call_result(response, call.uniqueId);
     this->send<GetDiagnosticsResponse>(call_result);
@@ -1767,7 +1767,7 @@ void ChargePoint::handleUpdateFirmwareRequest(Call<UpdateFirmwareRequest> call) 
     UpdateFirmwareResponse response;
     if (this->update_firmware_callback) {
         // FIXME(kai): respect call.msg.retrieveDate and only then trigger this callback
-        this->update_firmware_callback(call.msg.location);
+        this->update_firmware_callback(call.msg);
     }
     CallResult<UpdateFirmwareResponse> call_result(response, call.uniqueId);
     this->send<UpdateFirmwareResponse>(call_result);
@@ -2669,11 +2669,12 @@ void ChargePoint::register_set_max_current_callback(
 }
 
 void ChargePoint::register_upload_diagnostics_callback(
-    const std::function<std::string(std::string location)>& callback) {
+    const std::function<std::string(const ocpp1_6::GetDiagnosticsRequest& request)>& callback) {
     this->upload_diagnostics_callback = callback;
 }
 
-void ChargePoint::register_update_firmware_callback(const std::function<void(std::string location)>& callback) {
+void ChargePoint::register_update_firmware_callback(
+    const std::function<void(const ocpp1_6::UpdateFirmwareRequest msg)>& callback) {
     this->update_firmware_callback = callback;
 }
 


### PR DESCRIPTION
The argument for the callbacks for GetDiagnostics.req and UpdateFirmware.req has been changed from the single (ftp) location to the whole ocpp message, so that all members of this message can be considered in the callback function.

Signed-off-by: pietfried <piet.goempel@pionix.de>