### PR TITLE
Various fixes and improvements from 11-2022 OCPP Plugfest

### DIFF
--- a/aux/config-docker.json
+++ b/aux/config-docker.json
@@ -11,7 +11,7 @@
     "Core": {
         "AuthorizeRemoteTxRequests": false,
         "ClockAlignedDataInterval": 900,
-        "ConnectionTimeOut": 10,
+        "ConnectionTimeOut": 30,
         "ConnectorPhaseRotation": "0.RST,1.RST",
         "GetConfigurationMaxKeys": 100,
         "HeartbeatInterval": 86400,

--- a/aux/profile_schemas/ocpp1_6/Core.json
+++ b/aux/profile_schemas/ocpp1_6/Core.json
@@ -38,7 +38,7 @@
         },
         "AuthorizeRemoteTxRequests": {
             "type": "boolean",
-            "readOnly": true,
+            "readOnly": false,
             "description": "Authorize a RemoteStartTransaction request like a local StartTransaction. Readonly setting is up to the implementation."
         },
         "BlinkRepeat": {

--- a/include/ocpp1_6/charge_point_configuration.hpp
+++ b/include/ocpp1_6/charge_point_configuration.hpp
@@ -77,6 +77,7 @@ public:
 
     // Core Profile
     bool getAuthorizeRemoteTxRequests();
+    void setAuthorizeRemoteTxRequests(bool enabled);
     KeyValue getAuthorizeRemoteTxRequestsKeyValue();
 
     // Core Profile - optional

--- a/include/ocpp1_6/message_queue.hpp
+++ b/include/ocpp1_6/message_queue.hpp
@@ -109,7 +109,9 @@ public:
         } else {
             // all other messages are allowed to "jump the queue" to improve user experience
             // TODO: decide if we only want to allow this for a subset of messages
-            this->add_to_normal_message_queue(message);
+            if (!this->paused || message->messageType == MessageType::BootNotification) {
+                this->add_to_normal_message_queue(message);
+            }
         }
         this->cv.notify_all();
     }

--- a/include/ocpp1_6/transaction.hpp
+++ b/include/ocpp1_6/transaction.hpp
@@ -169,9 +169,8 @@ public:
     /// \returns true if successful
     bool remove_active_transaction(int32_t connector);
 
-    /// \brief Removes a transaction with the provided \p stop_transaction_message_id
-    /// \returns true if successful
-    bool remove_stopped_transaction(std::string stop_transaction_message_id);
+    /// \brief Erases a transaction with the provided \p stop_transaction_message_id
+    void erase_stopped_transaction(std::string stop_transaction_message_id);
 
     /// \brief Returns the transaction associated with the transaction at the provided \p connector
     /// \returns The associated transaction if available or nullptr if not

--- a/lib/ocpp1_6/charge_point_configuration.cpp
+++ b/lib/ocpp1_6/charge_point_configuration.cpp
@@ -422,10 +422,14 @@ boost::optional<KeyValue> ChargePointConfiguration::getAuthorizationCacheEnabled
 bool ChargePointConfiguration::getAuthorizeRemoteTxRequests() {
     return this->config["Core"]["AuthorizeRemoteTxRequests"];
 }
+void ChargePointConfiguration::setAuthorizeRemoteTxRequests(bool enabled) {
+    this->config["Core"]["AuthorizeRemoteTxRequests"] = enabled;
+    this->setInUserConfig("Core", "AuthorizeRemoteTxRequests", enabled);
+}
 KeyValue ChargePointConfiguration::getAuthorizeRemoteTxRequestsKeyValue() {
     ocpp1_6::KeyValue kv;
     kv.key = "AuthorizeRemoteTxRequests";
-    kv.readonly = true; // Could also be RW if we choose so
+    kv.readonly = false;
     kv.value.emplace(conversions::bool_to_string(this->getAuthorizeRemoteTxRequests()));
     return kv;
 }
