### PR TITLE
Basic Implementation of Functional Block: Provisioning

### DIFF
--- a/config/v201/component_schemas/InternalCtrlr.json
+++ b/config/v201/component_schemas/InternalCtrlr.json
@@ -282,6 +282,24 @@
       ],
       "default": "31536000",
       "type": "integer"
+    },
+    "NumberOfConnectors": {
+      "characteristics": {
+        "minLimit": 1,
+        "maxLimit": 128,
+        "supportsMonitoring": true,
+        "dataType": "integer"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadOnly"
+        }
+      ],
+      "minimum": 1,
+      "maximum": 128,
+      "default": "1",
+      "type": "integer"
     }
   },
   "required": [
@@ -291,6 +309,7 @@
     "ChargePointModel",
     "ChargePointVendor",
     "FirmwareVersion",
+    "NumberOfConnectors",
     "SupportedCiphers12",
     "SupportedCiphers13",
     "WebsocketReconnectInterval"

--- a/config/v201/component_schemas/SecurityCtrlr.json
+++ b/config/v201/component_schemas/SecurityCtrlr.json
@@ -118,6 +118,8 @@
     },
     "SecurityProfile": {
       "characteristics": {
+        "minLimit": 1,
+        "maxLimit": 3,
         "supportsMonitoring": true,
         "dataType": "integer"
       },
@@ -128,6 +130,8 @@
         }
       ],
       "description": "The security profile used by the Charging Station.",
+      "minimum": 1,
+      "maximum": 3,
       "type": "integer"
     }
   },

--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -6,6 +6,7 @@
         "ChargePointModel": "Yeti",
         "ChargePointVendor": "Pionix",
         "FirmwareVersion": "0.4",
+        "NumberOfConnectors": 2,
         "SupportedCiphers12": "ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256,GCM-SHA384,AES128-GCM-SHA256,AES256-GCM-SHA384,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256",
         "SupportedCiphers13": "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256",
         "WebsocketReconnectInterval": 30
@@ -41,7 +42,7 @@
         "TxUpdatedMeasurands": ""
     },
     "SecurityCtrlr": {
-        "SecurityProfile": 0,
+        "SecurityProfile": 1,
         "OrganizationName": "Pionix",
         "CertificateEntries": 100
     }

