### PR TITLE
Make nlohmann_json_schema_validator a public dependency of libocpp

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(ocpp
         everest::log
         everest::timer
         websocketpp::websocketpp
+        nlohmann_json_schema_validator
     PRIVATE
         OpenSSL::SSL
         OpenSSL::Crypto
@@ -57,7 +58,6 @@ target_link_libraries(ocpp
         Threads::Threads
 
         nlohmann_json::nlohmann_json
-        nlohmann_json_schema_validator
         date::date-tz
 )
 


### PR DESCRIPTION
The header files from nlohmann_json_schema_validator are required by the public interface headers of libocpp.

When linking to libocpp outside of Everest framework the nlohmann_json_schema_validator dependency has to be supplied.