@@ -1592,10 +1596,9 @@ ConfigurationStatus ChargePointConfiguration::set(CiString50Type key, CiString50
             return ConfigurationStatus::Rejected;
         }
     }
-    // TODO(kai): Implementations can choose if the is R or RW, at the moment readonly
-    // if (key == "AuthorizeRemoteTxRequests") {
-    //     this->setAuthorizeRemoteTxRequests(conversions::string_to_bool(value.get()));
-    // }
+    if (key == "AuthorizeRemoteTxRequests") {
+        this->setAuthorizeRemoteTxRequests(conversions::string_to_bool(value.get()));
+    }
     if (key == "BlinkRepeat") {
         if (this->getBlinkRepeat() == boost::none) {
             return ConfigurationStatus::NotSupported;

--- a/lib/ocpp1_6/database_handler.cpp
+++ b/lib/ocpp1_6/database_handler.cpp
@@ -154,7 +154,7 @@ void DatabaseHandler::update_transaction(const std::string& session_id, int32_t 
     }
 
     if (sqlite3_finalize(stmt) != SQLITE_OK) {
-        EVLOG_error << "Error inserting into table" << std::endl;
+        EVLOG_error << "Error updating table" << std::endl;
         throw std::runtime_error("db access error");
     }
 }
@@ -189,7 +189,7 @@ void DatabaseHandler::update_transaction(const std::string& session_id, int32_t 
     }
 
     if (sqlite3_finalize(stmt) != SQLITE_OK) {
-        EVLOG_error << "Error inserting into table" << std::endl;
+        EVLOG_error << "Error updating table" << std::endl;
         throw std::runtime_error("db access error");
     }
 }

