### PR TITLE
Configuration of smart charging profile purposes

### DIFF
--- a/aux/profile_schemas/ocpp1_6/Internal.json
+++ b/aux/profile_schemas/ocpp1_6/Internal.json
@@ -119,6 +119,19 @@
             "type": "boolean",
             "readOnly": true,
             "default": true
+        },
+        "SupportedChargingProfilePurposeTypes": {
+            "$comment": "Indicates which ChargingProfilePurposeTypes are supported. SetChargingProfile.req for profiles not listed will be rejected.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "readOnly": true,
+            "default": [
+                "ChargePointMaxProfile",
+                "TxDefaultProfile",
+                "TxProfile"
+            ]
         }
     },
     "additionalProperties": false

--- a/include/ocpp1_6/charge_point_configuration.hpp
+++ b/include/ocpp1_6/charge_point_configuration.hpp
@@ -53,6 +53,7 @@ public:
     int32_t getWebsocketReconnectInterval();
     bool getAuthorizeConnectorZeroOnConnectorOne();
     bool getLogMessages();
+    std::vector<ChargingProfilePurposeType> getSupportedChargingProfilePurposeTypes();
 
     std::string getSupportedCiphers12();
     std::string getSupportedCiphers13();

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -1270,9 +1270,14 @@ void ChargePoint::handleSetChargingProfileRequest(Call<SetChargingProfileRequest
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatus::Rejected;
     auto number_of_connectors = this->configuration->getNumberOfConnectors();
+    const auto supported_purpose_types = this->configuration->getSupportedChargingProfilePurposeTypes();
     if (call.msg.connectorId > number_of_connectors || call.msg.connectorId < 0 ||
         call.msg.csChargingProfiles.stackLevel < 0 ||
         call.msg.csChargingProfiles.stackLevel > this->configuration->getChargeProfileMaxStackLevel()) {
+        response.status = ChargingProfileStatus::Rejected;
+    } else if (std::find(supported_purpose_types.begin(), supported_purpose_types.end(),
+                         call.msg.csChargingProfiles.chargingProfilePurpose) == supported_purpose_types.end()) {
+        EVLOG_debug << "Rejecting SetChargingProfileRequest because purpose type is not supported: " << call.msg.csChargingProfiles.chargingProfilePurpose;
         response.status = ChargingProfileStatus::Rejected;
     } else {
         // to avoid conflicts, the existence of multiple charging profiles with the same purpose and stack level is not

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -235,6 +235,15 @@ bool ChargePointConfiguration::getLogMessages() {
     return this->config["Internal"]["LogMessages"];
 }
 
+std::vector<ChargingProfilePurposeType> ChargePointConfiguration::getSupportedChargingProfilePurposeTypes() {
+    std::vector<ChargingProfilePurposeType> supported_purpose_types;
+    const auto str_list = this->config["Internal"]["SupportedChargingProfilePurposeTypes"];
+    for (const auto &str : str_list) {
+        supported_purpose_types.push_back(conversions::string_to_charging_profile_purpose_type(str));
+    }
+    return supported_purpose_types;
+}
+
 std::string ChargePointConfiguration::getSupportedCiphers12() {
 
     std::vector<std::string> supported_ciphers = this->config["Internal"]["SupportedCiphers12"];


### PR DESCRIPTION
Configuration of smart charging profile purposes is now possible ConfigurationKey "SupportedChargingProfilePurposeTypes" defines the supported profiles. Default configuration supports all profiles.

Signed-off-by: pietfried <piet.goempel@pionix.de>