### PR TITLE
Improved transaction_id replacement for complete offline transaction

### DIFF
--- a/include/ocpp1_6/message_queue.hpp
+++ b/include/ocpp1_6/message_queue.hpp
@@ -158,6 +158,7 @@ public:
     /// \brief Adds the given \p transaction_id to the message_id_transaction_id_map using the key \p
     /// stop_transaction_message_id
     void add_stopped_transaction_id(std::string stop_transaction_message_id, int32_t transaction_id);
+    void notify_start_transaction_handled();
 };
 
 } // namespace ocpp1_6


### PR DESCRIPTION
There was a race condition when we had a complete offline transaction and wanted to replace the transaction id in the message queue.

Replacement of transaction id takes place in StartTransaction.conf handler but might be already too late when StopTransaction.req was sent before the replacement. Now we have a specific handling for StartTransaction.conf messages which means that we wait for the StartTransaction.conf handler to replace the transaction id in the mq before we send the next message

Signed-off-by: pietfried <piet.goempel@pionix.de>