### PR TITLE
OCPP201: Support for NetworkConnectionProfiles and Migration to new CSMS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.8.4
+    VERSION 0.8.5
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -101,12 +101,23 @@
                 "TLS_AES_128_GCM_SHA256"
             ]
         },
-        "WebsocketReconnectInterval": {
-            "$comment": "The reconnect interval of the websocket in seconds",
+        "RetryBackoffRandomRange": {
+            "$comment": "maximum value for the random part of the websocket reconnect back-off time",
             "type": "integer",
-            "readOnly": true,
-            "minimum": 0,
+            "readOnly": false,
             "default": 10
+        },
+        "RetryBackoffRepeatTimes": {
+            "$comment": "amount of times previous reconnect back-off time will be doubled",
+            "type": "integer",
+            "readOnly": false,
+            "default": 3
+        },
+        "RetryBackoffWaitMinimum": {
+            "$comment": "minimum back-off time of the first reconnect",
+            "type": "integer",
+            "readOnly": false,
+            "default": 3
         },
         "AuthorizeConnectorZeroOnConnectorOne": {
             "$comment": "Automatically authorize id tags on connector 1 when there is only one connector",

--- a/config/v201/component_schemas/standardized/InternalCtrlr.json
+++ b/config/v201/component_schemas/standardized/InternalCtrlr.json
@@ -32,19 +32,20 @@
       "minLength": 1,
       "type": "string"
     },
-    "CentralSystemURI": {
-      "variable_name": "CentralSystemURI",
+    "NetworkConnectionProfiles": {
+      "variable_name": "NetworkConnectionProfiles",
       "characteristics": {
         "supportsMonitoring": true,
-        "dataType": "string"
+        "dataType": "MemberList"
       },
       "attributes": [
         {
           "type": "Actual",
-          "mutability": "ReadOnly"
+          "mutability": "ReadWrite"
         }
       ],
-      "minLength": 1,
+      "description": "List of NetworkConnectionProfiles that define the functional and technical parameters of a communication link. Must be a (JSON) string with the format of SetNetworkProfileRequest",
+      "default": "[{\\\"configurationSlot\\\": 1, \\\"connectionData\\\": {\\\"messageTimeout\\\": 30, \\\"ocppCsmsUrl\\\": \\\"ws://localhost:9000/cp001\\\", \\\"ocppInterface\\\": \\\"Wired0\\\", \\\"ocppTransport\\\": \\\"JSON\\\", \\\"ocppVersion\\\": \\\"OCPP20\\\", \\\"securityProfile\\\": 1}}]\n",
       "type": "string"
     },
     "ChargeBoxSerialNumber": {
@@ -223,23 +224,6 @@
       "minLength": 0,
       "type": "string"
     },
-    "WebsocketReconnectInterval": {
-      "variable_name": "WebsocketReconnectInterval",
-      "characteristics": {
-        "minLimit": 0,
-        "supportsMonitoring": true,
-        "dataType": "integer"
-      },
-      "attributes": [
-        {
-          "type": "Actual",
-          "mutability": "ReadOnly"
-        }
-      ],
-      "minimum": 0,
-      "default": "10",
-      "type": "integer"
-    },
     "AuthorizeConnectorZeroOnConnectorOne": {
       "variable_name": "AuthorizeConnectorZeroOnConnectorOne",
       "characteristics": {
@@ -386,15 +370,14 @@
     }
   },
   "required": [
-    "CentralSystemURI",
     "ChargeBoxSerialNumber",
     "ChargePointId",
     "ChargePointModel",
     "ChargePointVendor",
     "FirmwareVersion",
+    "NetworkConnectionProfiles",
     "NumberOfConnectors",
     "SupportedCiphers12",
-    "SupportedCiphers13",
-    "WebsocketReconnectInterval"
+    "SupportedCiphers13"
   ]
 }

--- a/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
+++ b/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
@@ -304,6 +304,10 @@
     "NetworkProfileConnectionAttempts",
     "OfflineThreshold",
     "ResetRetries",
-    "UnlockOnEVSideDisconnect"
+    "RetryBackOffRandomRange",
+    "RetryBackOffRepeatTimes",
+    "RetryBackOffWaitMinimum",
+    "UnlockOnEVSideDisconnect",
+    "WebSocketPingInterval"
   ]
 }

