### PR TITLE
Default Transaction Id of -1

### DIFF
--- a/include/ocpp1_6/database_handler.hpp
+++ b/include/ocpp1_6/database_handler.hpp
@@ -39,8 +39,10 @@ public:
 
     // transactions
     /// \brief Inserts a transaction with the given parameter to the TRANSACTIONS table.
-    void insert_transaction(const std::string& session_id, int32_t connector, const std::string& id_tag_start,
-                            const std::string& time_start, int32_t meter_start, boost::optional<int32_t> reservation_id);
+    void insert_transaction(const std::string& session_id, const int32_t transaction_id, const int32_t connector,
+                            const std::string& id_tag_start, const std::string& time_start, const int32_t meter_start,
+                            const boost::optional<int32_t> reservation_id);
+
     /// \brief Updates the given parameters for the transaction with the given \p session_id in the TRANSACTIONS table.
     void update_transaction(const std::string& session_id, int32_t transaction_id,
                             boost::optional<CiString20Type> parent_id_tag = boost::none);
@@ -65,11 +67,11 @@ public:
 
     // connector availability
     /// \brief Inserts or updates the given \p availability_type of the given \p connector to the CONNECTORS table.
-    void insert_or_update_connector_availability(int32_t connector, const AvailabilityType &availability_type);
+    void insert_or_update_connector_availability(int32_t connector, const AvailabilityType& availability_type);
 
     /// \brief Inserts or updates the given \p availability_type of the given \p connectors to the CONNECTORS table.
-    void insert_or_update_connector_availability(const std::vector<int32_t> &connectors,
-                                                 const AvailabilityType &availability_type);
+    void insert_or_update_connector_availability(const std::vector<int32_t>& connectors,
+                                                 const AvailabilityType& availability_type);
 
     /// \brief Returns the AvailabilityType of the given \p connector of the CONNECTORS table.
     AvailabilityType get_connector_availability(int32_t connector);

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -139,8 +139,8 @@ struct TransactionEntry {
     std::string id_tag_start;
     std::string time_start;
     int32_t meter_start;
+    int32_t transaction_id;
     boost::optional<int32_t> reservation_id = boost::none;
-    boost::optional<int32_t> transaction_id = boost::none;
     boost::optional<std::string> parent_id_tag = boost::none;
     boost::optional<int32_t> meter_stop = boost::none;
     boost::optional<std::string> time_end = boost::none;

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -201,8 +201,8 @@ void ChargePoint::stop_pending_transactions() {
         StopTransactionRequest req;
         req.meterStop = transaction_entry.meter_start; // FIXME(piet): Get latest meter value here
         req.timestamp = DateTime();
-        req.transactionId = transaction_entry.transaction_id.value();
         req.reason = Reason::PowerLoss;
+        req.transactionId = transaction_entry.transaction_id;
 
         auto message_id = this->message_queue->createMessageId();
         Call<StopTransactionRequest> call(req, message_id);
@@ -2527,8 +2527,8 @@ void ChargePoint::on_transaction_started(const int32_t& connector, const std::st
         transaction->add_meter_value(meter_value);
     }
 
-    this->database_handler->insert_transaction(session_id, connector, id_token, timestamp.to_rfc3339(), meter_start,
-                                               reservation_id);
+    this->database_handler->insert_transaction(session_id, transaction->get_transaction_id(), connector, id_token,
+                                               timestamp.to_rfc3339(), meter_start, reservation_id);
     this->transaction_handler->add_transaction(transaction);
     this->start_transaction(transaction);
 }

--- a/src/charge_point.cpp
+++ b/src/charge_point.cpp
@@ -119,7 +119,7 @@ int main(int argc, char* argv[]) {
     });
 
     charge_point->register_provide_token_callback(
-        [](const std::string& id_token, int32_t connector, bool prevalidated) {
+        [](const std::string& id_token, const std::vector<int32_t> &referenced_connectors, bool prevalidated) {
             std::cout << "Callback: "
                        << "Received token " << id_token << " for further validation" << std::endl;
         });

--- a/tests/database_tests.cpp
+++ b/tests/database_tests.cpp
@@ -214,12 +214,12 @@ TEST_F(DatabaseTest, test_insert_and_get_transaction) {
     boost::optional<CiString20Type> id_tag;
     id_tag.emplace(CiString20Type(std::string("DEADBEEF")));
 
-    this->db_handler->insert_transaction("id-42", 1, "DEADBEEF", "2022-08-18T09:42:41", 42, 42);
+    this->db_handler->insert_transaction("id-42", -1, 1, "DEADBEEF", "2022-08-18T09:42:41", 42, 42);
     this->db_handler->update_transaction("id-42", 42);
     this->db_handler->update_transaction("id-42", 5000, "2022-08-18T10:42:41", id_tag,
                                          Reason::EVDisconnected);
     
-    this->db_handler->insert_transaction("id-43", 1, "BEEFDEAD", "2022-08-18T09:42:41", 43, 43);
+    this->db_handler->insert_transaction("id-43", -1, 1, "BEEFDEAD", "2022-08-18T09:42:41", 43, 43);
     
 
     auto incomplete_transactions = this->db_handler->get_transactions(true);
@@ -228,7 +228,7 @@ TEST_F(DatabaseTest, test_insert_and_get_transaction) {
     auto transaction = incomplete_transactions.at(0);
 
     ASSERT_EQ(transaction.session_id, "id-43");
-    ASSERT_EQ(transaction.transaction_id, boost::none);
+    ASSERT_EQ(transaction.transaction_id, -1);
 
     auto all_transactions = this->db_handler->get_transactions();
     ASSERT_EQ(all_transactions.size(), 2);
@@ -244,12 +244,12 @@ TEST_F(DatabaseTest, test_insert_and_get_transaction) {
 TEST_F(DatabaseTest, test_insert_and_get_transaction_without_id_tag) {
 
     boost::optional<ocpp1_6::CiString20Type> id_tag;
-    this->db_handler->insert_transaction("id-42", 1, "DEADBEEF", "2022-08-18T09:42:41", 42, 42);
+    this->db_handler->insert_transaction("id-42", -1, 1, "DEADBEEF", "2022-08-18T09:42:41", 42, 42);
     this->db_handler->update_transaction("id-42", 42);
     this->db_handler->update_transaction("id-42", 5000, "2022-08-18T10:42:41", id_tag,
                                          Reason::EVDisconnected);
     
-    this->db_handler->insert_transaction("id-43", 1, "BEEFDEAD", "2022-08-18T09:42:41", 43, 43);
+    this->db_handler->insert_transaction("id-43", -1, 1, "BEEFDEAD", "2022-08-18T09:42:41", 43, 43);
     
     auto incomplete_transactions = this->db_handler->get_transactions(true);
 
@@ -257,7 +257,7 @@ TEST_F(DatabaseTest, test_insert_and_get_transaction_without_id_tag) {
     auto transaction = incomplete_transactions.at(0);
 
     ASSERT_EQ(transaction.session_id, "id-43");
-    ASSERT_EQ(transaction.transaction_id, boost::none);
+    ASSERT_EQ(transaction.transaction_id, -1);
 
     auto all_transactions = this->db_handler->get_transactions();
     ASSERT_EQ(all_transactions.size(), 2);


### PR DESCRIPTION
- Adding default transaction id of -1 when instantiating transactions
- transaction_id is therefore not optional anymore in TransactionEntry struct
- transaction_id is updated on StartTransaction.conf
- updated database test cases
- PR includes fix to build example in src/charge_point.cpp