### PR TITLE
OCPP1.6: Including MeterValues without Measurands in StopTransaction.req

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.8.2
+    VERSION 0.8.3
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3047,6 +3047,8 @@ ChargePointImpl::get_filtered_transaction_data(const std::shared_ptr<Transaction
                             }
                         }
                     }
+                } else {
+                    sampled_values.push_back(meter_value);
                 }
             }
             if (!sampled_values.empty()) {


### PR DESCRIPTION
now including meter values without measurands in StopTransaction.req. This includes e.g. signed meter values