--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -132,10 +132,10 @@
                 "Actual": "cp001"
             }
         },
-        "CentralSystemURI": {
-            "variable_name": "CentralSystemURI",
+        "NetworkConnectionProfiles": {
+            "variable_name": "NetworkConnectionProfiles",
             "attributes": {
-                "Actual": "localhost:9000/cp001"
+                "Actual": "[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"ws://localhost:9000/cp001\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]"
             }
         },
         "ChargeBoxSerialNumber": {
@@ -172,12 +172,6 @@
             "variable_name": "SupportedCiphers13",
             "attributes": {
                 "Actual": "TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256"
-            }
-        },
-        "WebsocketReconnectInterval": {
-            "variable_name": "WebsocketReconnectInterval",
-            "attributes": {
-                "Actual": "60"
             }
         },
         "NumberOfConnectors": {
@@ -262,13 +256,31 @@
         "NetworkConfigurationPriority": {
             "variable_name": "NetworkConfigurationPriority",
             "attributes": {
-                "Actual": "dummy"
+                "Actual": "1,2,3"
             }
         },
         "NetworkProfileConnectionAttempts": {
             "variable_name": "NetworkProfileConnectionAttempts",
             "attributes": {
-                "Actual": 42
+                "Actual": 3 
+            }
+        },
+        "RetryBackOffRandomRange": {
+            "variable_name": "RetryBackOffRandomRange",
+            "attributes": {
+                "Actual": 2
+            }
+        },
+        "RetryBackOffWaitMinimum": {
+            "variable_name": "RetryBackOffWaitMinimum",
+            "attributes": {
+                "Actual": 1
+            }
+        },
+        "RetryBackOffRepeatTimes": {
+            "variable_name": "RetryBackOffRepeatTimes",
+            "attributes": {
+                "Actual": 2
             }
         },
         "OfflineThreshold": {
@@ -287,6 +299,12 @@
             "variable_name": "UnlockOnEVSideDisconnect",
             "attributes": {
                 "Actual": true
+            }
+        },
+        "WebSocketPingInterval": {
+            "variable_name": "WebSocketPingInterval",
+            "attributes": {
+                "Actual": "60"
             }
         }
     },

--- a/include/ocpp/common/charging_station_base.hpp
+++ b/include/ocpp/common/charging_station_base.hpp
@@ -16,6 +16,7 @@ protected:
     std::unique_ptr<Websocket> websocket;
     std::shared_ptr<PkiHandler> pki_handler;
     std::shared_ptr<MessageLogging> logging;
+    Everest::SteadyTimer websocket_timer;
 
     boost::shared_ptr<boost::asio::io_service::work> work;
     boost::asio::io_service io_service;
@@ -32,7 +33,6 @@ protected:
     /// \brief Generates a uuid  
     /// \return uuid
     std::string uuid();
-
 
 public:
     ChargingStationBase();

--- a/include/ocpp/common/utils.hpp
+++ b/include/ocpp/common/utils.hpp
@@ -4,11 +4,14 @@
 #define OCPP_COMMON_UTILS_HPP
 
 #include <string>
+#include <vector>
 
 namespace ocpp {
 
 /// \brief Case insensitive compare for a case insensitive (Ci)String
 bool iequals(const std::string& lhs, const std::string rhs);
+
+std::vector<std::string> get_vector_from_csv(const std::string& csv_str);
 
 } // namespace ocpp
 

--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -16,7 +16,7 @@ class Websocket {
 private:
     std::unique_ptr<WebsocketBase> websocket;
     std::function<void(const int security_profile)> connected_callback;
-    std::function<void()> disconnected_callback;
+    std::function<void()> closed_callback;
     std::function<void(const std::string& message)> message_callback;
     std::shared_ptr<MessageLogging> logging;
 
@@ -26,11 +26,10 @@ public:
                        std::shared_ptr<MessageLogging> logging);
     ~Websocket();
 
-    /// \brief connect to a websocket (TLS or non-TLS depending on the central system uri in the configuration). If \p
-    /// try_once is set to true, to establish a connection will only be tried once and will be no reconnect attempts.
-    /// This mechanism is used to switch back to a working security profile if a connection for a new security profile
-    /// cant be established. \returns true if the websocket is initialized and a connection attempt is made
-    bool connect(int32_t security_profile, bool try_once = false);
+    /// \brief connect to a websocket (TLS or non-TLS depending on the central system uri in the configuration).
+    bool connect();
+
+    void set_connection_options(const WebsocketConnectionOptions &connection_options);
 
     /// \brief disconnect the websocket
     void disconnect(websocketpp::close::status::value code);
@@ -44,8 +43,9 @@ public:
     /// \brief register a \p callback that is called when the websocket is connected successfully
     void register_connected_callback(const std::function<void(const int security_profile)>& callback);
 
-    /// \brief register a \p callback that is called when the websocket is disconnected
-    void register_disconnected_callback(const std::function<void()>& callback);
+    /// \brief register a \p callback that is called when the websocket connection has been closed and will not attempt
+    /// to reconnect
+    void register_closed_callback(const std::function<void()>& callback);
 
     /// \brief register a \p callback that is called when the websocket receives a message
     void register_message_callback(const std::function<void(const std::string& message)>& callback);
@@ -56,6 +56,9 @@ public:
 
     /// \brief set the websocket ping interval \p interval_s in seconds
     void set_websocket_ping_interval(int32_t interval_s);
+
+    /// \brief set the \p authorization_key of the connection_options
+    void set_authorization_key(const std::string &authorization_key);
 };
 
 } // namespace ocpp