--- a/include/ocpp/common/charging_station_base.hpp
+++ b/include/ocpp/common/charging_station_base.hpp
@@ -12,8 +12,8 @@
 
 namespace ocpp {
 
-/// \brief Common base class for OCPP1.6 and OCPP2.0.1 chargepoints
-class ChargePoint {
+/// \brief Common base class for OCPP1.6 and OCPP2.0.1 charging stations
+class ChargingStationBase {
 
 protected:
     std::unique_ptr<Websocket> websocket;
@@ -21,15 +21,13 @@ protected:
     std::shared_ptr<MessageLogging> logging;
     std::shared_ptr<DatabaseHandler> database_handler;
 
-    ChargePointConnectionState connection_state;
-
     boost::shared_ptr<boost::asio::io_service::work> work;
     boost::asio::io_service io_service;
     std::thread io_service_thread;
 
 public:
-    ChargePoint();
-    virtual ~ChargePoint(){};
+    ChargingStationBase();
+    virtual ~ChargingStationBase(){};
 };
 
 } // namespace ocpp

--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -402,7 +402,7 @@ public:
     /// \brief Handles a message timeout or a CALLERROR. \p enhanced_message_opt is set only in case of CALLERROR
     void handle_timeout_or_callerror(const boost::optional<EnhancedMessage<M>>& enhanced_message_opt) {
         std::lock_guard<std::mutex> lk(this->message_mutex);
-        EVLOG_warning << "Message timeout for: " << this->in_flight->messageType << " (" << this->in_flight->uniqueId()
+        EVLOG_warning << "Message timeout or CALLERROR for: " << this->in_flight->messageType << " (" << this->in_flight->uniqueId()
                       << ")";
         if (this->isTransactionMessage(this->in_flight)) {
             if (this->in_flight->message_attempts < this->transaction_message_attempts) {

--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -255,28 +255,6 @@ void from_json(const json& j, CallError& c);
 std::ostream& operator<<(std::ostream& os, const CallError& c);
 
 /// \brief Contains the different connection states of the charge point
-enum ChargePointConnectionState {
-    Disconnected,
-    Connected,
-    Booted,
-    Pending,
-    Rejected,
-};
-namespace conversions {
-/// \brief Converts the given ChargePointConnectionState \p e to std::string
-/// \returns a string representation of the ChargePointConnectionState
-std::string charge_point_connection_state_to_string(ChargePointConnectionState e);
-
-/// \brief Converts the given std::string \p s to ChargePointConnectionState
-/// \returns a ChargePointConnectionState from a string representation
-ChargePointConnectionState string_to_charge_point_connection_state(const std::string& s);
-} // namespace conversions
-
-/// \brief Writes the string representation of the given \p charge_point_connection_state
-/// to the given output stream \p os \returns an output stream with the ChargePointConnectionState written to
-std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state);
-
-/// \brief Contains the different connection states of the charge point
 enum SessionStartedReason {
     EVConnected,
     Authorized

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -13,7 +13,7 @@
 
 #include <everest/timer.hpp>
 
-#include <ocpp/common/charge_point.hpp>
+#include <ocpp/common/charging_station_base.hpp>
 #include <ocpp/common/database_handler.hpp>
 #include <ocpp/common/message_queue.hpp>
 #include <ocpp/common/schemas.hpp>
@@ -70,7 +70,7 @@ namespace ocpp {
 namespace v16 {
 
 /// \brief Contains a ChargePoint implementation compatible with OCPP-J 1.6
-class ChargePoint : ocpp::ChargePoint {
+class ChargePoint : ocpp::ChargingStationBase {
 private:
     std::unique_ptr<MessageQueue<v16::MessageType>> message_queue;
     std::map<int32_t, std::shared_ptr<Connector>> connectors;
@@ -82,6 +82,7 @@ private:
     std::set<MessageType> allowed_message_types;
     std::mutex allowed_message_types_mutex;
     RegistrationStatus registration_status;
+    ChargePointConnectionState connection_state;
     std::unique_ptr<ChargePointStates> status;
     std::shared_ptr<ChargePointConfiguration> configuration;
     std::shared_ptr<ocpp::DatabaseHandler> database_handler;

--- a/include/ocpp/v16/types.hpp
+++ b/include/ocpp/v16/types.hpp
@@ -139,6 +139,28 @@ SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string&
 /// \returns an output stream with the SupportedFeatureProfiles written to
 std::ostream& operator<<(std::ostream& os, const SupportedFeatureProfiles& supported_feature_profiles);
 
+/// \brief Contains the different connection states of the charge point
+enum ChargePointConnectionState {
+    Disconnected,
+    Connected,
+    Booted,
+    Pending,
+    Rejected,
+};
+namespace conversions {
+/// \brief Converts the given ChargePointConnectionState \p e to std::string
+/// \returns a string representation of the ChargePointConnectionState
+std::string charge_point_connection_state_to_string(ChargePointConnectionState e);
+
+/// \brief Converts the given std::string \p s to ChargePointConnectionState
+/// \returns a ChargePointConnectionState from a string representation
+ChargePointConnectionState string_to_charge_point_connection_state(const std::string& s);
+} // namespace conversions
+
+/// \brief Writes the string representation of the given \p charge_point_connection_state
+/// to the given output stream \p os \returns an output stream with the ChargePointConnectionState written to
+std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state);
+
 /// \brief Combines a Measurand with an optional Phase
 struct MeasurandWithPhase {
     Measurand measurand;          ///< A OCPP Measurand

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -3,25 +3,43 @@
 
 #include <future>
 
-#include <ocpp/common/charge_point.hpp>
+#include <ocpp/common/charging_station_base.hpp>
 
-#include <ocpp/v201/charge_point_configuration.hpp>
+#include <ocpp/v201/device_model_management.hpp>
 #include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/evse.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/types.hpp>
 
 #include <ocpp/v201/messages/BootNotification.hpp>
+#include <ocpp/v201/messages/GetBaseReport.hpp>
+#include <ocpp/v201/messages/GetReport.hpp>
+#include <ocpp/v201/messages/GetVariables.hpp>
 #include <ocpp/v201/messages/Heartbeat.hpp>
+#include <ocpp/v201/messages/NotifyReport.hpp>
+#include <ocpp/v201/messages/SetVariables.hpp>
+#include <ocpp/v201/messages/StatusNotification.hpp>
+#include <ocpp/v201/messages/TriggerMessage.hpp>
 
 namespace ocpp {
 namespace v201 {
 
-/// \brief Class implements OCPP2.0.1 charging point
-class ChargePoint : ocpp::ChargePoint {
+/// \brief Class implements OCPP2.0.1 Charging Station
+class ChargePoint : ocpp::ChargingStationBase {
 
 private:
     std::unique_ptr<MessageQueue<v201::MessageType>> message_queue;
-    std::shared_ptr<ChargePointConfiguration> configuration;
+    std::shared_ptr<DeviceModelManager> device_model_manager;
+
+    std::map<int32_t, std::unique_ptr<Evse>> evses;
+
+    // timers
+    Everest::SteadyTimer heartbeat_timer;
+    Everest::SteadyTimer boot_notification_timer;
+
+    // states
+    RegistrationStatusEnum registration_status;
+    WebsocketConnectionStatusEnum websocket_connection_status;
 
     // general message handling
     template <class T> bool send(Call<T> call);
@@ -31,24 +49,50 @@ private:
 
     void init_websocket();
 
-    void handle_message(const json& json_message, MessageType message_type);
+    void handle_message(const json& json_message, const MessageType& message_type);
     void message_callback(const std::string& message);
 
     // message requests
 
     // Provisioning
-    void boot_notification_req();
+    void boot_notification_req(const BootReasonEnum& reason);
+    void notify_report_req(const int request_id, const int seq_no, const std::vector<ReportData>& report_data);
 
-    // message response handlers
+    // Availability
+    void status_notification_req(const int32_t evse_id, const int32_t connector_id, const ConnectorStatusEnum status);
+    void heartbeat_req();
+
+    // message handlers
 
     // Provisioning
     void handle_boot_notification_response(CallResult<BootNotificationResponse> call_result);
+    void handle_set_variables_req(Call<SetVariablesRequest> call);
+    void handle_get_variables_req(Call<GetVariablesRequest> call);
+    void handle_get_base_report_req(Call<GetBaseReportRequest> call);
+    void handle_get_report_req(Call<GetReportRequest> call);
 
 public:
+    /// \brief Construct a new ChargePoint object
+    /// \param config OCPP json config
+    /// \param ocpp_main_path Path where utility files for OCPP are read and written to
+    /// \param message_log_path Path to where logfiles are written to
     ChargePoint(const json& config, const std::string& ocpp_main_path, const std::string& message_log_path);
 
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint
-    bool start();
+    void start();
+
+    /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers
+    void stop();
+
+    /// \brief Event handler that should be called when a session has started
+    /// \param evse_id
+    /// \param connector_id
+    void on_session_started(const int32_t evse_id, const int32_t connector_id);
+
+    /// \brief Event handler that should be called when a session has finished
+    /// \param evse_id
+    /// \param connector_id
+    void on_session_finished(const int32_t evse_id, const int32_t connector_id);
 };
 
 } // namespace v201

--- a/include/ocpp/v201/connector.hpp
+++ b/include/ocpp/v201/connector.hpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include <functional>
+#include <mutex>
+
+#include <ocpp/v201/enums.hpp>
+
+namespace ocpp {
+namespace v201 {
+
+/// \brief Enum for ConnectorEvents
+enum class ConnectorEvent {
+    PlugIn,
+    PlugOut,
+    Reserve,
+    Error,
+    Unavailable,
+    ReservationFinished,
+    PlugInAndTokenValid,
+    ErrorCleared,
+    ErrorCleardOnOccupied,
+    ErrorCleardOnReserved,
+    UnavailableToAvailable,
+    UnavailableToOccupied,
+    UnavailableToReserved,
+    UnavailableFaulted
+};
+
+/// \brief Represents a Connector, thus electrical outlet on a Charging Station. Single physical Connector.
+class Connector {
+private:
+    int32_t connector_id;
+    ConnectorStatusEnum state;
+    std::mutex state_mutex;
+
+    std::function<void(const ConnectorStatusEnum& status)> status_notification_callback;
+
+public:
+    /// \brief Construct a new Connector object
+    /// \param connector_id id of the connector
+    /// \param status_notification_callback callback executed when the state of the connector changes
+    Connector(const int32_t connector_id,
+              const std::function<void(const ConnectorStatusEnum& status)>& status_notification_callback);
+
+    /// \brief Get the state object
+    /// \return ConnectorStatusEnum
+    ConnectorStatusEnum get_state();
+
+    /// \brief Submits the given \p event to the state machine controller
+    /// \param event
+    void submit_event(ConnectorEvent event);
+};
+
+} // namespace v201
+} // namespace ocpp

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include <functional>
+#include <map>
+#include <memory>
+
+#include <ocpp/v201/connector.hpp>
+
+namespace ocpp {
+namespace v201 {
+
+/// \brief Represents an EVSE. An EVSE can contain multiple Connector objects, but can only supply energy to one of
+/// them.
+class Evse {
+
+private:
+    int32_t evse_id;
+    std::map<int32_t, std::unique_ptr<Connector>> id_connector_map;
+    std::function<void(const int32_t connector_id, const ConnectorStatusEnum& status)> status_notification_callback;
+
+public:
+    /// \brief Construct a new Evse object
+    /// \param evse_id id of the evse
+    /// \param number_of_connectors of the evse
+    /// \param status_notification_callback that is called when the status of a connector changes
+    Evse(const int32_t evse_id, const int32_t number_of_connectors,
+         const std::function<void(const int32_t connector_id, const ConnectorStatusEnum& status)>&
+             status_notification_callback);
+
+    /// \brief Get the state of the connector with the given \p connector_id
+    /// \param connector_id id of the connector of the evse
+    /// \return ConnectorStatusEnum
+    ConnectorStatusEnum get_state(const int32_t connector_id);
+
+    /// \brief Submits the given \p event to the state machine controller of the connector with the given \p
+    /// connector_id
+    /// \param connector_id id of the connector of the evse \param event
+    void submit_event(const int32_t connector_id, ConnectorEvent event);
+
+    /// \brief Triggers status notification callback for all connectors of the evse
+    void trigger_status_notification_callbacks();
+};
+
+} // namespace v201
+} // namespace ocpp

--- a/include/ocpp/v201/types.hpp
+++ b/include/ocpp/v201/types.hpp
@@ -157,6 +157,26 @@ MessageType string_to_messagetype(const std::string& s);
 /// \returns an output stream with the MessageType written to
 std::ostream& operator<<(std::ostream& os, const MessageType& message_type);
 
+enum class WebsocketConnectionStatusEnum {
+    Connected,
+    Disconnected
+};
+
+namespace conversions {
+/// \brief Converts the given WebsocketConnectionStatusEnum \p m to std::string
+/// \returns a string representation of the WebsocketConnectionStatusEnum
+std::string websocket_connection_status_to_string(WebsocketConnectionStatusEnum m);
+
+/// \brief Converts the given std::string \p s to WebsocketConnectionStatusEnum
+/// \returns a WebsocketConnectionStatusEnum from a string representation
+WebsocketConnectionStatusEnum string_to_websocket_connection_status(const std::string& s);
+
+} // namespace conversions
+
+/// \brief Writes the string representation of the given \p websocket_connection_status to the given output stream \p os
+/// \returns an output stream with the WebsocketConnectionStatusEnum written to
+std::ostream& operator<<(std::ostream& os, const WebsocketConnectionStatusEnum& websocket_connection_status);
+
 } // namespace v201
 } // namespace ocpp
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(ocpp)
 add_library(everest::ocpp ALIAS ocpp)
 target_sources(ocpp
     PRIVATE
-        ocpp/common/charge_point.cpp
+        ocpp/common/charging_station_base.cpp
         ocpp/common/database_handler.cpp
         ocpp/common/message_queue.cpp
         ocpp/common/ocpp_logging.cpp
@@ -19,10 +19,12 @@ target_sources(ocpp
         ocpp/v16/ocpp_types.cpp
         ocpp/v16/types.cpp
         ocpp/v201/charge_point.cpp
-        ocpp/v201/charge_point_configuration.cpp
+        ocpp/v201/device_model_management.cpp
         ocpp/v201/enums.cpp
         ocpp/v201/ocpp_types.cpp
         ocpp/v201/types.cpp
+        ocpp/v201/connector.cpp
+        ocpp/v201/evse.cpp
 )
 
 add_subdirectory(ocpp/common/websocket)

--- a/lib/ocpp/common/charging_station_base.cpp
+++ b/lib/ocpp/common/charging_station_base.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
-#include <ocpp/common/charge_point.hpp>
+#include <ocpp/common/charging_station_base.hpp>
 
 namespace ocpp {
-ChargePoint::ChargePoint() : connection_state(ChargePointConnectionState::Disconnected) {
+ChargingStationBase::ChargingStationBase() {
     this->work = boost::make_shared<boost::asio::io_service::work>(this->io_service);
     this->io_service_thread = std::thread([this]() { this->io_service.run(); });
 }

--- a/lib/ocpp/common/types.cpp
+++ b/lib/ocpp/common/types.cpp
@@ -111,51 +111,6 @@ std::ostream& operator<<(std::ostream& os, const CallError& c) {
     os << json(c).dump(4);
     return os;
 }
-namespace conversions {
-
-std::string charge_point_connection_state_to_string(ChargePointConnectionState e) {
-    switch (e) {
-    case ChargePointConnectionState::Disconnected:
-        return "Disconnected";
-    case ChargePointConnectionState::Connected:
-        return "Connected";
-    case ChargePointConnectionState::Booted:
-        return "Booted";
-    case ChargePointConnectionState::Pending:
-        return "Pending";
-    case ChargePointConnectionState::Rejected:
-        return "Rejected";
-    }
-
-    throw std::out_of_range("No known string conversion for provided enum of type ChargePointConnectionState");
-}
-
-ChargePointConnectionState string_to_charge_point_connection_state(const std::string& s) {
-    if (s == "Disconnected") {
-        return ChargePointConnectionState::Disconnected;
-    }
-    if (s == "Connected") {
-        return ChargePointConnectionState::Connected;
-    }
-    if (s == "Booted") {
-        return ChargePointConnectionState::Booted;
-    }
-    if (s == "Pending") {
-        return ChargePointConnectionState::Pending;
-    }
-    if (s == "Rejected") {
-        return ChargePointConnectionState::Rejected;
-    }
-
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ChargePointConnectionState");
-}
-} // namespace conversions
-
-std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state) {
-    os << conversions::charge_point_connection_state_to_string(charge_point_connection_state);
-    return os;
-}
 
 namespace conversions {
 

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -14,8 +14,9 @@ namespace v16 {
 ChargePoint::ChargePoint(const json& config, const std::string& share_path, const std::string& user_config_path,
                          const std::string& database_path, const std::string& sql_init_path,
                          const std::string& message_log_path) :
-    ocpp::ChargePoint(),
+    ocpp::ChargingStationBase(),
     initialized(false),
+    connection_state(ChargePointConnectionState::Disconnected),
     registration_status(RegistrationStatus::Pending),
     diagnostics_status(DiagnosticsStatus::Idle),
     firmware_status(FirmwareStatus::Idle),

--- a/lib/ocpp/v16/types.cpp
+++ b/lib/ocpp/v16/types.cpp
@@ -487,6 +487,52 @@ std::ostream& operator<<(std::ostream& os, const SupportedFeatureProfiles& suppo
     return os;
 }
 
+namespace conversions {
+
+std::string charge_point_connection_state_to_string(ChargePointConnectionState e) {
+    switch (e) {
+    case ChargePointConnectionState::Disconnected:
+        return "Disconnected";
+    case ChargePointConnectionState::Connected:
+        return "Connected";
+    case ChargePointConnectionState::Booted:
+        return "Booted";
+    case ChargePointConnectionState::Pending:
+        return "Pending";
+    case ChargePointConnectionState::Rejected:
+        return "Rejected";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ChargePointConnectionState");
+}
+
+ChargePointConnectionState string_to_charge_point_connection_state(const std::string& s) {
+    if (s == "Disconnected") {
+        return ChargePointConnectionState::Disconnected;
+    }
+    if (s == "Connected") {
+        return ChargePointConnectionState::Connected;
+    }
+    if (s == "Booted") {
+        return ChargePointConnectionState::Booted;
+    }
+    if (s == "Pending") {
+        return ChargePointConnectionState::Pending;
+    }
+    if (s == "Rejected") {
+        return ChargePointConnectionState::Rejected;
+    }
+
+    throw std::out_of_range("Provided string " + s +
+                            " could not be converted to enum of type ChargePointConnectionState");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ChargePointConnectionState& charge_point_connection_state) {
+    os << conversions::charge_point_connection_state_to_string(charge_point_connection_state);
+    return os;
+}
+
 bool MeasurandWithPhase::operator==(MeasurandWithPhase measurand_with_phase) {
     if (this->measurand == measurand_with_phase.measurand) {
         if (this->phase || measurand_with_phase.phase) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -6,20 +6,54 @@
 namespace ocpp {
 namespace v201 {
 
+const auto DEFAULT_BOOT_NOTIFICATION_RETRY_INTERVAL = std::chrono::seconds(30);
+
 ChargePoint::ChargePoint(const json& config, const std::string& ocpp_main_path, const std::string& message_log_path) :
-    ocpp::ChargePoint() {
+    ocpp::ChargingStationBase(),
+    registration_status(RegistrationStatusEnum::Rejected),
+    websocket_connection_status(WebsocketConnectionStatusEnum::Disconnected) {
     this->pki_handler = std::make_shared<ocpp::PkiHandler>(ocpp_main_path);
-    this->configuration = std::make_shared<ChargePointConfiguration>(config, ocpp_main_path, this->pki_handler);
+    this->device_model_manager = std::make_shared<DeviceModelManager>(config, ocpp_main_path);
+
+    for (int evse_id = 1; evse_id <= this->device_model_manager->get_number_of_connectors(); evse_id++) {
+        this->evses.insert(std::make_pair(
+            evse_id, std::make_unique<Evse>(
+                         evse_id, 1, [this, evse_id](const int32_t connector_id, const ConnectorStatusEnum& status) {
+                             if (this->registration_status == RegistrationStatusEnum::Accepted) {
+                                 this->status_notification_req(evse_id, connector_id, status);
+                             }
+                         })));
+    }
+
     this->logging = std::make_shared<ocpp::MessageLogging>(true, message_log_path, DateTime().to_rfc3339(), false,
                                                            false, false, true, true);
     this->message_queue = std::make_unique<ocpp::MessageQueue<v201::MessageType>>(
-        [this](json message) -> bool { return this->websocket->send(message.dump()); }, 5, 30);
+        [this](json message) -> bool { return this->websocket->send(message.dump()); },
+        this->device_model_manager->get_message_attempts_transaction_event(),
+        this->device_model_manager->get_message_attempt_interval_transaction_event());
 }
 
-bool ChargePoint::start() {
+void ChargePoint::start() {
     this->init_websocket();
-    this->websocket->connect(this->configuration->get_security_profile());
-    return true;
+    this->websocket->connect(this->device_model_manager->get_security_profile());
+    this->boot_notification_req(BootReasonEnum::PowerUp);
+
+    // FIXME(piet): Run state machine with correct initial state
+}
+
+void ChargePoint::stop() {
+    this->heartbeat_timer.stop();
+    this->boot_notification_timer.stop();
+    this->websocket->disconnect(websocketpp::close::status::going_away);
+    this->message_queue->stop();
+}
+
+void ChargePoint::on_session_started(const int32_t evse_id, const int32_t connector_id) {
+    this->evses.at(evse_id)->submit_event(connector_id, ConnectorEvent::PlugIn);
+}
+
+void ChargePoint::on_session_finished(const int32_t evse_id, const int32_t connector_id) {
+    this->evses.at(evse_id)->submit_event(connector_id, ConnectorEvent::PlugOut);
 }
 
 template <class T> bool ChargePoint::send(ocpp::Call<T> call) {
@@ -40,60 +74,269 @@ bool ChargePoint::send(CallError call_error) {
 }
 
 void ChargePoint::init_websocket() {
+
+    if (this->device_model_manager->get_charge_point_id().find(':') != std::string::npos) {
+        EVLOG_AND_THROW(std::runtime_error("ChargePointId must not contain \':\'"));
+    }
+
+    // FIXME(piet): get password properly from configuration
+    boost::optional<std::string> basic_auth_password;
+    basic_auth_password.emplace("DEADBEEFDEADBEEF");
+
     WebsocketConnectionOptions connection_options{OcppProtocolVersion::v201,
-                                                  this->configuration->get_central_system_uri(),
-                                                  this->configuration->get_security_profile(),
-                                                  this->configuration->get_charge_point_id(),
-                                                  boost::none,
-                                                  this->configuration->get_websocket_reconnect_interval(),
-                                                  this->configuration->get_supported_ciphers12(),
-                                                  this->configuration->get_supported_ciphers13()};
+                                                  this->device_model_manager->get_central_system_uri(),
+                                                  this->device_model_manager->get_security_profile(),
+                                                  this->device_model_manager->get_charge_point_id(),
+                                                  basic_auth_password,
+                                                  this->device_model_manager->get_websocket_reconnect_interval(),
+                                                  this->device_model_manager->get_supported_ciphers12(),
+                                                  this->device_model_manager->get_supported_ciphers13()};
 
     this->websocket = std::make_unique<Websocket>(connection_options, this->pki_handler, this->logging);
     this->websocket->register_connected_callback([this](const int security_profile) {
         this->message_queue->resume();
-        this->connection_state = ChargePointConnectionState::Connected;
-        this->boot_notification_req();
+        this->websocket_connection_status = WebsocketConnectionStatusEnum::Disconnected;
     });
     this->websocket->register_disconnected_callback([this]() {
-        this->message_queue->pause(); //
+        this->websocket_connection_status = WebsocketConnectionStatusEnum::Disconnected;
+        this->message_queue->pause();
     });
 
     this->websocket->register_message_callback([this](const std::string& message) { this->message_callback(message); });
 }
 
-void ChargePoint::handle_message(const json& json_message, MessageType message_type) {
+void ChargePoint::handle_message(const json& json_message, const MessageType& message_type) {
     switch (message_type) {
     case MessageType::BootNotificationResponse:
         this->handle_boot_notification_response(json_message);
+        break;
+    case MessageType::SetVariables:
+        this->handle_set_variables_req(json_message);
+        break;
+    case MessageType::GetVariables:
+        this->handle_get_variables_req(json_message);
+        break;
+    case MessageType::GetBaseReport:
+        this->handle_get_base_report_req(json_message);
+        break;
+    case MessageType::GetReport:
+        this->handle_get_report_req(json_message);
+        break;
     }
 }
 
 void ChargePoint::message_callback(const std::string& message) {
-    EVLOG_info << "Received Message: " << message;
     auto enhanced_message = this->message_queue->receive(message);
     auto json_message = enhanced_message.message;
-    this->handle_message(json_message, enhanced_message.messageType);
+    this->logging->central_system(conversions::messagetype_to_string(enhanced_message.messageType), message);
+
+    if (this->registration_status == RegistrationStatusEnum::Accepted) {
+        this->handle_message(json_message, enhanced_message.messageType);
+    } else if (this->registration_status == RegistrationStatusEnum::Pending) {
+        if (enhanced_message.messageType == MessageType::BootNotificationResponse) {
+            this->handle_boot_notification_response(json_message);
+        } else {
+            // TODO(piet): Check what kind of messages we should accept in Pending state
+            if (enhanced_message.messageType == MessageType::GetVariables or
+                enhanced_message.messageType == MessageType::SetVariables or
+                enhanced_message.messageType == MessageType::GetBaseReport or
+                enhanced_message.messageType == MessageType::GetReport or
+                enhanced_message.messageType == MessageType::TriggerMessage) {
+                this->handle_message(json_message, enhanced_message.messageType);
+            } else {
+                EVLOG_warning << "Received invalid MessageType: "
+                              << conversions::messagetype_to_string(enhanced_message.messageType)
+                              << " from CSMS while in state Pending";
+            }
+        }
+    } else if (this->registration_status == RegistrationStatusEnum::Rejected) {
+        if (enhanced_message.messageType == MessageType::BootNotificationResponse) {
+            this->handle_boot_notification_response(json_message);
+        } else if (enhanced_message.messageType == MessageType::TriggerMessage) {
+            Call<TriggerMessageRequest> call(json_message);
+            if (call.msg.requestedMessage == MessageTriggerEnum::BootNotification) {
+                this->handle_message(json_message, enhanced_message.messageType);
+            } else {
+                const auto error_message = "Received TriggerMessage with requestedMessage != BootNotification before "
+                                           "having received an accepted BootNotificationResponse";
+                EVLOG_warning << error_message;
+                const auto call_error = CallError(enhanced_message.uniqueId, "SecurityError", "", json({}));
+                this->send(call_error);
+            }
+        } else {
+            const auto error_message = "Received other message than BootNotificationResponse before "
+                                       "having received an accepted BootNotificationResponse";
+            EVLOG_warning << error_message;
+            const auto call_error = CallError(enhanced_message.uniqueId, "SecurityError", "", json({}));
+            this->send(call_error);
+        }
+    }
 }
 
-void ChargePoint::boot_notification_req() {
+void ChargePoint::boot_notification_req(const BootReasonEnum& reason) {
     EVLOG_debug << "Sending BootNotification";
     BootNotificationRequest req;
 
     ChargingStation charging_station;
-    charging_station.model = this->configuration->get_charge_point_model();
-    charging_station.vendorName = this->configuration->get_charge_point_vendor();
+    charging_station.model = this->device_model_manager->get_charge_point_model();
+    charging_station.vendorName = this->device_model_manager->get_charge_point_vendor();
+    charging_station.firmwareVersion.emplace(this->device_model_manager->get_firmware_version());
+    charging_station.serialNumber.emplace(this->device_model_manager->get_charge_box_serial_number());
 
-    req.reason = BootReasonEnum::PowerUp;
+    req.reason = reason;
     req.chargingStation = charging_station;
 
     ocpp::Call<BootNotificationRequest> call(req, this->message_queue->createMessageId());
     this->send<BootNotificationRequest>(call);
 }
 
+void ChargePoint::notify_report_req(const int request_id, const int seq_no,
+                                    const std::vector<ReportData>& report_data) {
+
+    NotifyReportRequest req;
+    req.requestId = request_id;
+    req.seqNo = seq_no;
+    req.generatedAt = ocpp::DateTime();
+    req.reportData.emplace(report_data);
+
+    ocpp::Call<NotifyReportRequest> call(req, this->message_queue->createMessageId());
+    this->send<NotifyReportRequest>(call);
+}
+
+void ChargePoint::status_notification_req(const int32_t evse_id, const int32_t connector_id,
+                                          const ConnectorStatusEnum status) {
+    StatusNotificationRequest req;
+    req.connectorId = connector_id;
+    req.evseId = evse_id;
+    req.timestamp = DateTime().to_rfc3339();
+    req.connectorStatus = status;
+
+    ocpp::Call<StatusNotificationRequest> call(req, this->message_queue->createMessageId());
+    this->send<StatusNotificationRequest>(call);
+}
+
+void ChargePoint::heartbeat_req() {
+    HeartbeatRequest req;
+
+    ocpp::Call<HeartbeatRequest> call(req, this->message_queue->createMessageId());
+    this->send<HeartbeatRequest>(call);
+}
+
 void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationResponse> call_result) {
+    // TODO(piet): B01.FR.06
+    // TODO(piet): B01.FR.07
+    // TODO(piet): B01.FR.08
+    // TODO(piet): B01.FR.09
+    // TODO(piet): B01.FR.13
     EVLOG_info << "Received BootNotificationResponse: " << call_result.msg
                << "\nwith messageId: " << call_result.uniqueId;
+
+    const auto msg = call_result.msg;
+
+    this->registration_status = msg.status;
+
+    if (this->registration_status == RegistrationStatusEnum::Accepted) {
+        if (msg.interval > 0) {
+            this->heartbeat_timer.interval([this]() { this->heartbeat_req(); }, std::chrono::seconds(msg.interval));
+        }
+        for (auto const& [evse_id, evse] : this->evses) {
+            evse->trigger_status_notification_callbacks();
+        }
+    } else {
+        auto retry_interval = DEFAULT_BOOT_NOTIFICATION_RETRY_INTERVAL;
+        if (msg.interval > 0) {
+            retry_interval = std::chrono::seconds(msg.interval);
+        }
+        this->boot_notification_timer.timeout(
+            [this, msg]() {
+                this->boot_notification_req(BootReasonEnum::PowerUp); // FIXME(piet): Choose correct reason here
+            },
+            retry_interval);
+    }
+}
+
+void ChargePoint::handle_set_variables_req(Call<SetVariablesRequest> call) {
+    const auto msg = call.msg;
+
+    SetVariablesResponse response;
+
+    for (const auto& set_variable_data : msg.setVariableData) {
+        SetVariableResult set_variable_result;
+        set_variable_result.component = set_variable_data.component;
+        set_variable_result.variable = set_variable_data.variable;
+        set_variable_result.attributeType = set_variable_data.attributeType.get_value_or(AttributeEnum::Actual);
+        set_variable_result.attributeStatus = this->device_model_manager->set_variable(set_variable_data);
+
+        response.setVariableResult.push_back(set_variable_result);
+    }
+
+    ocpp::CallResult<SetVariablesResponse> call_result(response, call.uniqueId);
+    this->send<SetVariablesResponse>(call_result);
+}
+
+void ChargePoint::handle_get_variables_req(Call<GetVariablesRequest> call) {
+    const auto msg = call.msg;
+
+    // FIXME(piet): add handling for B06.FR.16
+    // FIXME(piet): add handling for B06.FR.17
+
+    GetVariablesResponse response;
+
+    for (const auto& get_variable_data : msg.getVariableData) {
+        GetVariableResult get_variable_result;
+        get_variable_result.component = get_variable_data.component;
+        get_variable_result.variable = get_variable_data.variable;
+        get_variable_result.attributeType = get_variable_data.attributeType.get_value_or(AttributeEnum::Actual);
+        const auto status_value_pair = this->device_model_manager->get_variable(get_variable_data);
+        get_variable_result.attributeStatus = status_value_pair.first;
+        if (status_value_pair.second.has_value()) {
+            get_variable_result.attributeValue.emplace(status_value_pair.second.value());
+        }
+
+        response.getVariableResult.push_back(get_variable_result);
+    }
+
+    ocpp::CallResult<GetVariablesResponse> call_result(response, call.uniqueId);
+    this->send<GetVariablesResponse>(call_result);
+}
+
+void ChargePoint::handle_get_base_report_req(Call<GetBaseReportRequest> call) {
+    const auto msg = call.msg;
+
+    // TODO(piet): B07.FR.02
+    // TODO(piet): B07.FR.13
+
+    GetBaseReportResponse response;
+    response.status = GenericDeviceModelStatusEnum::Accepted;
+
+    ocpp::CallResult<GetBaseReportResponse> call_result(response, call.uniqueId);
+    this->send<GetBaseReportResponse>(call_result);
+
+    // TODO(piet): Propably split this up into several NotifyReport.req depending on ItemsPerMessage / BytesPerMessage
+    const auto report_data = this->device_model_manager->get_report_data(msg.reportBase);
+    this->notify_report_req(msg.requestId, 0, report_data);
+}
+
+void ChargePoint::handle_get_report_req(Call<GetReportRequest> call) {
+    const auto msg = call.msg;
+
+    GetReportResponse response;
+
+    // TODO(piet): Propably split this up into several NotifyReport.req depending on ItemsPerMessage / BytesPerMessage
+    const auto report_data = this->device_model_manager->get_report_data(ReportBaseEnum::FullInventory,
+                                                                         msg.componentVariable, msg.componentCriteria);
+    if (report_data.empty()) {
+        response.status = GenericDeviceModelStatusEnum::EmptyResultSet;
+    } else {
+        response.status = GenericDeviceModelStatusEnum::Accepted;
+    }
+
+    ocpp::CallResult<GetReportResponse> call_result(response, call.uniqueId);
+    this->send<GetReportResponse>(call_result);
+
+    if (response.status == GenericDeviceModelStatusEnum::Accepted) {
+        this->notify_report_req(msg.requestId, 0, report_data);
+    }
 }
 
 } // namespace v201

--- a/lib/ocpp/v201/connector.cpp
+++ b/lib/ocpp/v201/connector.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include <utility>
+
+#include <everest/logging.hpp>
+#include <ocpp/v201/connector.hpp>
+
+namespace ocpp {
+namespace v201 {
+
+Connector::Connector(const int32_t connector_id,
+                     const std::function<void(const ConnectorStatusEnum& status)>& status_notification_callback) :
+    connector_id(connector_id),
+    state(ConnectorStatusEnum::Available),
+    status_notification_callback(status_notification_callback) {
+}
+
+ConnectorStatusEnum Connector::get_state() {
+    std::lock_guard<std::mutex> lg(this->state_mutex);
+    return this->state;
+}
+
+void Connector::submit_event(ConnectorEvent event) {
+
+    //FIXME(piet): This state machine implementation is a first draft
+    const auto current_state = this->get_state();
+    std::lock_guard<std::mutex> lg(this->state_mutex);
+
+    switch (current_state) {
+    case ConnectorStatusEnum::Available:
+        switch (event) {
+        case ConnectorEvent::PlugIn:
+            this->state = ConnectorStatusEnum::Occupied;
+            break;
+        case ConnectorEvent::Reserve:
+            this->state = ConnectorStatusEnum::Reserved;
+            break;
+        case ConnectorEvent::Error:
+            this->state = ConnectorStatusEnum::Faulted;
+            break;
+        case ConnectorEvent::Unavailable:
+            this->state = ConnectorStatusEnum::Unavailable;
+            break;
+        default:
+            EVLOG_warning << "Invalid connector event in state Available.";
+            return;
+        }
+        break;
+    case ConnectorStatusEnum::Occupied:
+        switch (event) {
+        case ConnectorEvent::PlugOut:
+            this->state = ConnectorStatusEnum::Available;
+            break;
+        case ConnectorEvent::Error:
+            this->state = ConnectorStatusEnum::Faulted;
+            break;
+        case ConnectorEvent::Unavailable:
+            this->state = ConnectorStatusEnum::Unavailable;
+            break;
+        default:
+            EVLOG_warning << "Invalid connector event in state Occupied.";
+            return;
+        }
+        break;
+    case ConnectorStatusEnum::Reserved:
+        switch (event) {
+        case ConnectorEvent::ReservationFinished:
+            this->state = ConnectorStatusEnum::Available;
+            break;
+        case ConnectorEvent::PlugInAndTokenValid:
+            this->state = ConnectorStatusEnum::Occupied;
+            break;
+        case ConnectorEvent::Error:
+            this->state = ConnectorStatusEnum::Faulted;
+            break;
+        case ConnectorEvent::Unavailable:
+            this->state = ConnectorStatusEnum::Unavailable;
+            break;
+        default:
+            EVLOG_warning << "Invalid connector event in state Reserved.";
+            return;
+        }
+        break;
+    case ConnectorStatusEnum::Unavailable:
+        switch (event) {
+        case ConnectorEvent::UnavailableToAvailable:
+            this->state = ConnectorStatusEnum::Available;
+            break;
+        case ConnectorEvent::UnavailableToOccupied:
+            this->state = ConnectorStatusEnum::Occupied;
+            break;
+        case ConnectorEvent::UnavailableToReserved:
+            this->state = ConnectorStatusEnum::Reserved;
+            break;
+        case ConnectorEvent::UnavailableFaulted:
+            this->state = ConnectorStatusEnum::Faulted;
+            break;
+        default:
+            EVLOG_warning << "Invalid connector event in state Unavailable.";
+            return;
+        }
+        break;
+    case ConnectorStatusEnum::Faulted:
+        switch (event) {
+        case ConnectorEvent::ErrorCleared:
+            this->state = ConnectorStatusEnum::Available;
+            break;
+        case ConnectorEvent::ErrorCleardOnOccupied:
+            this->state = ConnectorStatusEnum::Occupied;
+            break;
+        case ConnectorEvent::ErrorCleardOnReserved:
+            this->state = ConnectorStatusEnum::Reserved;
+            break;
+        case ConnectorEvent::Unavailable:
+            this->state = ConnectorStatusEnum::Unavailable;
+            break;
+        default:
+            EVLOG_warning << "Invalid connector event in state Faulted.";
+            return;
+        }
+        break;
+    }
+    this->status_notification_callback(this->state);
+}
+
+} // namespace v201
+} // namespace ocpp

--- a/lib/ocpp/v201/device_model_management.cpp
+++ b/lib/ocpp/v201/device_model_management.cpp
@@ -3,7 +3,7 @@
 #include <fstream>
 
 #include <ocpp/common/schemas.hpp>
-#include <ocpp/v201/charge_point_configuration.hpp>
+#include <ocpp/v201/device_model_management.hpp>
 
 namespace ocpp {
 namespace v201 {
@@ -173,8 +173,7 @@ std::ostream& operator<<(std::ostream& os, const StandardizedComponent& standard
     return os;
 }
 
-ChargePointConfiguration::ChargePointConfiguration(const json& config, const std::string& ocpp_main_path,
-                                                   std::shared_ptr<ocpp::PkiHandler> pki_handler) {
+DeviceModelManager::DeviceModelManager(const json& config, const std::string& ocpp_main_path) {
     auto json_config = config;
 
     // validate config entries
@@ -183,7 +182,7 @@ ChargePointConfiguration::ChargePointConfiguration(const json& config, const std
         const auto patch = schemas.get_validator()->validate(json_config);
         if (!patch.is_null()) {
             // extend config with default values
-            EVLOG_debug << "Adding the following default values to the charge point configuration: " << patch;
+            EVLOG_debug << "Adding the following default values to the charge point device_tree_manager: " << patch;
             json_config = json_config.patch(patch);
         }
     } catch (const std::exception& e) {
@@ -191,10 +190,10 @@ ChargePointConfiguration::ChargePointConfiguration(const json& config, const std
     }
 
     std::set<boost::filesystem::path> available_schemas_paths;
-    const auto profile_schemas_path = boost::filesystem::path(ocpp_main_path) / "profile_schemas";
+    const auto component_schemas_path = boost::filesystem::path(ocpp_main_path) / "component_schemas";
 
     // iterating over schemas to initialize standardized components and variables
-    for (auto file : boost::filesystem::directory_iterator(profile_schemas_path)) {
+    for (auto file : boost::filesystem::directory_iterator(component_schemas_path)) {
         if (file.path().filename() != "Config.json") {
 
             auto component_name = file.path().filename().replace_extension("").string();
@@ -254,183 +253,337 @@ ChargePointConfiguration::ChargePointConfiguration(const json& config, const std
     }
 }
 
-std::string ChargePointConfiguration::get_charge_point_id() {
+SetVariableStatusEnum DeviceModelManager::set_variable(const SetVariableData& set_variable_data) {
+    // FIXME(piet): Consider RebootRequired, etc. ; propably needs to be reworked in general
+    try {
+        const auto standardized_component =
+            conversions::string_to_standardized_component(set_variable_data.component.name.get());
+        if (this->components.find(standardized_component) == this->components.end()) {
+            return SetVariableStatusEnum::UnknownComponent;
+        } else {
+            auto component = this->components.at(standardized_component);
+            if (component.variables.find(set_variable_data.variable.name.get()) == component.variables.end()) {
+                return SetVariableStatusEnum::UnknownVariable;
+            } else {
+                auto variable = component.variables.at(set_variable_data.variable.name.get());
+                if (variable.attributes.find(set_variable_data.attributeType.get_value_or(AttributeEnum::Actual)) ==
+                    variable.attributes.end()) {
+                    return SetVariableStatusEnum::NotSupportedAttributeType;
+                } else {
+                    // FIXME(piet): Setting this value for the component does not mean that it is set within the module
+                    // configuration (e.g. AuthCtrlr / Auth Module)
+
+                    // FIXME(piet): add handling for B05.FR.07
+                    // FIXME(piet): add handling for B05.FR.08
+                    // FIXME(piet): add handling for B05.FR.09
+                    // FIXME(piet): add handling for B05.FR.11
+                    this->components.at(standardized_component)
+                        .variables.at(set_variable_data.variable.name.get())
+                        .attributes.at(set_variable_data.attributeType.get_value_or(AttributeEnum::Actual))
+                        .value.emplace(set_variable_data.attributeValue.get());
+                    return SetVariableStatusEnum::Accepted;
+                }
+            }
+        }
+    } catch (const std::exception& e) {
+        return SetVariableStatusEnum::UnknownComponent;
+    }
+}
+
+std::pair<GetVariableStatusEnum, boost::optional<CiString<2500>>>
+DeviceModelManager::get_variable(const GetVariableData& get_variable_data) {
+
+    std::pair<GetVariableStatusEnum, boost::optional<CiString<2500>>> status_value_pair;
+
+    try {
+        const auto standardized_component =
+            conversions::string_to_standardized_component(get_variable_data.component.name.get());
+        if (this->components.find(standardized_component) == this->components.end()) {
+            // this is executed when the component is part of the StandardizedComponents enum, but was not configured in
+            // the config file
+            status_value_pair.first = GetVariableStatusEnum::UnknownComponent;
+            return status_value_pair;
+        } else {
+            auto component = this->components.at(standardized_component);
+            if (component.variables.find(get_variable_data.variable.name.get()) == component.variables.end()) {
+                status_value_pair.first = GetVariableStatusEnum::UnknownVariable;
+                return status_value_pair;
+            } else {
+                auto variable = component.variables.at(get_variable_data.variable.name.get());
+                if (variable.attributes.find(get_variable_data.attributeType.get_value_or(AttributeEnum::Actual)) ==
+                    variable.attributes.end()) {
+                    status_value_pair.first = GetVariableStatusEnum::NotSupportedAttributeType;
+                    return status_value_pair;
+                } else {
+                    // FIXME(piet): add handling for B06.FR.09
+                    // FIXME(piet): add handling for B06.FR.14
+                    // FIXME(piet): add handling for B06.FR.15
+
+                    status_value_pair.second.emplace(
+                        this->components.at(standardized_component)
+                            .variables.at(get_variable_data.variable.name.get())
+                            .attributes.at(get_variable_data.attributeType.get_value_or(AttributeEnum::Actual))
+                            .value.get_value_or("")); // B06.FR.13
+                    status_value_pair.first = GetVariableStatusEnum::Accepted;
+                    return status_value_pair;
+                }
+            }
+        }
+    } catch (const std::out_of_range& ex) {
+        // this catches when the requested component is not part of StandardizedComponent enum
+        // FIXME(piet): Consider more than just standardized components
+        status_value_pair.first = GetVariableStatusEnum::UnknownComponent;
+        return status_value_pair;
+    }
+}
+
+static bool component_criteria_match(const EnhancedComponent& enhanced_component,
+                                     const std::vector<ComponentCriterionEnum>& component_criteria) {
+    for (const auto& criteria : component_criteria) {
+        const auto variable_name = conversions::component_criterion_enum_to_string(criteria);
+        if (!enhanced_component.variables.count(variable_name) or
+            (enhanced_component.variables.at(variable_name).attributes.at(AttributeEnum::Actual).value.has_value() and
+            ocpp::conversions::string_to_bool(enhanced_component.variables.at(variable_name)
+                                                  .attributes.at(AttributeEnum::Actual)
+                                                  .value.value()
+                                                  .get()))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<ReportData>
+DeviceModelManager::get_report_data(const boost::optional<ReportBaseEnum>& report_base,
+                                    const boost::optional<std::vector<ComponentVariable>>& component_variables,
+                                    const boost::optional<std::vector<ComponentCriterionEnum>>& component_criteria) {
+    std::vector<ReportData> report_data_vec;
+
+    for (const auto& component_entry : this->components) {
+        if (!component_criteria.has_value() or
+            component_criteria_match(component_entry.second, component_criteria.value())) {
+            for (const auto& variable_entry : component_entry.second.variables) {
+                const auto variable = variable_entry.second;
+                if (!component_variables.has_value() or
+                    std::find_if(component_variables.value().begin(), component_variables.value().end(),
+                                 [variable, component_entry](ComponentVariable v) {
+                                     return component_entry.second == v.component and v.variable.has_value() and
+                                            variable == v.variable.value();
+                                 }) != component_variables.value().end()) {
+                    ReportData report_data;
+                    report_data.component = component_entry.second;
+                    report_data.variable = variable;
+                    for (const auto& attribute_entry : variable.attributes) {
+                        const auto attribute = attribute_entry.second;
+                        if (report_base == ReportBaseEnum::FullInventory or
+                            attribute.mutability == MutabilityEnum::ReadWrite or
+                            attribute.mutability == MutabilityEnum::WriteOnly) {
+                            report_data.variableAttribute.push_back(attribute);
+                            if (variable.characteristics.has_value()) {
+                                report_data.variableCharacteristics.emplace(variable.characteristics.value());
+                            }
+                        }
+                    }
+                    if (!report_data.variableAttribute.empty()) {
+                        report_data_vec.push_back(report_data);
+                    }
+                }
+            }
+        }
+    }
+    return report_data_vec;
+}
+
+std::string DeviceModelManager::get_charge_point_id() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargePointId")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_charge_point_id(const std::string& charge_point_id) {
+void DeviceModelManager::set_charge_point_id(const std::string& charge_point_id) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargePointId")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(charge_point_id);
 }
 
-std::string ChargePointConfiguration::get_central_system_uri() {
+std::string DeviceModelManager::get_central_system_uri() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("CentralSystemURI")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_central_system_uri(const std::string& central_system_uri) {
+void DeviceModelManager::set_central_system_uri(const std::string& central_system_uri) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("CentralSystemURI")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(central_system_uri);
 }
 
-std::string ChargePointConfiguration::get_charge_box_serial_number() {
+std::string DeviceModelManager::get_charge_box_serial_number() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargeBoxSerialNumber")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_charge_box_serial_number(const std::string& charge_box_serial_number) {
+void DeviceModelManager::set_charge_box_serial_number(const std::string& charge_box_serial_number) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargeBoxSerialNumber")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(charge_box_serial_number);
 }
 
-std::string ChargePointConfiguration::get_charge_point_model() {
+std::string DeviceModelManager::get_charge_point_model() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargePointModel")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_charge_point_model(const std::string& charge_point_model) {
+void DeviceModelManager::set_charge_point_model(const std::string& charge_point_model) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargePointModel")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(charge_point_model);
 }
 
-std::string ChargePointConfiguration::get_charge_point_vendor() {
+std::string DeviceModelManager::get_charge_point_vendor() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargePointVendor")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_charge_point_vendor(const std::string& charge_point_vendor) {
+void DeviceModelManager::set_charge_point_vendor(const std::string& charge_point_vendor) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("ChargePointVendor")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(charge_point_vendor);
 }
 
-std::string ChargePointConfiguration::get_firmware_version() {
+std::string DeviceModelManager::get_firmware_version() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("FirmwareVersion")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_firmware_version(const std::string& firmware_version) {
+void DeviceModelManager::set_firmware_version(const std::string& firmware_version) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("FirmwareVersion")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(firmware_version);
 }
 
-std::string ChargePointConfiguration::get_supported_ciphers12() {
+std::string DeviceModelManager::get_supported_ciphers12() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("SupportedCiphers12")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_supported_ciphers12(const std::string& supported_ciphers12) {
+void DeviceModelManager::set_supported_ciphers12(const std::string& supported_ciphers12) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("SupportedCiphers12")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(supported_ciphers12);
 }
 
-std::string ChargePointConfiguration::get_supported_ciphers13() {
+std::string DeviceModelManager::get_supported_ciphers13() {
     return this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("SupportedCiphers13")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_supported_ciphers13(const std::string& supported_ciphers13) {
+void DeviceModelManager::set_supported_ciphers13(const std::string& supported_ciphers13) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("SupportedCiphers13")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(supported_ciphers13);
 }
 
-int32_t ChargePointConfiguration::get_websocket_reconnect_interval() {
+int32_t DeviceModelManager::get_websocket_reconnect_interval() {
     return std::stoi(this->components.at(StandardizedComponent::InternalCtrlr)
                          .variables.at("WebsocketReconnectInterval")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_websocket_reconnect_interval(const int32_t& websocket_reconnect_interval) {
+void DeviceModelManager::set_websocket_reconnect_interval(const int32_t& websocket_reconnect_interval) {
     this->components.at(StandardizedComponent::InternalCtrlr)
         .variables.at("WebsocketReconnectInterval")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(websocket_reconnect_interval));
 }
 
-int32_t ChargePointConfiguration::get_interval() {
+int32_t DeviceModelManager::get_number_of_connectors() {
+    return std::stoi(this->components.at(StandardizedComponent::InternalCtrlr)
+                         .variables.at("NumberOfConnectors")
+                         .attributes.at(AttributeEnum::Actual)
+                         .value.value());
+}
+
+void DeviceModelManager::set_number_of_connectors(const int32_t& number_of_connectors) {
+    this->components.at(StandardizedComponent::InternalCtrlr)
+        .variables.at("NumberOfConnectors")
+        .attributes.at(AttributeEnum::Actual)
+        .value.emplace(std::to_string(number_of_connectors));
+}
+
+int32_t DeviceModelManager::get_interval() {
     return std::stoi(this->components.at(StandardizedComponent::AlignedDataCtrlr)
                          .variables.at("Interval")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_interval(const int32_t& interval) {
+void DeviceModelManager::set_interval(const int32_t& interval) {
     this->components.at(StandardizedComponent::AlignedDataCtrlr)
         .variables.at("Interval")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(interval));
 }
 
-std::string ChargePointConfiguration::get_measurands() {
+std::string DeviceModelManager::get_measurands() {
     return this->components.at(StandardizedComponent::AlignedDataCtrlr)
         .variables.at("Measurands")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_measurands(const std::string& measurands) {
+void DeviceModelManager::set_measurands(const std::string& measurands) {
     this->components.at(StandardizedComponent::AlignedDataCtrlr)
         .variables.at("Measurands")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(measurands);
 }
 
-int32_t ChargePointConfiguration::get_aligned_data_ctrlr_tx_ended_interval() {
+int32_t DeviceModelManager::get_aligned_data_ctrlr_tx_ended_interval() {
     return std::stoi(this->components.at(StandardizedComponent::AlignedDataCtrlr)
                          .variables.at("TxEndedInterval")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_aligned_data_ctrlr_tx_ended_interval(
-    const int32_t& aligned_data_ctrlr_tx_ended_interval) {
+void DeviceModelManager::set_aligned_data_ctrlr_tx_ended_interval(const int32_t& aligned_data_ctrlr_tx_ended_interval) {
     this->components.at(StandardizedComponent::AlignedDataCtrlr)
         .variables.at("TxEndedInterval")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(aligned_data_ctrlr_tx_ended_interval));
 }
 
-std::string ChargePointConfiguration::get_aligned_data_ctrlr_tx_ended_measurands() {
+std::string DeviceModelManager::get_aligned_data_ctrlr_tx_ended_measurands() {
     return this->components.at(StandardizedComponent::AlignedDataCtrlr)
         .variables.at("TxEndedMeasurands")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_aligned_data_ctrlr_tx_ended_measurands(
+void DeviceModelManager::set_aligned_data_ctrlr_tx_ended_measurands(
     const std::string& aligned_data_ctrlr_tx_ended_measurands) {
     this->components.at(StandardizedComponent::AlignedDataCtrlr)
         .variables.at("TxEndedMeasurands")
@@ -438,56 +591,56 @@ void ChargePointConfiguration::set_aligned_data_ctrlr_tx_ended_measurands(
         .value.emplace(aligned_data_ctrlr_tx_ended_measurands);
 }
 
-bool ChargePointConfiguration::get_authorize_remote_start() {
+bool DeviceModelManager::get_authorize_remote_start() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::AuthCtrlr)
                                                  .variables.at("AuthorizeRemoteStart")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_authorize_remote_start(const bool& authorize_remote_start) {
+void DeviceModelManager::set_authorize_remote_start(const bool& authorize_remote_start) {
     this->components.at(StandardizedComponent::AuthCtrlr)
         .variables.at("AuthorizeRemoteStart")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(authorize_remote_start));
 }
 
-bool ChargePointConfiguration::get_local_authorize_offline() {
+bool DeviceModelManager::get_local_authorize_offline() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::AuthCtrlr)
                                                  .variables.at("LocalAuthorizeOffline")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_local_authorize_offline(const bool& local_authorize_offline) {
+void DeviceModelManager::set_local_authorize_offline(const bool& local_authorize_offline) {
     this->components.at(StandardizedComponent::AuthCtrlr)
         .variables.at("LocalAuthorizeOffline")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(local_authorize_offline));
 }
 
-bool ChargePointConfiguration::get_local_pre_authorize() {
+bool DeviceModelManager::get_local_pre_authorize() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::AuthCtrlr)
                                                  .variables.at("LocalPreAuthorize")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_local_pre_authorize(const bool& local_pre_authorize) {
+void DeviceModelManager::set_local_pre_authorize(const bool& local_pre_authorize) {
     this->components.at(StandardizedComponent::AuthCtrlr)
         .variables.at("LocalPreAuthorize")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(local_pre_authorize));
 }
 
-std::string ChargePointConfiguration::get_charging_station_availability_state() {
+std::string DeviceModelManager::get_charging_station_availability_state() {
     return this->components.at(StandardizedComponent::ChargingStation)
         .variables.at("AvailabilityState")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_charging_station_availability_state(
+void DeviceModelManager::set_charging_station_availability_state(
     const std::string& charging_station_availability_state) {
     this->components.at(StandardizedComponent::ChargingStation)
         .variables.at("AvailabilityState")
@@ -495,350 +648,350 @@ void ChargePointConfiguration::set_charging_station_availability_state(
         .value.emplace(charging_station_availability_state);
 }
 
-bool ChargePointConfiguration::get_charging_station_available() {
+bool DeviceModelManager::get_charging_station_available() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::ChargingStation)
                                                  .variables.at("Available")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_charging_station_available(const bool& charging_station_available) {
+void DeviceModelManager::set_charging_station_available(const bool& charging_station_available) {
     this->components.at(StandardizedComponent::ChargingStation)
         .variables.at("Available")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(charging_station_available));
 }
 
-int32_t ChargePointConfiguration::get_charging_station_supply_phases() {
+int32_t DeviceModelManager::get_charging_station_supply_phases() {
     return std::stoi(this->components.at(StandardizedComponent::ChargingStation)
                          .variables.at("SupplyPhases")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_charging_station_supply_phases(const int32_t& charging_station_supply_phases) {
+void DeviceModelManager::set_charging_station_supply_phases(const int32_t& charging_station_supply_phases) {
     this->components.at(StandardizedComponent::ChargingStation)
         .variables.at("SupplyPhases")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(charging_station_supply_phases));
 }
 
-ocpp::DateTime ChargePointConfiguration::get_date_time() {
+ocpp::DateTime DeviceModelManager::get_date_time() {
     return ocpp::DateTime(this->components.at(StandardizedComponent::ClockCtrlr)
                               .variables.at("DateTime")
                               .attributes.at(AttributeEnum::Actual)
                               .value.value());
 }
 
-void ChargePointConfiguration::set_date_time(const ocpp::DateTime& date_time) {
+void DeviceModelManager::set_date_time(const ocpp::DateTime& date_time) {
     this->components.at(StandardizedComponent::ClockCtrlr)
         .variables.at("DateTime")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(date_time.to_rfc3339());
 }
 
-std::string ChargePointConfiguration::get_time_source() {
+std::string DeviceModelManager::get_time_source() {
     return this->components.at(StandardizedComponent::ClockCtrlr)
         .variables.at("TimeSource")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_time_source(const std::string& time_source) {
+void DeviceModelManager::set_time_source(const std::string& time_source) {
     this->components.at(StandardizedComponent::ClockCtrlr)
         .variables.at("TimeSource")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(time_source);
 }
 
-bool ChargePointConfiguration::get_connector_available() {
+bool DeviceModelManager::get_connector_available() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::Connector)
                                                  .variables.at("Available")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_connector_available(const bool& connector_available) {
+void DeviceModelManager::set_connector_available(const bool& connector_available) {
     this->components.at(StandardizedComponent::Connector)
         .variables.at("Available")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(connector_available));
 }
 
-std::string ChargePointConfiguration::get_connector_type() {
+std::string DeviceModelManager::get_connector_type() {
     return this->components.at(StandardizedComponent::Connector)
         .variables.at("ConnectorType")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_connector_type(const std::string& connector_type) {
+void DeviceModelManager::set_connector_type(const std::string& connector_type) {
     this->components.at(StandardizedComponent::Connector)
         .variables.at("ConnectorType")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(connector_type);
 }
 
-int32_t ChargePointConfiguration::get_connector_supply_phases() {
+int32_t DeviceModelManager::get_connector_supply_phases() {
     return std::stoi(this->components.at(StandardizedComponent::Connector)
                          .variables.at("SupplyPhases")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_connector_supply_phases(const int32_t& connector_supply_phases) {
+void DeviceModelManager::set_connector_supply_phases(const int32_t& connector_supply_phases) {
     this->components.at(StandardizedComponent::Connector)
         .variables.at("SupplyPhases")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(connector_supply_phases));
 }
 
-int32_t ChargePointConfiguration::get_bytes_per_message_get_report() {
+int32_t DeviceModelManager::get_bytes_per_message_get_report() {
     return std::stoi(this->components.at(StandardizedComponent::DeviceDataCtrlr)
                          .variables.at("BytesPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_bytes_per_message_get_report(const int32_t& bytes_per_message_get_report) {
+void DeviceModelManager::set_bytes_per_message_get_report(const int32_t& bytes_per_message_get_report) {
     this->components.at(StandardizedComponent::DeviceDataCtrlr)
         .variables.at("BytesPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(bytes_per_message_get_report));
 }
 
-int32_t ChargePointConfiguration::get_bytes_per_message_get_variables() {
+int32_t DeviceModelManager::get_bytes_per_message_get_variables() {
     return std::stoi(this->components.at(StandardizedComponent::DeviceDataCtrlr)
                          .variables.at("BytesPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_bytes_per_message_get_variables(const int32_t& bytes_per_message_get_variables) {
+void DeviceModelManager::set_bytes_per_message_get_variables(const int32_t& bytes_per_message_get_variables) {
     this->components.at(StandardizedComponent::DeviceDataCtrlr)
         .variables.at("BytesPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(bytes_per_message_get_variables));
 }
 
-int32_t ChargePointConfiguration::get_bytes_per_message_set_variables() {
+int32_t DeviceModelManager::get_bytes_per_message_set_variables() {
     return std::stoi(this->components.at(StandardizedComponent::DeviceDataCtrlr)
                          .variables.at("BytesPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_bytes_per_message_set_variables(const int32_t& bytes_per_message_set_variables) {
+void DeviceModelManager::set_bytes_per_message_set_variables(const int32_t& bytes_per_message_set_variables) {
     this->components.at(StandardizedComponent::DeviceDataCtrlr)
         .variables.at("BytesPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(bytes_per_message_set_variables));
 }
 
-int32_t ChargePointConfiguration::get_items_per_message_get_report() {
+int32_t DeviceModelManager::get_items_per_message_get_report() {
     return std::stoi(this->components.at(StandardizedComponent::DeviceDataCtrlr)
                          .variables.at("ItemsPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_items_per_message_get_report(const int32_t& items_per_message_get_report) {
+void DeviceModelManager::set_items_per_message_get_report(const int32_t& items_per_message_get_report) {
     this->components.at(StandardizedComponent::DeviceDataCtrlr)
         .variables.at("ItemsPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(items_per_message_get_report));
 }
 
-int32_t ChargePointConfiguration::get_items_per_message_get_variables() {
+int32_t DeviceModelManager::get_items_per_message_get_variables() {
     return std::stoi(this->components.at(StandardizedComponent::DeviceDataCtrlr)
                          .variables.at("ItemsPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_items_per_message_get_variables(const int32_t& items_per_message_get_variables) {
+void DeviceModelManager::set_items_per_message_get_variables(const int32_t& items_per_message_get_variables) {
     this->components.at(StandardizedComponent::DeviceDataCtrlr)
         .variables.at("ItemsPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(items_per_message_get_variables));
 }
 
-int32_t ChargePointConfiguration::get_items_per_message_set_variables() {
+int32_t DeviceModelManager::get_items_per_message_set_variables() {
     return std::stoi(this->components.at(StandardizedComponent::DeviceDataCtrlr)
                          .variables.at("ItemsPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_items_per_message_set_variables(const int32_t& items_per_message_set_variables) {
+void DeviceModelManager::set_items_per_message_set_variables(const int32_t& items_per_message_set_variables) {
     this->components.at(StandardizedComponent::DeviceDataCtrlr)
         .variables.at("ItemsPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(items_per_message_set_variables));
 }
 
-int32_t ChargePointConfiguration::get_display_messages() {
+int32_t DeviceModelManager::get_display_messages() {
     return std::stoi(this->components.at(StandardizedComponent::DisplayMessageCtrlr)
                          .variables.at("DisplayMessages")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_display_messages(const int32_t& display_messages) {
+void DeviceModelManager::set_display_messages(const int32_t& display_messages) {
     this->components.at(StandardizedComponent::DisplayMessageCtrlr)
         .variables.at("DisplayMessages")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(display_messages));
 }
 
-std::string ChargePointConfiguration::get_supported_formats() {
+std::string DeviceModelManager::get_supported_formats() {
     return this->components.at(StandardizedComponent::DisplayMessageCtrlr)
         .variables.at("SupportedFormats")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_supported_formats(const std::string& supported_formats) {
+void DeviceModelManager::set_supported_formats(const std::string& supported_formats) {
     this->components.at(StandardizedComponent::DisplayMessageCtrlr)
         .variables.at("SupportedFormats")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(supported_formats);
 }
 
-std::string ChargePointConfiguration::get_supported_priorities() {
+std::string DeviceModelManager::get_supported_priorities() {
     return this->components.at(StandardizedComponent::DisplayMessageCtrlr)
         .variables.at("SupportedPriorities")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_supported_priorities(const std::string& supported_priorities) {
+void DeviceModelManager::set_supported_priorities(const std::string& supported_priorities) {
     this->components.at(StandardizedComponent::DisplayMessageCtrlr)
         .variables.at("SupportedPriorities")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(supported_priorities);
 }
 
-std::string ChargePointConfiguration::get_evse_availability_state() {
+std::string DeviceModelManager::get_evse_availability_state() {
     return this->components.at(StandardizedComponent::EVSE)
         .variables.at("AvailabilityState")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_evse_availability_state(const std::string& evse_availability_state) {
+void DeviceModelManager::set_evse_availability_state(const std::string& evse_availability_state) {
     this->components.at(StandardizedComponent::EVSE)
         .variables.at("AvailabilityState")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(evse_availability_state);
 }
 
-bool ChargePointConfiguration::get_evse_available() {
+bool DeviceModelManager::get_evse_available() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::EVSE)
                                                  .variables.at("Available")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_evse_available(const bool& evse_available) {
+void DeviceModelManager::set_evse_available(const bool& evse_available) {
     this->components.at(StandardizedComponent::EVSE)
         .variables.at("Available")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(evse_available));
 }
 
-double ChargePointConfiguration::get_power() {
+double DeviceModelManager::get_power() {
     return std::stod(this->components.at(StandardizedComponent::EVSE)
                          .variables.at("Power")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_power(const double& power) {
+void DeviceModelManager::set_power(const double& power) {
     this->components.at(StandardizedComponent::EVSE)
         .variables.at("Power")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::double_to_string(power));
 }
 
-int32_t ChargePointConfiguration::get_evse_supply_phases() {
+int32_t DeviceModelManager::get_evse_supply_phases() {
     return std::stoi(this->components.at(StandardizedComponent::EVSE)
                          .variables.at("SupplyPhases")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_evse_supply_phases(const int32_t& evse_supply_phases) {
+void DeviceModelManager::set_evse_supply_phases(const int32_t& evse_supply_phases) {
     this->components.at(StandardizedComponent::EVSE)
         .variables.at("SupplyPhases")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(evse_supply_phases));
 }
 
-bool ChargePointConfiguration::get_contract_validation_offline() {
+bool DeviceModelManager::get_contract_validation_offline() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::ISO15118Ctrlr)
                                                  .variables.at("ContractValidationOffline")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_contract_validation_offline(const bool& contract_validation_offline) {
+void DeviceModelManager::set_contract_validation_offline(const bool& contract_validation_offline) {
     this->components.at(StandardizedComponent::ISO15118Ctrlr)
         .variables.at("ContractValidationOffline")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(contract_validation_offline));
 }
 
-int32_t ChargePointConfiguration::get_bytes_per_message() {
+int32_t DeviceModelManager::get_bytes_per_message() {
     return std::stoi(this->components.at(StandardizedComponent::LocalAuthListCtrlr)
                          .variables.at("BytesPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_bytes_per_message(const int32_t& bytes_per_message) {
+void DeviceModelManager::set_bytes_per_message(const int32_t& bytes_per_message) {
     this->components.at(StandardizedComponent::LocalAuthListCtrlr)
         .variables.at("BytesPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(bytes_per_message));
 }
 
-int32_t ChargePointConfiguration::get_entries() {
+int32_t DeviceModelManager::get_entries() {
     return std::stoi(this->components.at(StandardizedComponent::LocalAuthListCtrlr)
                          .variables.at("Entries")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_entries(const int32_t& entries) {
+void DeviceModelManager::set_entries(const int32_t& entries) {
     this->components.at(StandardizedComponent::LocalAuthListCtrlr)
         .variables.at("Entries")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(entries));
 }
 
-int32_t ChargePointConfiguration::get_items_per_message() {
+int32_t DeviceModelManager::get_items_per_message() {
     return std::stoi(this->components.at(StandardizedComponent::LocalAuthListCtrlr)
                          .variables.at("ItemsPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_items_per_message(const int32_t& items_per_message) {
+void DeviceModelManager::set_items_per_message(const int32_t& items_per_message) {
     this->components.at(StandardizedComponent::LocalAuthListCtrlr)
         .variables.at("ItemsPerMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(items_per_message));
 }
 
-int32_t ChargePointConfiguration::get_bytes_per_message_set_variable_monitoring() {
+int32_t DeviceModelManager::get_bytes_per_message_set_variable_monitoring() {
     return std::stoi(this->components.at(StandardizedComponent::MonitoringCtrlr)
                          .variables.at("BytesPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_bytes_per_message_set_variable_monitoring(
+void DeviceModelManager::set_bytes_per_message_set_variable_monitoring(
     const int32_t& bytes_per_message_set_variable_monitoring) {
     this->components.at(StandardizedComponent::MonitoringCtrlr)
         .variables.at("BytesPerMessage")
@@ -846,14 +999,14 @@ void ChargePointConfiguration::set_bytes_per_message_set_variable_monitoring(
         .value.emplace(std::to_string(bytes_per_message_set_variable_monitoring));
 }
 
-int32_t ChargePointConfiguration::get_items_per_message_set_variable_monitoring() {
+int32_t DeviceModelManager::get_items_per_message_set_variable_monitoring() {
     return std::stoi(this->components.at(StandardizedComponent::MonitoringCtrlr)
                          .variables.at("ItemsPerMessage")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_items_per_message_set_variable_monitoring(
+void DeviceModelManager::set_items_per_message_set_variable_monitoring(
     const int32_t& items_per_message_set_variable_monitoring) {
     this->components.at(StandardizedComponent::MonitoringCtrlr)
         .variables.at("ItemsPerMessage")
@@ -861,42 +1014,42 @@ void ChargePointConfiguration::set_items_per_message_set_variable_monitoring(
         .value.emplace(std::to_string(items_per_message_set_variable_monitoring));
 }
 
-std::string ChargePointConfiguration::get_file_transfer_protocols() {
+std::string DeviceModelManager::get_file_transfer_protocols() {
     return this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("FileTransferProtocols")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_file_transfer_protocols(const std::string& file_transfer_protocols) {
+void DeviceModelManager::set_file_transfer_protocols(const std::string& file_transfer_protocols) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("FileTransferProtocols")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(file_transfer_protocols);
 }
 
-int32_t ChargePointConfiguration::get_message_timeout_default() {
+int32_t DeviceModelManager::get_message_timeout_default() {
     return std::stoi(this->components.at(StandardizedComponent::OCPPCommCtrlr)
                          .variables.at("MessageTimeout")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_message_timeout_default(const int32_t& message_timeout_default) {
+void DeviceModelManager::set_message_timeout_default(const int32_t& message_timeout_default) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("MessageTimeout")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(message_timeout_default));
 }
 
-int32_t ChargePointConfiguration::get_message_attempt_interval_transaction_event() {
+int32_t DeviceModelManager::get_message_attempt_interval_transaction_event() {
     return std::stoi(this->components.at(StandardizedComponent::OCPPCommCtrlr)
-                         .variables.at("MessageAttemptInterval")
+                         .variables.at("MessageAttemptIntervalTransactionEvent")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_message_attempt_interval_transaction_event(
+void DeviceModelManager::set_message_attempt_interval_transaction_event(
     const int32_t& message_attempt_interval_transaction_event) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("MessageAttemptInterval")
@@ -904,115 +1057,112 @@ void ChargePointConfiguration::set_message_attempt_interval_transaction_event(
         .value.emplace(std::to_string(message_attempt_interval_transaction_event));
 }
 
-int32_t ChargePointConfiguration::get_message_attempts_transaction_event() {
+int32_t DeviceModelManager::get_message_attempts_transaction_event() {
     return std::stoi(this->components.at(StandardizedComponent::OCPPCommCtrlr)
-                         .variables.at("MessageAttempts")
+                         .variables.at("MessageAttemptsTransactionEvent")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_message_attempts_transaction_event(
-    const int32_t& message_attempts_transaction_event) {
+void DeviceModelManager::set_message_attempts_transaction_event(const int32_t& message_attempts_transaction_event) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("MessageAttempts")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(message_attempts_transaction_event));
 }
 
-std::string ChargePointConfiguration::get_network_configuration_priority() {
+std::string DeviceModelManager::get_network_configuration_priority() {
     return this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("NetworkConfigurationPriority")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_network_configuration_priority(const std::string& network_configuration_priority) {
+void DeviceModelManager::set_network_configuration_priority(const std::string& network_configuration_priority) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("NetworkConfigurationPriority")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(network_configuration_priority);
 }
 
-int32_t ChargePointConfiguration::get_network_profile_connection_attempts() {
+int32_t DeviceModelManager::get_network_profile_connection_attempts() {
     return std::stoi(this->components.at(StandardizedComponent::OCPPCommCtrlr)
                          .variables.at("NetworkProfileConnectionAttempts")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_network_profile_connection_attempts(
-    const int32_t& network_profile_connection_attempts) {
+void DeviceModelManager::set_network_profile_connection_attempts(const int32_t& network_profile_connection_attempts) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("NetworkProfileConnectionAttempts")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(network_profile_connection_attempts));
 }
 
-int32_t ChargePointConfiguration::get_offline_threshold() {
+int32_t DeviceModelManager::get_offline_threshold() {
     return std::stoi(this->components.at(StandardizedComponent::OCPPCommCtrlr)
                          .variables.at("OfflineThreshold")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_offline_threshold(const int32_t& offline_threshold) {
+void DeviceModelManager::set_offline_threshold(const int32_t& offline_threshold) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("OfflineThreshold")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(offline_threshold));
 }
 
-int32_t ChargePointConfiguration::get_reset_retries() {
+int32_t DeviceModelManager::get_reset_retries() {
     return std::stoi(this->components.at(StandardizedComponent::OCPPCommCtrlr)
                          .variables.at("ResetRetries")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_reset_retries(const int32_t& reset_retries) {
+void DeviceModelManager::set_reset_retries(const int32_t& reset_retries) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("ResetRetries")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(reset_retries));
 }
 
-bool ChargePointConfiguration::get_unlock_on_evside_disconnect() {
+bool DeviceModelManager::get_unlock_on_evside_disconnect() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::OCPPCommCtrlr)
                                                  .variables.at("UnlockOnEVSideDisconnect")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_unlock_on_evside_disconnect(const bool& unlock_on_evside_disconnect) {
+void DeviceModelManager::set_unlock_on_evside_disconnect(const bool& unlock_on_evside_disconnect) {
     this->components.at(StandardizedComponent::OCPPCommCtrlr)
         .variables.at("UnlockOnEVSideDisconnect")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(unlock_on_evside_disconnect));
 }
 
-int32_t ChargePointConfiguration::get_sampled_data_ctrlr_tx_ended_interval() {
+int32_t DeviceModelManager::get_sampled_data_ctrlr_tx_ended_interval() {
     return std::stoi(this->components.at(StandardizedComponent::SampledDataCtrlr)
                          .variables.at("TxEndedInterval")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_sampled_data_ctrlr_tx_ended_interval(
-    const int32_t& sampled_data_ctrlr_tx_ended_interval) {
+void DeviceModelManager::set_sampled_data_ctrlr_tx_ended_interval(const int32_t& sampled_data_ctrlr_tx_ended_interval) {
     this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxEndedInterval")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(sampled_data_ctrlr_tx_ended_interval));
 }
 
-std::string ChargePointConfiguration::get_sampled_data_ctrlr_tx_ended_measurands() {
+std::string DeviceModelManager::get_sampled_data_ctrlr_tx_ended_measurands() {
     return this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxEndedMeasurands")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_sampled_data_ctrlr_tx_ended_measurands(
+void DeviceModelManager::set_sampled_data_ctrlr_tx_ended_measurands(
     const std::string& sampled_data_ctrlr_tx_ended_measurands) {
     this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxEndedMeasurands")
@@ -1020,267 +1170,266 @@ void ChargePointConfiguration::set_sampled_data_ctrlr_tx_ended_measurands(
         .value.emplace(sampled_data_ctrlr_tx_ended_measurands);
 }
 
-std::string ChargePointConfiguration::get_tx_started_measurands() {
+std::string DeviceModelManager::get_tx_started_measurands() {
     return this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxStartedMeasurands")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_tx_started_measurands(const std::string& tx_started_measurands) {
+void DeviceModelManager::set_tx_started_measurands(const std::string& tx_started_measurands) {
     this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxStartedMeasurands")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(tx_started_measurands);
 }
 
-int32_t ChargePointConfiguration::get_tx_updated_interval() {
+int32_t DeviceModelManager::get_tx_updated_interval() {
     return std::stoi(this->components.at(StandardizedComponent::SampledDataCtrlr)
                          .variables.at("TxUpdatedInterval")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_tx_updated_interval(const int32_t& tx_updated_interval) {
+void DeviceModelManager::set_tx_updated_interval(const int32_t& tx_updated_interval) {
     this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxUpdatedInterval")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(tx_updated_interval));
 }
 
-std::string ChargePointConfiguration::get_tx_updated_measurands() {
+std::string DeviceModelManager::get_tx_updated_measurands() {
     return this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxUpdatedMeasurands")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_tx_updated_measurands(const std::string& tx_updated_measurands) {
+void DeviceModelManager::set_tx_updated_measurands(const std::string& tx_updated_measurands) {
     this->components.at(StandardizedComponent::SampledDataCtrlr)
         .variables.at("TxUpdatedMeasurands")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(tx_updated_measurands);
 }
 
-int32_t ChargePointConfiguration::get_certificate_entries() {
+int32_t DeviceModelManager::get_certificate_entries() {
     return std::stoi(this->components.at(StandardizedComponent::SecurityCtrlr)
                          .variables.at("CertificateEntries")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_certificate_entries(const int32_t& certificate_entries) {
+void DeviceModelManager::set_certificate_entries(const int32_t& certificate_entries) {
     this->components.at(StandardizedComponent::SecurityCtrlr)
         .variables.at("CertificateEntries")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(certificate_entries));
 }
 
-std::string ChargePointConfiguration::get_security_ctrlr_organization_name() {
+std::string DeviceModelManager::get_security_ctrlr_organization_name() {
     return this->components.at(StandardizedComponent::SecurityCtrlr)
         .variables.at("OrganizationName")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_security_ctrlr_organization_name(
-    const std::string& security_ctrlr_organization_name) {
+void DeviceModelManager::set_security_ctrlr_organization_name(const std::string& security_ctrlr_organization_name) {
     this->components.at(StandardizedComponent::SecurityCtrlr)
         .variables.at("OrganizationName")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(security_ctrlr_organization_name);
 }
 
-int32_t ChargePointConfiguration::get_security_profile() {
+int32_t DeviceModelManager::get_security_profile() {
     return std::stoi(this->components.at(StandardizedComponent::SecurityCtrlr)
                          .variables.at("SecurityProfile")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_security_profile(const int32_t& security_profile) {
+void DeviceModelManager::set_security_profile(const int32_t& security_profile) {
     this->components.at(StandardizedComponent::SecurityCtrlr)
         .variables.at("SecurityProfile")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(security_profile));
 }
 
-int32_t ChargePointConfiguration::get_entries_charging_profiles() {
+int32_t DeviceModelManager::get_entries_charging_profiles() {
     return std::stoi(this->components.at(StandardizedComponent::SmartChargingCtrlr)
                          .variables.at("Entries")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_entries_charging_profiles(const int32_t& entries_charging_profiles) {
+void DeviceModelManager::set_entries_charging_profiles(const int32_t& entries_charging_profiles) {
     this->components.at(StandardizedComponent::SmartChargingCtrlr)
         .variables.at("Entries")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(entries_charging_profiles));
 }
 
-double ChargePointConfiguration::get_limit_change_significance() {
+double DeviceModelManager::get_limit_change_significance() {
     return std::stod(this->components.at(StandardizedComponent::SmartChargingCtrlr)
                          .variables.at("LimitChangeSignificance")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_limit_change_significance(const double& limit_change_significance) {
+void DeviceModelManager::set_limit_change_significance(const double& limit_change_significance) {
     this->components.at(StandardizedComponent::SmartChargingCtrlr)
         .variables.at("LimitChangeSignificance")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::double_to_string(limit_change_significance));
 }
 
-int32_t ChargePointConfiguration::get_periods_per_schedule() {
+int32_t DeviceModelManager::get_periods_per_schedule() {
     return std::stoi(this->components.at(StandardizedComponent::SmartChargingCtrlr)
                          .variables.at("PeriodsPerSchedule")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_periods_per_schedule(const int32_t& periods_per_schedule) {
+void DeviceModelManager::set_periods_per_schedule(const int32_t& periods_per_schedule) {
     this->components.at(StandardizedComponent::SmartChargingCtrlr)
         .variables.at("PeriodsPerSchedule")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(periods_per_schedule));
 }
 
-int32_t ChargePointConfiguration::get_profile_stack_level() {
+int32_t DeviceModelManager::get_profile_stack_level() {
     return std::stoi(this->components.at(StandardizedComponent::SmartChargingCtrlr)
                          .variables.at("ProfileStackLevel")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_profile_stack_level(const int32_t& profile_stack_level) {
+void DeviceModelManager::set_profile_stack_level(const int32_t& profile_stack_level) {
     this->components.at(StandardizedComponent::SmartChargingCtrlr)
         .variables.at("ProfileStackLevel")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(profile_stack_level));
 }
 
-std::string ChargePointConfiguration::get_rate_unit() {
+std::string DeviceModelManager::get_rate_unit() {
     return this->components.at(StandardizedComponent::SmartChargingCtrlr)
         .variables.at("RateUnit")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_rate_unit(const std::string& rate_unit) {
+void DeviceModelManager::set_rate_unit(const std::string& rate_unit) {
     this->components.at(StandardizedComponent::SmartChargingCtrlr)
         .variables.at("RateUnit")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(rate_unit);
 }
 
-std::string ChargePointConfiguration::get_currency() {
+std::string DeviceModelManager::get_currency() {
     return this->components.at(StandardizedComponent::TariffCostCtrlr)
         .variables.at("Currency")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_currency(const std::string& currency) {
+void DeviceModelManager::set_currency(const std::string& currency) {
     this->components.at(StandardizedComponent::TariffCostCtrlr)
         .variables.at("Currency")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(currency);
 }
 
-std::string ChargePointConfiguration::get_tariff_fallback_message() {
+std::string DeviceModelManager::get_tariff_fallback_message() {
     return this->components.at(StandardizedComponent::TariffCostCtrlr)
         .variables.at("TariffFallbackMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_tariff_fallback_message(const std::string& tariff_fallback_message) {
+void DeviceModelManager::set_tariff_fallback_message(const std::string& tariff_fallback_message) {
     this->components.at(StandardizedComponent::TariffCostCtrlr)
         .variables.at("TariffFallbackMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(tariff_fallback_message);
 }
 
-std::string ChargePointConfiguration::get_total_cost_fallback_message() {
+std::string DeviceModelManager::get_total_cost_fallback_message() {
     return this->components.at(StandardizedComponent::TariffCostCtrlr)
         .variables.at("TotalCostFallbackMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_total_cost_fallback_message(const std::string& total_cost_fallback_message) {
+void DeviceModelManager::set_total_cost_fallback_message(const std::string& total_cost_fallback_message) {
     this->components.at(StandardizedComponent::TariffCostCtrlr)
         .variables.at("TotalCostFallbackMessage")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(total_cost_fallback_message);
 }
 
-int32_t ChargePointConfiguration::get_evconnection_time_out() {
+int32_t DeviceModelManager::get_evconnection_time_out() {
     return std::stoi(this->components.at(StandardizedComponent::TxCtrlr)
                          .variables.at("EVConnectionTimeOut")
                          .attributes.at(AttributeEnum::Actual)
                          .value.value());
 }
 
-void ChargePointConfiguration::set_evconnection_time_out(const int32_t& evconnection_time_out) {
+void DeviceModelManager::set_evconnection_time_out(const int32_t& evconnection_time_out) {
     this->components.at(StandardizedComponent::TxCtrlr)
         .variables.at("EVConnectionTimeOut")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(std::to_string(evconnection_time_out));
 }
 
-bool ChargePointConfiguration::get_stop_tx_on_evside_disconnect() {
+bool DeviceModelManager::get_stop_tx_on_evside_disconnect() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::TxCtrlr)
                                                  .variables.at("StopTxOnEVSideDisconnect")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_stop_tx_on_evside_disconnect(const bool& stop_tx_on_evside_disconnect) {
+void DeviceModelManager::set_stop_tx_on_evside_disconnect(const bool& stop_tx_on_evside_disconnect) {
     this->components.at(StandardizedComponent::TxCtrlr)
         .variables.at("StopTxOnEVSideDisconnect")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(stop_tx_on_evside_disconnect));
 }
 
-bool ChargePointConfiguration::get_stop_tx_on_invalid_id() {
+bool DeviceModelManager::get_stop_tx_on_invalid_id() {
     return ocpp::conversions::string_to_bool(this->components.at(StandardizedComponent::TxCtrlr)
                                                  .variables.at("StopTxOnInvalidId")
                                                  .attributes.at(AttributeEnum::Actual)
                                                  .value.value());
 }
 
-void ChargePointConfiguration::set_stop_tx_on_invalid_id(const bool& stop_tx_on_invalid_id) {
+void DeviceModelManager::set_stop_tx_on_invalid_id(const bool& stop_tx_on_invalid_id) {
     this->components.at(StandardizedComponent::TxCtrlr)
         .variables.at("StopTxOnInvalidId")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(ocpp::conversions::bool_to_string(stop_tx_on_invalid_id));
 }
 
-std::string ChargePointConfiguration::get_tx_start_point() {
+std::string DeviceModelManager::get_tx_start_point() {
     return this->components.at(StandardizedComponent::TxCtrlr)
         .variables.at("TxStartPoint")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_tx_start_point(const std::string& tx_start_point) {
+void DeviceModelManager::set_tx_start_point(const std::string& tx_start_point) {
     this->components.at(StandardizedComponent::TxCtrlr)
         .variables.at("TxStartPoint")
         .attributes.at(AttributeEnum::Actual)
         .value.emplace(tx_start_point);
 }
 
-std::string ChargePointConfiguration::get_tx_stop_point() {
+std::string DeviceModelManager::get_tx_stop_point() {
     return this->components.at(StandardizedComponent::TxCtrlr)
         .variables.at("TxStopPoint")
         .attributes.at(AttributeEnum::Actual)
         .value.value();
 }
 
-void ChargePointConfiguration::set_tx_stop_point(const std::string& tx_stop_point) {
+void DeviceModelManager::set_tx_stop_point(const std::string& tx_stop_point) {
     this->components.at(StandardizedComponent::TxCtrlr)
         .variables.at("TxStopPoint")
         .attributes.at(AttributeEnum::Actual)

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include <utility>
+
+#include <ocpp/v201/evse.hpp>
+
+namespace ocpp {
+namespace v201 {
+
+Evse::Evse(const int32_t evse_id, const int32_t number_of_connectors,
+           const std::function<void(const int32_t connector_id, const ConnectorStatusEnum& status)>&
+               status_notification_callback) :
+    evse_id(evse_id), status_notification_callback(status_notification_callback) {
+    for (int connector_id = 1; connector_id <= number_of_connectors; connector_id++) {
+        this->id_connector_map.insert(std::make_pair(
+            connector_id,
+            std::make_unique<Connector>(connector_id, [this, connector_id](const ConnectorStatusEnum& status) {
+                this->status_notification_callback(connector_id, status);
+            })));
+    }
+}
+
+ConnectorStatusEnum Evse::get_state(const int32_t connector_id) {
+    return this->id_connector_map.at(connector_id)->get_state();
+}
+
+void Evse::submit_event(const int32_t connector_id, ConnectorEvent event) {
+    return this->id_connector_map.at(connector_id)->submit_event(event);
+}
+
+void Evse::trigger_status_notification_callbacks() {
+    for (auto const& [connector_id, connector] : this->id_connector_map) {
+        this->status_notification_callback(connector_id, connector->get_state());
+    }
+}
+
+} // namespace v201
+} // namespace ocpp

--- a/lib/ocpp/v201/messages/GetReport.cpp
+++ b/lib/ocpp/v201/messages/GetReport.cpp
@@ -36,7 +36,8 @@ void to_json(json& j, const GetReportRequest& k) {
     if (k.componentCriteria) {
         j["componentCriteria"] = json::array();
         for (auto val : k.componentCriteria.value()) {
-            j["componentCriteria"].push_back(val);
+            //FIXME(piet): Fix this in code generator
+            j["componentCriteria"].push_back(conversions::component_criterion_enum_to_string(val));
         }
     }
 }
@@ -61,7 +62,8 @@ void from_json(const json& j, GetReportRequest& k) {
         json arr = j.at("componentCriteria");
         std::vector<ComponentCriterionEnum> vec;
         for (auto val : arr) {
-            vec.push_back(val);
+            //FIXME(piet): Fix this in code generator
+            vec.push_back(conversions::string_to_component_criterion_enum(val));
         }
         k.componentCriteria.emplace(vec);
     }

--- a/lib/ocpp/v201/types.cpp
+++ b/lib/ocpp/v201/types.cpp
@@ -543,5 +543,36 @@ std::ostream& operator<<(std::ostream& os, const MessageType& message_type) {
     return os;
 }
 
+namespace conversions {
+
+std::string websocket_connection_status_to_string(WebsocketConnectionStatusEnum m) {
+    switch (m) {
+    case WebsocketConnectionStatusEnum::Connected:
+        return "Connected";
+    case WebsocketConnectionStatusEnum::Disconnected:
+        return "Disconnected";
+    default:
+        throw std::out_of_range("No known string conversion for provided enum of type MessageType");
+    }
+}
+
+/// \brief Converts the given std::string \p s to WebsocketConnectionStatusEnum
+/// \returns a WebsocketConnectionStatusEnum from a string representation
+WebsocketConnectionStatusEnum string_to_websocket_connection_status(const std::string& s) {
+    if (s == "Connected") {
+        return WebsocketConnectionStatusEnum::Connected;
+    } else if (s == "Disconnected") {
+        return WebsocketConnectionStatusEnum::Disconnected;
+    }
+    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type WebsocketConnectionStatusEnum");
+}
+
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const WebsocketConnectionStatusEnum& websocket_connection_status) {
+    os << conversions::websocket_connection_status_to_string(websocket_connection_status);
+    return os;
+}
+
 } // namespace v201
 } // namespace ocpp


### PR DESCRIPTION
- moved ChargePointConnectionState back to 1.6
- improved ws connection and bootnotification handling
- implemented functional block Provisioning profile as draft (B01 - B08)
- renamed common ChargePoint to ChargingStationBase
- renamed ChargePointConfiguration to DeviceModelManager for OCPP2.0.1
- added method documentation
- implemented draft for state machine within connector class instead of using libfsm

Signed-off-by: pietfried <piet.goempel@pionix.de>