### PR TITLE
added basic implementation for DataTransfer mechanism

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -54,6 +54,11 @@ private:
 
     std::map<int32_t, ChangeAvailabilityRequest> scheduled_change_availability_requests;
 
+    std::map<std::string,
+             std::map<std::string, std::function<DataTransferResponse(const std::optional<std::string>& msg)>>>
+        data_transfer_callbacks;
+    std::mutex data_transfer_callbacks_mutex;
+    
     // timers
     Everest::SteadyTimer heartbeat_timer;
     Everest::SteadyTimer boot_notification_timer;
@@ -208,6 +213,13 @@ public:
     /// \brief Event handler that can be called to trigger a NotifyEvent.req with the given \p events
     /// \param events
     void on_event(const std::vector<EventData>& events);
+
+    /// @brief Data transfer mechanism initiated by charger
+    /// @param vendorId 
+    /// @param messageId 
+    /// @param data 
+    /// @return DataTransferResponse contaning the result from CSMS
+    DataTransferResponse data_transfer(const CiString<255>& vendorId,const CiString<50>& messageId, const std::string& data);
 };
 
 } // namespace v201

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -770,10 +770,45 @@ void ChargePoint::handle_change_availability_req(Call<ChangeAvailabilityRequest>
 void ChargePoint::handle_data_transfer_req(Call<DataTransferRequest> call) {
     const auto msg = call.msg;
     DataTransferResponse response;
-    response.status = DataTransferStatusEnum::Rejected;
+    auto vendorId = call.msg.vendorId.get();
+    auto messageId = call.msg.messageId.get_value_or(CiString<50>()).get();
+    {
+        std::lock_guard<std::mutex> lock(data_transfer_callbacks_mutex);
+        if (this->data_transfer_callbacks.count(vendorId) == 0) {
+            response.status = DataTransferStatus::UnknownVendorId;
+        } else if (this->data_transfer_callbacks.count(vendorId) and
+                   this->data_transfer_callbacks[vendorId].count(messageId) == 0) {
+            response.status = DataTransferStatus::UnknownMessageId;
+        } else {
+            // there is a callback registered for this vendorId and messageId
+            response = this->data_transfer_callbacks[vendorId][messageId](call.msg.data);
+        }
+    }
 
     ocpp::CallResult<DataTransferResponse> call_result(response, call.uniqueId);
     this->send<DataTransferResponse>(call_result);
+}
+
+DataTransferResponse ChargePoint::data_transfer(const CiString<255>& vendorId,const CiString<50>& messageId, const std::string& data) {
+    DataTransferRequest req;
+    req.vendorId = vendorId;
+    req.messageId = messageId;
+    req.data.emplace(data);
+
+    DataTransferResponse response;
+    ocpp::Call<DataTransferRequest> call(req, this->message_queue->createMessageId());
+    auto data_transfer_future = this->send_async<DataTransferRequest>(call);
+
+    auto enhanced_message = data_transfer_future.get();
+    if(enhanced_message.messageType == MessageType::DataTransferResponse){
+        ocpp::CallResult<DataTransferResponse> call_result = enhanced_message.message;
+        response = call_result.msg;
+    }
+    if(enhanced_message.offline){
+        response.status = DataTransferStatusEnum::Rejected;
+    }
+
+    return response;
 }
 
 } // namespace v201


### PR DESCRIPTION
Added basic implementation for DataTransfer for version 2.0.1. Sorry for closing last PR opening a new one, things did not go well with rebasing. However, all the before-mentioned  comments has been resolved, regarding a line of comment (deleted) and PnC callback definition (also deleted).