### PR TITLE
Session Logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.5
+    VERSION 0.5.1
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/config/v16/config-docker.json
+++ b/config/v16/config-docker.json
@@ -5,8 +5,7 @@
         "ChargeBoxSerialNumber": "cp001",
         "ChargePointModel": "Yeti",
         "ChargePointVendor": "Pionix",
-        "FirmwareVersion": "0.1",
-        "LogMessagesFormat": ["log", "html"]
+        "FirmwareVersion": "0.1"
     },
     "Core": {
         "AuthorizeRemoteTxRequests": false,

--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -121,7 +121,7 @@
             "default": true
         },
         "LogMessagesFormat": {
-            "$comment": "Supported log formats are console, log, html and console_detailed",
+            "$comment": "Supported log formats are console, log, html, console_detailed and session_logging",
             "type": "array",
             "items": {
                 "type": "string"
@@ -129,7 +129,8 @@
             "readOnly": true,
             "default": [
                 "log",
-                "html"
+                "html",
+                "session_logging"
             ]
         },
         "SupportedChargingProfilePurposeTypes": {

--- a/include/ocpp/common/ocpp_logging.hpp
+++ b/include/ocpp/common/ocpp_logging.hpp
@@ -24,12 +24,16 @@ private:
     std::ofstream output_file;
     std::ofstream html_log_file;
     std::mutex output_file_mutex;
+    std::string message_log_path;
+    std::string output_file_name;
     bool log_messages;
     bool log_to_console;
     bool detailed_log_to_console;
     bool log_to_file;
     bool log_to_html;
+    bool session_logging;
     std::map<std::string, std::string> lookup_map;
+    std::map<std::string, std::shared_ptr<MessageLogging>> session_id_logging;
 
     void log_output(unsigned int typ, const std::string& message_type, const std::string& json_str);
     std::string html_encode(const std::string& msg);
@@ -37,13 +41,18 @@ private:
 
 public:
     /// \brief Creates a new Websocket object with the providede \p configuration
-    explicit MessageLogging(bool log_messages, const std::string& message_log_path, bool log_to_console,
-                            bool detailed_log_to_console, bool log_to_file, bool log_to_html);
+    explicit MessageLogging(bool log_messages, const std::string& message_log_path, const std::string& output_file_name,
+                            bool log_to_console, bool detailed_log_to_console, bool log_to_file, bool log_to_html,
+                            bool session_logging);
     ~MessageLogging();
 
     void charge_point(const std::string& message_type, const std::string& json_str);
     void central_system(const std::string& message_type, const std::string& json_str);
     void sys(const std::string& msg);
+    void start_session_logging(const std::string& session_id, const std::string& log_path);
+    void stop_session_logging(const std::string& session_id);
+    std::string get_message_log_path();
+    bool session_logging_active();
 };
 
 } // namespace ocpp

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -295,12 +295,14 @@ public:
     void on_max_current_offered(int32_t connector, int32_t max_current);
 
     /// \brief Notifies chargepoint that a new session with the given \p session_id has been started at the given \p
-    /// connector with the given \p reason
-    void on_session_started(int32_t connector, const std::string& session_id, const std::string& reason);
+    /// connector with the given \p reason . The logs of the session will be written into \p session_logging_path if
+    /// present
+    void on_session_started(int32_t connector, const std::string& session_id, const std::string& reason,
+                            const boost::optional<std::string> &session_logging_path);
 
     /// \brief Notifies chargepoint that a session has been stopped at the given \p
     /// connector