--- a/include/ocpp/common/websocket/websocket_plain.hpp
+++ b/include/ocpp/common/websocket/websocket_plain.hpp
@@ -24,29 +24,34 @@ using websocketpp::lib::placeholders::_2;
 class WebsocketPlain : public WebsocketBase {
 private:
     client ws_client;
+    websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;
 
-    /// \brief Connect to a plaintext websocket
-    void connect_plain(int32_t security_profile, bool try_once);
+    /// \brief Connect to a plain websocket
+    void connect_plain();
 
     /// \brief Called when a plaintext websocket connection is established, calls the connected callback
-    void on_open_plain(client* c, websocketpp::connection_hdl hdl, int32_t security_profile);
+    void on_open_plain(client* c, websocketpp::connection_hdl hdl);
 
     /// \brief Called when a message is received over the plaintext websocket, calls the message callback
     void on_message_plain(websocketpp::connection_hdl hdl, client::message_ptr msg);
 
-    /// \brief Called when a plaintext websocket connection is closed, tries to reconnect
+    /// \brief Called when a plaintext websocket connection is closed
     void on_close_plain(client* c, websocketpp::connection_hdl hdl);
 
-    /// \brief Called when a plaintext websocket connection fails to be established, tries to reconnect
-    void on_fail_plain(client* c, websocketpp::connection_hdl hdl, bool try_once);
+    /// \brief Called when a plaintext websocket connection fails to be established
+    void on_fail_plain(client* c, websocketpp::connection_hdl hdl);
 
 public:
     /// \brief Creates a new WebsocketPlain object with the providede \p connection_options
     explicit WebsocketPlain(const WebsocketConnectionOptions& connection_options);
 
+    ~WebsocketPlain() {
+        this->websocket_thread->join();
+    }
+
     /// \brief connect to a plaintext websocket
     /// \returns true if the websocket is initialized and a connection attempt is made
-    bool connect(int32_t security_profile, bool try_once) override;
+    bool connect() override;
 
     /// \brief Reconnects the websocket using the delay, a reason for this reconnect can be provided with the
     /// \p reason parameter

--- a/include/ocpp/common/websocket/websocket_tls.hpp
+++ b/include/ocpp/common/websocket/websocket_tls.hpp
@@ -24,6 +24,7 @@ class WebsocketTLS : public WebsocketBase {
 private:
     tls_client wss_client;
     std::shared_ptr<PkiHandler> pki_handler;
+    websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;
     
     /// \brief Extracts the hostname from the provided \p uri
     /// FIXME(kai): this only works with a very limited subset of hostnames and should be extended to work spec conform
@@ -34,33 +35,37 @@ private:
     /// and how verification of the server certificate is handled
     tls_context on_tls_init(std::string hostname, websocketpp::connection_hdl hdl, int32_t security_profile);
 
-    /// \brief Connect to a TLS websocket, if the provided \p authorization_header is not empty use it to add a HTTP
-    /// Authorization header
-    void connect_tls(int32_t security_profile, bool try_once);
+    /// \brief Connect to a TLS websocket
+    void connect_tls();
 
     /// \brief Called when a TLS websocket connection is established, calls the connected callback
-    void on_open_tls(tls_client* c, websocketpp::connection_hdl hdl, int32_t security_profile);
+    void on_open_tls(tls_client* c, websocketpp::connection_hdl hdl);
 
     /// \brief Called when a message is received over the TLS websocket, calls the message callback
     void on_message_tls(websocketpp::connection_hdl hdl, tls_client::message_ptr msg);
 
-    /// \brief Called when a TLS websocket connection is closed, tries to reconnect
+    /// \brief Called when a TLS websocket connection is closed
     void on_close_tls(tls_client* c, websocketpp::connection_hdl hdl);
 
-    /// \brief Called when a TLS websocket connection fails to be established, tries to reconnect
-    void on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl, bool try_once);
+    /// \brief Called when a TLS websocket connection fails to be established
+    void on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl);
 
 public:
     /// \brief Creates a new Websocket object with the providede \p connection_options
     explicit WebsocketTLS(const WebsocketConnectionOptions& connection_options,
                           std::shared_ptr<PkiHandler> pki_handler);
 