--- a/lib/ocpp1_6/message_queue.cpp
+++ b/lib/ocpp1_6/message_queue.cpp
@@ -49,7 +49,6 @@ MessageQueue::MessageQueue(std::shared_ptr<ChargePointConfiguration> configurati
             ControlMessage* message = nullptr;
             QueueType queue_type = QueueType::None;
 
-            // send normal messages first
             if (!this->normal_message_queue.empty()) {
                 auto& normal_message = this->normal_message_queue.front();
                 EVLOG_debug << "normal msg timestamp: " << normal_message->timestamp;
@@ -63,8 +62,7 @@ MessageQueue::MessageQueue(std::shared_ptr<ChargePointConfiguration> configurati
                 }
             }
 
-            // send transaction messages when normal message queue is empty
-            if (!this->transaction_message_queue.empty() && message == nullptr) {
+            if (!this->transaction_message_queue.empty()) {
                 auto& transaction_message = this->transaction_message_queue.front();
                 EVLOG_debug << "transaction msg timestamp: " << transaction_message->timestamp;
                 if (message == nullptr) {

--- a/lib/ocpp1_6/pki_handler.cpp
+++ b/lib/ocpp1_6/pki_handler.cpp
@@ -65,7 +65,7 @@ bool X509Certificate::write() {
     return true;
 }
 
-PkiHandler::PkiHandler(const std::string &maindir) : maindir(boost::filesystem::path(maindir)) {
+PkiHandler::PkiHandler(const std::string& maindir) : maindir(boost::filesystem::path(maindir)) {
 }
 
 CertificateVerificationResult PkiHandler::verifyChargepointCertificate(const std::string& certificateChain,
@@ -275,7 +275,6 @@ PkiHandler::getRootCertificateHashData(CertificateUseEnumType type) {
 DeleteCertificateStatusEnumType PkiHandler::deleteRootCertificate(CertificateHashDataType certificate_hash_data,
                                                                   int32_t security_profile) {
     std::vector<std::shared_ptr<X509Certificate>> caCertificates = this->getCaCertificates();
-    DeleteCertificateStatusEnumType status = DeleteCertificateStatusEnumType::NotFound;
 
     for (std::shared_ptr<X509Certificate> cert : caCertificates) {
         std::string issuerNameHash = this->getIssuerNameHash(cert);
@@ -290,15 +289,15 @@ DeleteCertificateStatusEnumType PkiHandler::deleteRootCertificate(CertificateHas
                 security_profile >= 2) {
                 return DeleteCertificateStatusEnumType::Failed;
             }
-        }
-        bool success = boost::filesystem::remove(cert->path);
-        if (success) {
-            status = DeleteCertificateStatusEnumType::Accepted;
-        } else {
-            status = DeleteCertificateStatusEnumType::Failed;
+            bool success = boost::filesystem::remove(cert->path);
+            if (success) {
+                return DeleteCertificateStatusEnumType::Accepted;
+            } else {
+                return DeleteCertificateStatusEnumType::Failed;
+            }
         }
     }
-    return status;
+    return DeleteCertificateStatusEnumType::NotFound;
 }
 
 InstallCertificateResult PkiHandler::installRootCertificate(InstallCertificateRequest msg,

--- a/lib/ocpp1_6/transaction.cpp
+++ b/lib/ocpp1_6/transaction.cpp
@@ -166,11 +166,13 @@ bool TransactionHandler::remove_active_transaction(int32_t connector) {
     return true;
 }
 
-bool TransactionHandler::remove_stopped_transaction(std::string stop_transaction_message_id) {
-    return std::remove_if(this->stopped_transactions.begin(), this->stopped_transactions.end(),
-                          [stop_transaction_message_id](std::shared_ptr<ocpp1_6::Transaction>& transaction) {
-                              return transaction->get_stop_transaction_message_id() == stop_transaction_message_id;
-                          }) != this->stopped_transactions.end();
+void TransactionHandler::erase_stopped_transaction(std::string stop_transaction_message_id) {
+    this->stopped_transactions.erase(
+        std::remove_if(this->stopped_transactions.begin(), this->stopped_transactions.end(),
+                       [stop_transaction_message_id](std::shared_ptr<ocpp1_6::Transaction>& transaction) {
+                           return transaction->get_stop_transaction_message_id() == stop_transaction_message_id;
+                       }),
+        this->stopped_transactions.end());
 }
 
 std::shared_ptr<Transaction> TransactionHandler::get_transaction(int32_t connector) {

--- a/lib/ocpp1_6/websocket/websocket.cpp
+++ b/lib/ocpp1_6/websocket/websocket.cpp
@@ -13,11 +13,8 @@ using json = nlohmann::json;
 namespace ocpp1_6 {
 
 Websocket::Websocket(std::shared_ptr<ChargePointConfiguration> configuration, int32_t security_profile,
-                     std::shared_ptr<MessageLogging> logging) {
-
-    this->configuration = configuration;
-    this->logging = logging;
-
+                     std::shared_ptr<MessageLogging> logging) :
+    configuration(configuration), logging(logging) {
     auto uri = this->configuration->getCentralSystemURI();
     if (security_profile <= 1) {
         EVLOG_debug << "Creating plaintext websocket based on the provided URI: " << uri;


### PR DESCRIPTION
Reset Handling:
- stopping ocpp service properly before killing process on reset
- improved handling of Reset.req - Transactions will be stopped properly before the actual reboot
- Now sending StatusNotification.req after successful reconnect for all connectors

Authorization Handling:
- Configuration key AuthorizeRemoteTxRequests is now rw
- improved authorization handling and consideration of keys LocalPreAuthorize, LocalAuthorizeOffline, AuthorizationCacheEnabled, LocalAuthListEnabled
- RemoteStartTransaction.req for no connector given now supported

Message Queue:
- now dropping non-transaction-related msg queue is paused
- maintaining time based order of messages in message queue

Other:
- fixed bug that deleted ca cert without checking for parameters  issuerkeyhash, issuernamehash and serial
- Now properly erasing references of stopped transactions. This fixes the problem of MeterValues that have been sent also after stopped transactions
- MinimumStatusDuration is now a considered configuration key