-    void on_session_stopped(int32_t connector);
+    void on_session_stopped(int32_t connector, const std::string& session_id);
 
     /// \brief Notifies chargepoint that a transaction at the given \p connector with the given parameters has been
     /// started

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -44,10 +44,12 @@ ChargePoint::ChargePoint(const json& config, const std::string& share_path, cons
         std::find(log_formats.begin(), log_formats.end(), "console_detailed") != log_formats.end();
     bool log_to_file = std::find(log_formats.begin(), log_formats.end(), "log") != log_formats.end();
     bool log_to_html = std::find(log_formats.begin(), log_formats.end(), "html") != log_formats.end();
+    bool session_logging = std::find(log_formats.begin(), log_formats.end(), "session_logging") != log_formats.end();
 
-    this->logging =
-        std::make_shared<ocpp::MessageLogging>(this->configuration->getLogMessages(), message_log_path, log_to_console,
-                                               detailed_log_to_console, log_to_file, log_to_html);
+    this->logging = std::make_shared<ocpp::MessageLogging>(this->configuration->getLogMessages(), message_log_path,
+                                                           DateTime().to_rfc3339(), log_to_console,
+                                                           detailed_log_to_console, log_to_file, log_to_html,
+                                                           session_logging);
 
     this->boot_notification_timer =
         std::make_unique<Everest::SteadyTimer>(&this->io_service, [this]() { this->boot_notification(); });
@@ -2191,9 +2193,14 @@ void ChargePoint::start_transaction(std::shared_ptr<Transaction> transaction) {
     this->send<StartTransactionRequest>(call);
 }
 
-void ChargePoint::on_session_started(int32_t connector, const std::string& session_id, const std::string& reason) {
+void ChargePoint::on_session_started(int32_t connector, const std::string& session_id, const std::string& reason,
+                                     const boost::optional<std::string>& session_logging_path) {
 
     EVLOG_debug << "Session on connector#" << connector << " started with reason " << reason;
+
+    if (session_logging_path.has_value() && this->logging->session_logging_active()) {
+        this->logging->start_session_logging(session_id, session_logging_path.value());
+    }
 
     const auto session_started_reason = ocpp::conversions::string_to_session_started_reason(reason);
 
@@ -2205,13 +2212,17 @@ void ChargePoint::on_session_started(int32_t connector, const std::string& sessi
     }
 }
 
-void ChargePoint::on_session_stopped(const int32_t connector) {
+void ChargePoint::on_session_stopped(const int32_t connector, const std::string& session_id) {
     // TODO(piet) fix this when evse manager signals clearance of an error
     if (this->status->get_state(connector) == ChargePointStatus::Faulted) {
         this->status->submit_event(connector, Event_I1_ReturnToAvailable());
     } else if (this->status->get_state(connector) != ChargePointStatus::Reserved &&
                this->status->get_state(connector) != ChargePointStatus::Unavailable) {
         this->status->submit_event(connector, Event_BecomeAvailable());
+    }
+
+    if (this->logging->session_logging_active()) {
+        this->logging->stop_session_logging(session_id);
     }
 }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -9,9 +9,9 @@ namespace v201 {
 ChargePoint::ChargePoint(const json& config, const std::string& ocpp_main_path, const std::string& message_log_path) :
     ocpp::ChargePoint() {
     this->pki_handler = std::make_shared<ocpp::PkiHandler>(ocpp_main_path);
-    this->configuration =
-        std::make_shared<ChargePointConfiguration>(config, ocpp_main_path, this->pki_handler);
-    this->logging = std::make_shared<ocpp::MessageLogging>(true, message_log_path, false, false, false, true);
+    this->configuration = std::make_shared<ChargePointConfiguration>(config, ocpp_main_path, this->pki_handler);
+    this->logging = std::make_shared<ocpp::MessageLogging>(true, message_log_path, DateTime().to_rfc3339(), false,
+                                                           false, false, true, true);
     this->message_queue = std::make_unique<ocpp::MessageQueue<v201::MessageType>>(
         [this](json message) -> bool { return this->websocket->send(message.dump()); }, 5, 30);
 }


### PR DESCRIPTION
Extended Message Logging and API so that sessions can be logged in seperate files. This requires the parameter log_path within the on_session_started and on_session_stopped handlers and the session logging has to be enabled within the MessageLogFormats.

The session logging simply logs all ocpp messages that occur within the two handlers. So there is no filtering for messages that only belong to one or the other session. Everything is captured within these two events.