+    ~WebsocketTLS() {
+        this->websocket_thread->join();
+    }
+
     /// \brief connect to a TLS websocket
     /// \returns true if the websocket is initialized and a connection attempt is made
-    bool connect(int32_t security_profile, bool try_once) override;
+    bool connect() override;
 
     /// \brief Reconnects the websocket using the delay, a reason for this reconnect can be provided with the
-    /// \p reason parameter
+    /// \param reason parameter
+    /// \param delay delay of the reconnect attempt
     void reconnect(std::error_code reason, long delay);
 
     /// \brief closes the websocket

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -77,6 +77,18 @@ public:
     KeyValue getSupportedCiphers13KeyValue();
     bool getUseSslDefaultVerifyPaths();
     KeyValue getUseSslDefaultVerifyPathsKeyValue();
+    
+    int32_t getRetryBackoffRandomRange();
+    void setRetryBackoffRandomRange(int32_t retry_backoff_random_range);
+    KeyValue getRetryBackoffRandomRangeKeyValue();
+
+    int32_t getRetryBackoffRepeatTimes();
+    void setRetryBackoffRepeatTimes(int32_t retry_backoff_repeat_times);
+    KeyValue getRetryBackoffRepeatTimesKeyValue();
+
+    int32_t getRetryBackoffWaitMinimum();
+    void setRetryBackoffWaitMinimum(int32_t retry_backoff_wait_minimum);
+    KeyValue getRetryBackoffWaitMinimumKeyValue();
 
     std::set<MessageType> getSupportedMessageTypesSending();
     std::set<MessageType> getSupportedMessageTypesReceiving();

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -174,7 +174,8 @@ private:
 
     /// \brief This function is called after a successful connection to the Websocket
     void connected_callback();
-    void init_websocket(int32_t security_profile);
+    void init_websocket();
+    WebsocketConnectionOptions get_ws_connection_options();
     void message_callback(const std::string& message);
     void handle_message(const json& json_message, MessageType message_type);
     bool allowed_to_send_message(json::array_t message_type);
@@ -287,7 +288,7 @@ private:
     void handleGetLogRequest(Call<GetLogRequest> call);
     void handleSignedUpdateFirmware(Call<SignedUpdateFirmwareRequest> call);
     void securityEventNotification(const SecurityEvent& type, const std::string& tech_info);
-    void switchSecurityProfile(int32_t new_security_profile);
+    void switchSecurityProfile(int32_t new_security_profile, int32_t max_connection_attempts);
     // Local Authorization List profile
     void handleSendLocalListRequest(Call<SendLocalListRequest> call);
     void handleGetLocalListVersionRequest(Call<GetLocalListVersionRequest> call);

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -33,11 +33,11 @@ extern const Component& TariffCostCtrlr;
 extern const Component& TxCtrlr;
 } // ControllerComponents
 
