### PR TITLE
Authorization Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.2
+    VERSION 0.3
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp1_6/charge_point.hpp
+++ b/include/ocpp1_6/charge_point.hpp
@@ -166,7 +166,6 @@ private:
     void heartbeat();
     void boot_notification();
     void clock_aligned_meter_values_sample();
-    void connection_timeout(int32_t connector);
     void update_heartbeat_interval();
     void update_meter_values_sample_interval();
     void update_clock_aligned_meter_values_interval();
@@ -281,6 +280,9 @@ public:
 
     /// \brief Disconnects the the websocket if it is connected
     void disconnect_websocket();
+
+    /// \brief Calls the set_connection_timeout_callback
+    void call_set_connection_timeout();
 
     // public API for Core profile
 


### PR DESCRIPTION
- RemoteStartTransaction.req is now considering connector id of single connectors
- set_connection_timeout_callback can now be called from outside the chargepoint

Signed-off-by: pietfried <piet.goempel@pionix.de>