### PR TITLE
Stop and Restart of OCPP communication

### DIFF
--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -68,6 +68,7 @@ private:
     std::unique_ptr<MessageQueue> message_queue;
     int32_t heartbeat_interval;
     bool initialized;
+    bool stopped;
     std::chrono::time_point<date::utc_clock> boot_time;
     std::set<MessageType> allowed_message_types;
     std::mutex allowed_message_types_mutex;
@@ -243,11 +244,15 @@ public:
     /// \brief Creates a ChargePoint object with the provided \p configuration
     explicit ChargePoint(std::shared_ptr<ChargePointConfiguration> configuration);
 
-    /// \brief Starts the ChargePoint, connecting to the Websocket
-    void start();
+    /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint
+    bool start();
 
-    /// \brief Stops the ChargePoint, stopping timers, transactions and disconnecting from the Websocket
-    void stop();
+    /// \brief Restarts the ChargePoint if it has been stopped before. The ChargePoint reinitialized, connects to the
+    /// websocket and starts to communicate OCPP messages again.
+    bool restart();
+
+    /// \brief Stops the ChargePoint, stops timers, transactions and the message queue, disconnects from the websocket
+    bool stop();
 
     /// \brief connects the websocket if it is not yet connected
     void connect_websocket();

--- a/include/ocpp1_6/charge_point_configuration.hpp
+++ b/include/ocpp1_6/charge_point_configuration.hpp
@@ -18,7 +18,8 @@ class ChargePointConfiguration {
 private:
     json config;
     sqlite3* db;
-    std::string configs_path;
+    const std::string &configs_path;
+    const std::string &database_path;
     std::shared_ptr<PkiHandler> pki_handler;
 
     std::set<SupportedFeatureProfiles> supported_feature_profiles;
@@ -36,8 +37,9 @@ private:
     bool isConnectorPhaseRotationValid(std::string str);
 
 public:
-    ChargePointConfiguration(json config, std::string configs_path, std::string schemas_path,
-                             std::string database_path);
+    ChargePointConfiguration(json config, const std::string& configs_path, const std::string& schemas_path,
+                             const std::string& database_path);
+    void restart();
     void close();
 
     std::string getConfigsPath();

--- a/lib/ocpp1_6/message_queue.cpp
+++ b/lib/ocpp1_6/message_queue.cpp
@@ -316,6 +316,7 @@ void MessageQueue::stop() {
     // stop the running thread
     this->running = false;
     this->cv.notify_one();
+    this->worker_thread.join();
     EVLOG_debug << "stop() notified message queue";
 }
 

--- a/lib/ocpp1_6/websocket/websocket_base.cpp
+++ b/lib/ocpp1_6/websocket/websocket_base.cpp
@@ -38,10 +38,6 @@ void WebsocketBase::register_sign_certificate_callback(const std::function<void(
 }
 
 bool WebsocketBase::initialized() {
-    if (this->shutting_down) {
-        EVLOG_error << "Not properly initialized: websocket already shutdown.";
-        return false;
-    }
     if (this->connected_callback == nullptr) {
         EVLOG_error << "Not properly initialized: please register connected callback.";
         return false;
@@ -63,8 +59,7 @@ void WebsocketBase::disconnect(websocketpp::close::status::value code) {
         EVLOG_error << "Cannot disconnect a websocket that was not initialized";
         return;
     }
-    this->shutting_down = true; // FIXME(kai): this makes the websocket inoperable after a disconnect, however this
-                                // might not be a bad thing.
+    this->shutting_down = true;
     if (this->reconnect_timer) {
         this->reconnect_timer.get()->cancel();
     }


### PR DESCRIPTION
With these changes it is possible to disconnect the websocket and stop the OCPP communication permanently. No messages will be queued after a stop call. The communication can be enabled again when calling restart. These calls can be used to externally control the OCPP connection.