+// Provides access to standardized variables of OCPP2.0.1 spec
 namespace ControllerComponentVariables {
-
 extern const ComponentVariable& InternalCtrlrEnabled;
 extern const ComponentVariable& ChargePointId;
-extern const ComponentVariable& CentralSystemURI;
+extern const ComponentVariable& NetworkConnectionProfiles;
 extern const ComponentVariable& ChargeBoxSerialNumber;
 extern const ComponentVariable& ChargePointModel;
 extern const ComponentVariable& ChargePointSerialNumber;
@@ -49,7 +49,6 @@ extern const ComponentVariable& MeterSerialNumber;
 extern const ComponentVariable& MeterType;
 extern const ComponentVariable& SupportedCiphers12;
 extern const ComponentVariable& SupportedCiphers13;
-extern const ComponentVariable& WebsocketReconnectInterval;
 extern const ComponentVariable& AuthorizeConnectorZeroOnConnectorOne;
 extern const ComponentVariable& LogMessages;
 extern const ComponentVariable& LogMessagesFormat;
@@ -144,6 +143,9 @@ extern const ComponentVariable& NetworkProfileConnectionAttempts;
 extern const ComponentVariable& OfflineThreshold;
 extern const ComponentVariable& QueueAllMessages;
 extern const ComponentVariable& ResetRetries;
+extern const ComponentVariable& RetryBackOffRandomRange;
+extern const ComponentVariable& RetryBackOffRepeatTimes;
+extern const ComponentVariable& RetryBackOffWaitMinimum;
 extern const ComponentVariable& UnlockOnEVSideDisconnect;
 extern const ComponentVariable& WebSocketPingInterval;
 extern const ComponentVariable& ReservationCtrlrAvailable;

--- a/include/ocpp/v201/device_model_storage.hpp
+++ b/include/ocpp/v201/device_model_storage.hpp
@@ -56,6 +56,17 @@ inline bool operator<(const Variable& lhs, const Variable& rhs) {
     return lhs.instance < rhs.instance;
 };
 
+inline bool operator==(const ComponentVariable& lhs, const ComponentVariable &rhs) {
+    return lhs.component == rhs.component and lhs.variable == rhs.variable;
+}
+
+inline bool operator<(const ComponentVariable& lhs, const ComponentVariable &rhs) {
+    if (lhs.component == rhs.component) {
+        return lhs.variable < rhs.variable;
+    }
+    return lhs.component < rhs.component;    
+}
+
 using VariableMap = std::map<Variable, VariableMetaData>;
 using DeviceModelMap = std::map<Component, VariableMap>;
 

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -4,7 +4,6 @@
 #define V201_UTILS_HPP
 
 #include <openssl/sha.h>
-#include <sstream>
 
 #include <ocpp/v201/ocpp_types.hpp>
 namespace ocpp {

--- a/lib/ocpp/common/utils.cpp
+++ b/lib/ocpp/common/utils.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <sstream>
 
 #include <ocpp/common/utils.hpp>
 
@@ -9,6 +10,16 @@ namespace ocpp {
 
 bool iequals(const std::string& lhs, const std::string rhs) {
     return boost::algorithm::iequals(lhs, rhs);
+}
+
+std::vector<std::string> get_vector_from_csv(const std::string& csv_str) {
+    std::vector<std::string> csv;
+    std::string str;
+    std::stringstream ss(csv_str);
+    while (std::getline(ss, str, ',')) {
+        csv.push_back(str);
+    }
+    return csv;
 }
 
 } // namespace ocpp

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -26,8 +26,12 @@ Websocket::Websocket(const WebsocketConnectionOptions& connection_options, std::
 Websocket::~Websocket() {
 }
 
-bool Websocket::connect(int32_t security_profile, bool try_once) {
-    return this->websocket->connect(security_profile, try_once);
+bool Websocket::connect() {
+    return this->websocket->connect();
+}
+
+void Websocket::set_connection_options(const WebsocketConnectionOptions &connection_options) {
+    this->websocket->set_connection_options(connection_options);
 }
 
 void Websocket::disconnect(websocketpp::close::status::value code) {
@@ -52,13 +56,15 @@ void Websocket::register_connected_callback(const std::function<void(const int s
         this->connected_callback(security_profile);
     });
 }
-void Websocket::register_disconnected_callback(const std::function<void()>& callback) {
-    this->disconnected_callback = callback;
-    this->websocket->register_disconnected_callback([this]() {
+
+void Websocket::register_closed_callback(const std::function<void()>& callback) {
+    this->closed_callback = callback;
+    this->websocket->register_closed_callback([this]() {
         this->logging->sys("Disconnected");
-        this->disconnected_callback();
+        this->closed_callback();
     });
 }
+
 void Websocket::register_message_callback(const std::function<void(const std::string& message)>& callback) {
     this->message_callback = callback;
 
@@ -73,6 +79,10 @@ bool Websocket::send(const std::string& message) {
 void Websocket::set_websocket_ping_interval(int32_t interval_s) {
     this->logging->sys("WebsocketPingInterval changed");
     this->websocket->set_websocket_ping_interval(interval_s);
+}
+
+void Websocket::set_authorization_key(const std::string &authorization_key) {
+    this->websocket->set_authorization_key(authorization_key);
 }
 
 } // namespace ocpp

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -252,9 +252,6 @@ std::optional<CiString<25>> ChargePointConfiguration::getMeterType() {
     }
     return meter_type;
 }
-int32_t ChargePointConfiguration::getWebsocketReconnectInterval() {
-    return this->config["Internal"]["WebsocketReconnectInterval"];
-}
 bool ChargePointConfiguration::getAuthorizeConnectorZeroOnConnectorOne() {
     if (this->getNumberOfConnectors() == 1) {
         return this->config["Internal"]["AuthorizeConnectorZeroOnConnectorOne"];
@@ -410,14 +407,6 @@ std::optional<KeyValue> ChargePointConfiguration::getMeterTypeKeyValue() {
     return kv_opt;
 }
 
-KeyValue ChargePointConfiguration::getWebsocketReconnectIntervalKeyValue() {
-    KeyValue kv;
-    kv.key = "WebsocketReconnectInterval";
-    kv.readonly = true;
-    kv.value.emplace(std::to_string(this->getWebsocketReconnectInterval()));
-    return kv;
-}
-
 KeyValue ChargePointConfiguration::getAuthorizeConnectorZeroOnConnectorOneKeyValue() {
     KeyValue kv;
     kv.key = "AuthorizeConnectorZeroOnConnectorOne";
@@ -491,6 +480,57 @@ KeyValue ChargePointConfiguration::getWebsocketPingPayloadKeyValue() {
     kv.key = "WebsocketPingPayload";
     kv.readonly = true;
     kv.value.emplace(this->getWebsocketPingPayload());
+    return kv;
+}
+
+int32_t ChargePointConfiguration::getRetryBackoffRandomRange() {
+    return this->config["Internal"]["RetryBackoffRandomRange"];
+}
+
+void ChargePointConfiguration::setRetryBackoffRandomRange(int32_t retry_backoff_random_range) {
+    this->config["Internal"]["RetryBackoffRandomRange"] = retry_backoff_random_range;
+    this->setInUserConfig("Internal", "RetryBackoffRandomRange", retry_backoff_random_range);
+}
+
+KeyValue ChargePointConfiguration::getRetryBackoffRandomRangeKeyValue() {
+    KeyValue kv;
+    kv.key = "RetryBackoffRandomRange";
+    kv.readonly = false;
+    kv.value.emplace(std::to_string(this->getRetryBackoffRandomRange()));
+    return kv;
+}
+
+int32_t ChargePointConfiguration::getRetryBackoffRepeatTimes() {
+    return this->config["Internal"]["RetryBackoffRepeatTimes"];
+}
+
+void ChargePointConfiguration::setRetryBackoffRepeatTimes(int32_t retry_backoff_repeat_times) {
+    this->config["Internal"]["RetryBackoffRepeatTimes"] = retry_backoff_repeat_times;
+    this->setInUserConfig("Internal", "RetryBackoffRepeatTimes", retry_backoff_repeat_times);
+}
+
+KeyValue ChargePointConfiguration::getRetryBackoffRepeatTimesKeyValue() {
+    KeyValue kv;
+    kv.key = "RetryBackoffRepeatTimes";
+    kv.readonly = false;
+    kv.value.emplace(std::to_string(this->getRetryBackoffRepeatTimes()));
+    return kv;
+}
+
+int32_t ChargePointConfiguration::getRetryBackoffWaitMinimum() {
+    return this->config["Internal"]["RetryBackoffWaitMinimum"];
+}
+
+void ChargePointConfiguration::setRetryBackoffWaitMinimum(int32_t retry_backoff_wait_minimum) {
+    this->config["Internal"]["RetryBackoffWaitMinimum"] = retry_backoff_wait_minimum;
+    this->setInUserConfig("Internal", "RetryBackoffWaitMinimum", retry_backoff_wait_minimum);
+}
+
+KeyValue ChargePointConfiguration::getRetryBackoffWaitMinimumKeyValue() {
+    KeyValue kv;
+    kv.key = "RetryBackoffWaitMinimum";
+    kv.readonly = false;
+    kv.value.emplace(std::to_string(this->getRetryBackoffWaitMinimum()));
     return kv;
 }
 
@@ -1951,8 +1991,14 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     if (key == "SupportedCiphers13") {
         return this->getSupportedCiphers13KeyValue();
     }
-    if (key == "WebsocketReconnectInterval") {
-        return this->getWebsocketReconnectIntervalKeyValue();
+    if (key == "RetryBackoffRandomRange") {
+        return this->getRetryBackoffRandomRangeKeyValue();
+    }
+    if (key == "RetryBackoffRepeatTimes") {
+        return this->getRetryBackoffRepeatTimesKeyValue();
+    }
+    if (key == "RetryBackoffWaitMinimum") {
+        return this->getRetryBackoffWaitMinimumKeyValue();
     }
     if (key == "AuthorizeConnectorZeroOnConnectorOne") {
         return this->getAuthorizeConnectorZeroOnConnectorOneKeyValue();

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -46,11 +46,11 @@ const ComponentVariable& ChargePointId = {
         "ChargePointId",
     }),
 };
-const ComponentVariable& CentralSystemURI = {
+const ComponentVariable& NetworkConnectionProfiles = {
     ControllerComponents::InternalCtrlr,
     std::nullopt,
     std::optional<Variable>({
-        "CentralSystemURI",
+        "NetworkConnectionProfiles",
     }),
 };
 const ComponentVariable& ChargeBoxSerialNumber = {
@@ -128,13 +128,6 @@ const ComponentVariable& SupportedCiphers13 = {
     std::nullopt,
     std::optional<Variable>({
         "SupportedCiphers13",
-    }),
-};
-const ComponentVariable& WebsocketReconnectInterval = {
-    ControllerComponents::InternalCtrlr,
-    std::nullopt,
-    std::optional<Variable>({
-        "WebsocketReconnectInterval",
     }),
 };
 const ComponentVariable& AuthorizeConnectorZeroOnConnectorOne = {
@@ -763,6 +756,27 @@ const ComponentVariable& ResetRetries = {
     std::nullopt,
     std::optional<Variable>({
         "ResetRetries",
+    }),
+};
+const ComponentVariable& RetryBackOffRandomRange = {
+    ControllerComponents::OCPPCommCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "RetryBackOffRandomRange",
+    }),
+};
+const ComponentVariable& RetryBackOffRepeatTimes = {
+    ControllerComponents::OCPPCommCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "RetryBackOffRepeatTimes",
+    }),
+};
+const ComponentVariable& RetryBackOffWaitMinimum = {
+    ControllerComponents::OCPPCommCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "RetryBackOffWaitMinimum",
     }),
 };
 const ComponentVariable& UnlockOnEVSideDisconnect = {

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -4,6 +4,7 @@
 #include <everest/logging.hpp>
 
 #include <ocpp/v201/utils.hpp>
+#include <ocpp/common/utils.hpp>
 
 namespace ocpp {
 namespace v201 {
@@ -11,13 +12,7 @@ namespace utils {
 
 std::vector<MeasurandEnum> get_measurands_vec(const std::string& measurands_csv) {
     std::vector<MeasurandEnum> measurands;
-    std::vector<std::string> measurands_strings;
-    std::stringstream ss(measurands_csv);
-
-    std::string measurand;
-    while (std::getline(ss, measurand, ',')) {
-        measurands_strings.push_back(measurand);
-    }
+    std::vector<std::string> measurands_strings = ocpp::get_vector_from_csv(measurands_csv);
 
     for (const auto& measurand_string : measurands_strings) {
         try {


### PR DESCRIPTION
Support for OCPP201 use cases:
- a01 (change BasicAuthPassword)
- b09 (Set NetworkConnectionProfile)
- b10 (Migrate CSMS)

Changes:
- added functionality in device model for that in order to validate values that are set against minLimit and maxLimit of VariableCharacteristics
- changed to same validation handling in device model for MemberList and SequenceList
- restructuted websocket connections
- implemented set_network_profile for ocpp201
- changes due to restructured websockets in 16 and 201
- introduced backoff configuration variables for websocket reconnects for 16 and 201