### PR TITLE
Report and Configuration of Internal Configuration Keys

### DIFF
--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -179,8 +179,7 @@
         "SeccLeafSubjectCountry": {
             "$comment": "County of the SECC (EVSE) leaf certificate. Indicates in which country the CPO operates.",
             "type": "string",
-            "readOnly": false,
-            "default": "DE"
+            "readOnly": false
         },
         "SeccLeafSubjectOrganization": {
             "$comment": "Organization of the SECC (EVSE) leaf certificate. Indicates which CPO operates this EVSE. Example: Hubject GmbH",

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -38,31 +38,51 @@ public:
 
     // Internal config options
     std::string getChargePointId();
+    KeyValue getChargePointIdKeyValue();
     std::string getCentralSystemURI();
+    KeyValue getCentralSystemURIKeyValue();
     std::string getChargeBoxSerialNumber();
+    KeyValue getChargeBoxSerialNumberKeyValue();
     CiString<20> getChargePointModel();
+    KeyValue getChargePointModelKeyValue();
     boost::optional<CiString<25>> getChargePointSerialNumber();
+    boost::optional<KeyValue> getChargePointSerialNumberKeyValue();
     CiString<20> getChargePointVendor();
+    KeyValue getChargePointVendorKeyValue();
     CiString<50> getFirmwareVersion();
+    KeyValue getFirmwareVersionKeyValue();
     boost::optional<CiString<20>> getICCID();
+    boost::optional<KeyValue> getICCIDKeyValue();
     boost::optional<CiString<20>> getIMSI();
+    boost::optional<KeyValue> getIMSIKeyValue();
     boost::optional<CiString<25>> getMeterSerialNumber();
+    boost::optional<KeyValue> getMeterSerialNumberKeyValue();
     boost::optional<CiString<25>> getMeterType();
+    boost::optional<KeyValue> getMeterTypeKeyValue();
     int32_t getWebsocketReconnectInterval();
+    KeyValue getWebsocketReconnectIntervalKeyValue();
     bool getAuthorizeConnectorZeroOnConnectorOne();
+    KeyValue getAuthorizeConnectorZeroOnConnectorOneKeyValue();
     bool getLogMessages();
+    KeyValue getLogMessagesKeyValue();
     std::vector<std::string> getLogMessagesFormat();
+    KeyValue getLogMessagesFormatKeyValue();
     std::vector<ChargingProfilePurposeType> getSupportedChargingProfilePurposeTypes();
+    KeyValue getSupportedChargingProfilePurposeTypesKeyValue();
     int32_t getMaxCompositeScheduleDuration();
-
+    KeyValue getMaxCompositeScheduleDurationKeyValue();
     std::string getSupportedCiphers12();
+    KeyValue getSupportedCiphers12KeyValue();
     std::string getSupportedCiphers13();
+    KeyValue getSupportedCiphers13KeyValue();
     bool getUseSslDefaultVerifyPaths();
+    KeyValue getUseSslDefaultVerifyPathsKeyValue();
 
     std::set<MessageType> getSupportedMessageTypesSending();
     std::set<MessageType> getSupportedMessageTypesReceiving();
 
     std::string getWebsocketPingPayload();
+    KeyValue getWebsocketPingPayloadKeyValue();
 
     // Core Profile - optional
     boost::optional<bool> getAllowOfflineTxForUnknownId();

--- a/include/ocpp/v16/types.hpp
+++ b/include/ocpp/v16/types.hpp
@@ -117,6 +117,7 @@ std::ostream& operator<<(std::ostream& os, const MessageType& message_type);
 
 /// \brief Contains the supported OCPP 1.6 feature profiles
 enum SupportedFeatureProfiles {
+    Internal,
     Core,
     FirmwareManagement,
     LocalAuthListManagement,

--- a/lib/ocpp/v16/types.cpp
+++ b/lib/ocpp/v16/types.cpp
@@ -431,6 +431,8 @@ namespace conversions {
 /// \returns a string representation of the SupportedFeatureProfiles
 std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
     switch (e) {
+    case SupportedFeatureProfiles::Internal:
+        return "Internal";
     case SupportedFeatureProfiles::Core:
         return "Core";
     case SupportedFeatureProfiles::FirmwareManagement:
@@ -455,6 +457,9 @@ std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
 /// \returns a SupportedFeatureProfiles from a string representation
 SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string& s) {
+    if (s == "Internal") {
+        return SupportedFeatureProfiles::Internal;
+    }
     if (s == "Core") {
         return SupportedFeatureProfiles::Core;
     }


### PR DESCRIPTION
Internal configuration keys have not been reported in a GetConfiguration.req in the past and this functionality has been added in this PR. In addition, configuration keys that are rw can now be configured using a ChangeConfiguration.req