### PR TITLE
Powermeter Update + Improvement of Stop- and Restart Behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.4
+    VERSION 0.4.1
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp1_6/types.hpp
+++ b/include/ocpp1_6/types.hpp
@@ -727,18 +727,23 @@ SessionStartedReason string_to_session_started_reason(const std::string& s);
 std::ostream& operator<<(std::ostream& os, const SessionStartedReason& session_started_reason);
 
 struct Current {
-    float L1;                  ///< L1 value only
-    boost::optional<float> L2; ///< L2 value only
-    boost::optional<float> L3; ///< L3 value only
-    boost::optional<float> N;  ///< Neutral value only
+    boost::optional<float> DC; ///< DC current
+    boost::optional<float> L1; ///< AC L1 value only
+    boost::optional<float> L2; ///< AC L2 value only
+    boost::optional<float> L3; ///< AC L3 value only
+    boost::optional<float> N;  ///< AC Neutral value only
 
     /// \brief Conversion from a given Current \p k to a given json object \p j
     friend void to_json(json& j, const Current& k) {
         // the required parts of the type
-        j = json{
-            {"L1", k.L1},
-        };
+        j = json({});
         // the optional parts of the type
+        if (k.DC) {
+            j["DC"] = k.DC.value();
+        }
+        if (k.L1) {
+            j["L1"] = k.L1.value();
+        }
         if (k.L2) {
             j["L2"] = k.L2.value();
         }
@@ -753,9 +758,14 @@ struct Current {
     /// \brief Conversion from a given json object \p j to a given Current \p k
     friend void from_json(const json& j, Current& k) {
         // the required parts of the type
-        k.L1 = j.at("L1");
 
         // the optional parts of the type
+        if (j.contains("DC")) {
+            k.DC.emplace(j.at("DC"));
+        }
+        if (j.contains("L1")) {
+            k.L1.emplace(j.at("L1"));
+        }
         if (j.contains("L2")) {
             k.L2.emplace(j.at("L2"));
         }
@@ -775,17 +785,22 @@ struct Current {
     }
 };
 struct Voltage {
-    float L1;                  ///< L1 value only
-    boost::optional<float> L2; ///< L2 value only
-    boost::optional<float> L3; ///< L3 value only
+    boost::optional<float> DC; ///< DC voltage
+    boost::optional<float> L1; ///< AC L1 value only
+    boost::optional<float> L2; ///< AC L2 value only
+    boost::optional<float> L3; ///< AC L3 value only
 
     /// \brief Conversion from a given Voltage \p k to a given json object \p j
     friend void to_json(json& j, const Voltage& k) {
         // the required parts of the type
-        j = json{
-            {"L1", k.L1},
-        };
+        j = json({});
         // the optional parts of the type
+        if (k.DC) {
+            j["DC"] = k.DC.value();
+        }
+        if (k.L1) {
+            j["L1"] = k.L1.value();
+        }
         if (k.L2) {
             j["L2"] = k.L2.value();
         }
@@ -797,9 +812,14 @@ struct Voltage {
     /// \brief Conversion from a given json object \p j to a given Voltage \p k
     friend void from_json(const json& j, Voltage& k) {
         // the required parts of the type
-        k.L1 = j.at("L1");
 
         // the optional parts of the type
+        if (j.contains("DC")) {
+            k.DC.emplace(j.at("DC"));
+        }
+        if (j.contains("L1")) {
+            k.L1.emplace(j.at("L1"));
+        }
         if (j.contains("L2")) {
             k.L2.emplace(j.at("L2"));
         }
@@ -816,9 +836,9 @@ struct Voltage {
     }
 };
 struct Frequency {
-    float L1;                  ///< L1 value
-    boost::optional<float> L2; ///< L2 value
-    boost::optional<float> L3; ///< L3 value
+    float L1;                  ///< AC L1 value
+    boost::optional<float> L2; ///< AC L2 value
+    boost::optional<float> L3; ///< AC L3 value
 
     /// \brief Conversion from a given Frequency \p k to a given json object \p j
     friend void to_json(json& j, const Frequency& k) {
@@ -857,10 +877,10 @@ struct Frequency {
     }
 };
 struct Power {
-    float total;               ///< Sum value
-    boost::optional<float> L1; ///< L1 value only
-    boost::optional<float> L2; ///< L2 value only
-    boost::optional<float> L3; ///< L3 value only
+    float total;               ///< DC / AC Sum value
+    boost::optional<float> L1; ///< AC L1 value only
+    boost::optional<float> L2; ///< AC L2 value only
+    boost::optional<float> L3; ///< AC L3 value only
 
     /// \brief Conversion from a given Power \p k to a given json object \p j
     friend void to_json(json& j, const Power& k) {
@@ -905,10 +925,10 @@ struct Power {
     }
 };
 struct Energy {
-    float total;               ///< Sum value (which is relevant for billing)
-    boost::optional<float> L1; ///< L1 value only
-    boost::optional<float> L2; ///< L2 value only
-    boost::optional<float> L3; ///< L3 value only
+    float total;               ///< DC / AC Sum value (which is relevant for billing)
+    boost::optional<float> L1; ///< AC L1 value only
+    boost::optional<float> L2; ///< AC L2 value only
+    boost::optional<float> L3; ///< AC L3 value only
 
     /// \brief Conversion from a given Energy \p k to a given json object \p j
     friend void to_json(json& j, const Energy& k) {
@@ -952,16 +972,65 @@ struct Energy {
         return os;
     }
 };
+struct ReactivePower {
+    float total;                   ///< VAR total
+    boost::optional<float> VARphA; ///< VAR phase A
+    boost::optional<float> VARphB; ///< VAR phase B
+    boost::optional<float> VARphC; ///< VAR phase C
+
+    /// \brief Conversion from a given ReactivePower \p k to a given json object \p j
+    friend void to_json(json& j, const ReactivePower& k) {
+        // the required parts of the type
+        j = json{
+            {"total", k.total},
+        };
+        // the optional parts of the type
+        if (k.VARphA) {
+            j["VARphA"] = k.VARphA.value();
+        }
+        if (k.VARphB) {
+            j["VARphB"] = k.VARphB.value();
+        }
+        if (k.VARphC) {
+            j["VARphC"] = k.VARphC.value();
+        }
+    }
+
+    /// \brief Conversion from a given json object \p j to a given ReactivePower \p k
+    friend void from_json(const json& j, ReactivePower& k) {
+        // the required parts of the type
+        k.total = j.at("total");
+
+        // the optional parts of the type
+        if (j.contains("VARphA")) {
+            k.VARphA.emplace(j.at("VARphA"));
+        }
+        if (j.contains("VARphB")) {
+            k.VARphB.emplace(j.at("VARphB"));
+        }
+        if (j.contains("VARphC")) {
+            k.VARphC.emplace(j.at("VARphC"));
+        }
+    }
+
+    // \brief Writes the string representation of the given ReactivePower \p k to the given output stream \p os
+    /// \returns an output stream with the ReactivePower written to
+    friend std::ostream& operator<<(std::ostream& os, const ReactivePower& k) {
+        os << json(k).dump(4);
+        return os;
+    }
+};
 
 struct Powermeter {
-    float timestamp;                                        ///< Timestamp of measurement
+    std::string timestamp;                                  ///< Timestamp of measurement
     Energy energy_Wh_import;                  ///< Imported energy in Wh (from grid)
     boost::optional<std::string> meter_id;                  ///< A (user defined) meter if (e.g. id printed on the case)
-    boost::optional<bool> phase_seq_error;                  ///< true for 3 phase rotation error (ccw)
+    boost::optional<bool> phase_seq_error;                  ///< AC only: true for 3 phase rotation error (ccw)
     boost::optional<Energy> energy_Wh_export; ///< Exported energy in Wh (to grid)
     boost::optional<Power>
         power_W; ///< Instantaneous power in Watt. Negative values are exported, positive values imported Energy.
     boost::optional<Voltage> voltage_V;      ///< Voltage in Volts
+    boost::optional<ReactivePower> VAR;      ///< Reactive power VAR
     boost::optional<Current> current_A;      ///< Current in ampere
     boost::optional<Frequency> frequency_Hz; ///< Grid frequency in Hertz
 
@@ -987,6 +1056,9 @@ struct Powermeter {
         }
         if (k.voltage_V) {
             j["voltage_V"] = k.voltage_V.value();
+        }
+        if (k.VAR) {
+            j["VAR"] = k.VAR.value();
         }
         if (k.current_A) {
             j["current_A"] = k.current_A.value();
@@ -1017,6 +1089,9 @@ struct Powermeter {
         }
         if (j.contains("voltage_V")) {
             k.voltage_V.emplace(j.at("voltage_V"));
+        }
+        if (j.contains("VAR")) {
+            k.VAR.emplace(j.at("VAR"));
         }
         if (j.contains("current_A")) {
             k.current_A.emplace(j.at("current_A"));

--- a/lib/ocpp1_6/charge_point.cpp
+++ b/lib/ocpp1_6/charge_point.cpp
@@ -397,7 +397,12 @@ MeterValue ChargePoint::get_latest_meter_value(int32_t connector, std::vector<Me
                         auto phase = configured_measurand.phase.value();
                         sample.phase.emplace(phase);
                         if (phase == Phase::L1) {
-                            sample.value = conversions::double_to_string((double)voltage_V.value().L1);
+                            if (voltage_V.value().L1) {
+                                sample.value = conversions::double_to_string((double)voltage_V.value().L1.value());
+                            } else {
+                                EVLOG_debug
+                                    << "Power meter does not contain voltage_V configured measurand for phase L1";
+                            }
                         } else if (phase == Phase::L2) {
                             if (voltage_V.value().L2) {
                                 sample.value = conversions::double_to_string((double)voltage_V.value().L2.value());
@@ -430,7 +435,12 @@ MeterValue ChargePoint::get_latest_meter_value(int32_t connector, std::vector<Me
                         auto phase = configured_measurand.phase.value();
                         sample.phase.emplace(phase);
                         if (phase == Phase::L1) {
-                            sample.value = conversions::double_to_string((double)current_A.value().L1);
+                            if (current_A.value().L1) {
+                                sample.value = conversions::double_to_string((double)current_A.value().L1.value());
+                            } else {
+                                EVLOG_debug
+                                    << "Power meter does not contain current_A configured measurand for phase L1";
+                            }
                         } else if (phase == Phase::L2) {
                             if (current_A.value().L2) {
                                 sample.value = conversions::double_to_string((double)current_A.value().L2.value());
@@ -2102,6 +2112,7 @@ void ChargePoint::register_data_transfer_callback(const CiString255Type& vendorI
 }
 
 void ChargePoint::on_meter_values(int32_t connector, const Powermeter& power_meter) {
+    // FIXME: fix power meter to also work with dc
     EVLOG_debug << "updating power meter for connector: " << connector;
     std::lock_guard<std::mutex> lock(power_meters_mutex);
     this->connectors.at(connector)->powermeter = power_meter;

--- a/lib/ocpp1_6/database_handler.cpp
+++ b/lib/ocpp1_6/database_handler.cpp
@@ -104,8 +104,8 @@ void DatabaseHandler::insert_transaction(const std::string& session_id, const in
         "(@session_id, @transaction_id, @connector, @id_tag_start, @time_start, @meter_start, @reservation_id)";
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2(this->db, sql.c_str(), sql.size(), &stmt, NULL) != SQLITE_OK) {
-        EVLOG_error << "Could not prepare insert statement" << std::endl;
-        throw std::runtime_error("Database access error");
+        EVLOG_warning << "Could not prepare insert statement" << std::endl;
+        return;
     }
 
     sqlite3_bind_text(stmt, 1, session_id.c_str(), session_id.length(), NULL);
@@ -140,8 +140,8 @@ void DatabaseHandler::update_transaction(const std::string& session_id, int32_t 
 
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2(this->db, sql.c_str(), sql.size(), &stmt, NULL) != SQLITE_OK) {
-        EVLOG_error << "Could not prepare insert statement" << std::endl;
-        throw std::runtime_error("Database access error");
+        EVLOG_warning << "Could not prepare insert statement" << std::endl;
+        return;
     }
 
     // bindings
@@ -171,8 +171,8 @@ void DatabaseHandler::update_transaction(const std::string& session_id, int32_t 
 
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2(this->db, sql.c_str(), sql.size(), &stmt, NULL) != SQLITE_OK) {
-        EVLOG_error << "Could not prepare insert statement" << std::endl;
-        throw std::runtime_error("Database access error");
+        EVLOG_warning << "Could not prepare insert statement" << std::endl;
+        return;
     }
 
     sqlite3_bind_int(stmt, 1, meter_stop);
@@ -268,7 +268,7 @@ void DatabaseHandler::insert_or_update_authorization_cache_entry(const CiString2
     sqlite3_stmt* stmt;
     if (sqlite3_prepare_v2(this->db, sql.c_str(), sql.size(), &stmt, NULL) != SQLITE_OK) {
         EVLOG_error << "Could not prepare insert statement" << std::endl;
-        throw std::runtime_error("Database access error");
+        return;
     }
 
     const auto id_tag_str = id_tag.get();

--- a/lib/ocpp1_6/transaction.cpp
+++ b/lib/ocpp1_6/transaction.cpp
@@ -86,6 +86,7 @@ std::vector<TransactionData> Transaction::get_transaction_data() {
 }
 
 void Transaction::stop() {
+    this->meter_values_sample_timer->stop();
     this->active = false;
 }
 


### PR DESCRIPTION
Powermeter:
- Import Powermeter (and related) types from everest-core

Stop-/Restart Behavior:
- Avoid crashing on failing database operations (these can occur when the ocpp service was shut down previously)
- Not resetting work and io_service_thread on restart

Misc:
- Stopping meter values timer when Transaction is stopped