### PR TITLE
Add partial trigger message support

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -118,6 +118,8 @@ private:
     WebsocketConnectionStatusEnum websocket_connection_status;
     OperationalStatusEnum operational_state;
     FirmwareStatusEnum firmware_status;
+    UploadLogStatusEnum upload_log_status;
+    int32_t upload_log_status_id;
     int network_configuration_priority;
     bool disable_automatic_websocket_reconnects;
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -153,7 +153,7 @@ private:
     void handle_variable_changed(const SetVariableData& set_variable_data);
     bool validate_set_variable(const SetVariableData& set_variable_data);
     MeterValue get_latest_meter_value_filtered(const MeterValue& meter_value, ReadingContextEnum context,
-                                               const std::string& measurands);
+                                               const ComponentVariable& component_variable);
 
     ///
     /// \brief Get evseid for the given transaction id.

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -152,6 +152,8 @@ private:
     void handle_scheduled_change_availability_requests(const int32_t evse_id);
     void handle_variable_changed(const SetVariableData& set_variable_data);
     bool validate_set_variable(const SetVariableData& set_variable_data);
+    MeterValue get_latest_meter_value_filtered(const MeterValue& meter_value, ReadingContextEnum context,
+                                               const std::string& measurands);
 
     ///
     /// \brief Get evseid for the given transaction id.
@@ -247,6 +249,7 @@ private:
     void handle_unlock_connector(Call<UnlockConnectorRequest> call);
     void handle_remote_start_transaction_request(Call<RequestStartTransactionRequest> call);
     void handle_remote_stop_transaction_request(Call<RequestStopTransactionRequest> call);
+    void handle_trigger_message(Call<TriggerMessageRequest> call);
 
     // Functional Block G: Availability
     void handle_change_availability_req(Call<ChangeAvailabilityRequest> call);

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -118,6 +118,7 @@ private:
     WebsocketConnectionStatusEnum websocket_connection_status;
     OperationalStatusEnum operational_state;
     FirmwareStatusEnum firmware_status;
+    int32_t firmware_status_id;
     UploadLogStatusEnum upload_log_status;
     int32_t upload_log_status_id;
     int network_configuration_priority;

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -99,8 +99,8 @@ public:
     /// \brief Triggers status notification callback for all connectors of the evse
     void trigger_status_notification_callbacks();
 
-    /// @brief Triggers a status notification callback for connector_id of the evse
-    /// @param connector_id id of the connector of the evse
+    /// \brief Triggers a status notification callback for connector_id of the evse
+    /// \param connector_id id of the connector of the evse
     void trigger_status_notification_callback(const int32_t connector_id);
 
     /// \brief Event handler that should be called when a new meter_value for this evse is present

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -99,6 +99,10 @@ public:
     /// \brief Triggers status notification callback for all connectors of the evse
     void trigger_status_notification_callbacks();
 
+    /// @brief Triggers a status notification callback for connector_id of the evse
+    /// @param connector_id id of the connector of the evse
+    void trigger_status_notification_callback(const int32_t connector_id);
+
     /// \brief Event handler that should be called when a new meter_value for this evse is present
     /// \param meter_value
     void on_meter_value(const MeterValue& meter_value);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1455,12 +1455,12 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
         }
         break;
 
-    // TODO:
-    // FirmwareStatusNotification
-    // PublishFirmwareStatusNotification
-    // SignChargingStationCertificate
-    // SignV2GCertificate
-    // SignCombinedCertificate
+        // TODO:
+        // FirmwareStatusNotification
+        // PublishFirmwareStatusNotification
+        // SignChargingStationCertificate
+        // SignV2GCertificate
+        // SignCombinedCertificate
 
     default:
         response.status = TriggerMessageStatusEnum::NotImplemented;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -626,8 +626,8 @@ void ChargePoint::message_callback(const std::string& message) {
 
 MeterValue ChargePoint::get_latest_meter_value_filtered(const MeterValue& meter_value, ReadingContextEnum context,
                                                         const ComponentVariable& component_variable) {
-    auto filtered_meter_value =
-        utils::get_meter_value_with_measurands_applied(meter_value, utils::get_measurands_vec(this->device_model->get_value<std::string>(component_variable)));
+    auto filtered_meter_value = utils::get_meter_value_with_measurands_applied(
+        meter_value, utils::get_measurands_vec(this->device_model->get_value<std::string>(component_variable)));
     for (auto& sampled_value : filtered_meter_value.sampledValue) {
         sampled_value.context = context;
     }
@@ -1448,6 +1448,14 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
             // F06.FR.12: Reject if evse or connectorId is ommited
         }
         break;
+
+    // TODO:
+    // LogStatusNotification
+    // FirmwareStatusNotification
+    // PublishFirmwareStatusNotification
+    // SignChargingStationCertificate
+    // SignV2GCertificate
+    // SignCombinedCertificate
 
     default:
         response.status = TriggerMessageStatusEnum::NotImplemented;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -625,9 +625,9 @@ void ChargePoint::message_callback(const std::string& message) {
 }
 
 MeterValue ChargePoint::get_latest_meter_value_filtered(const MeterValue& meter_value, ReadingContextEnum context,
-                                                        const std::string& measurands) {
+                                                        const ComponentVariable& component_variable) {
     auto filtered_meter_value =
-        utils::get_meter_value_with_measurands_applied(meter_value, utils::get_measurands_vec(measurands));
+        utils::get_meter_value_with_measurands_applied(meter_value, utils::get_measurands_vec(this->device_model->get_value<std::string>(component_variable)));
     for (auto& sampled_value : filtered_meter_value.sampledValue) {
         sampled_value.context = context;
     }
@@ -647,8 +647,7 @@ void ChargePoint::update_aligned_data_interval() {
                     // according to the configuration
                     const auto meter_value =
                         get_latest_meter_value_filtered(_meter_value, ReadingContextEnum::Sample_Clock,
-                                                        this->device_model->get_value<std::string>(
-                                                            ControllerComponentVariables::AlignedDataMeasurands));
+                                                        ControllerComponentVariables::AlignedDataMeasurands);
 
                     if (evse->has_active_transaction()) {
                         // because we do not actively read meter values at clock aligned timepoint, we switch the
@@ -1474,7 +1473,7 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
         auto send_meter_value = [&](int32_t evse_id, Evse& evse) {
             const auto meter_value = get_latest_meter_value_filtered(
                 evse.get_meter_value(), ReadingContextEnum::Trigger,
-                this->device_model->get_value<std::string>(ControllerComponentVariables::AlignedDataMeasurands));
+                ControllerComponentVariables::AlignedDataMeasurands);
 
             this->meter_values_req(evse_id, std::vector<ocpp::v201::MeterValue>(1, meter_value));
         };
@@ -1489,8 +1488,7 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
 
             const auto meter_value =
                 get_latest_meter_value_filtered(evse.get_meter_value(), ReadingContextEnum::Trigger,
-                                                this->device_model->get_value<std::string>(
-                                                    ControllerComponentVariables::SampledDataTxUpdatedMeasurands));
+                                                ControllerComponentVariables::SampledDataTxUpdatedMeasurands);
 
             this->meter_values_req(evse_id, std::vector<ocpp::v201::MeterValue>(1, meter_value));
             const auto& enhanced_transaction = evse.get_transaction();

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1425,7 +1425,7 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
 
     case MessageTriggerEnum::TransactionEvent:
         if (msg.evse.has_value()) {
-            if (pEvse != nullptr && pEvse->has_active_transaction()) {
+            if (pEvse != nullptr and pEvse->has_active_transaction()) {
                 response.status = TriggerMessageStatusEnum::Accepted;
             }
         } else {
@@ -1439,9 +1439,9 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
         break;
 
     case MessageTriggerEnum::StatusNotification:
-        if (msg.evse.has_value() && msg.evse.value().connectorId.has_value()) {
+        if (msg.evse.has_value() and msg.evse.value().connectorId.has_value()) {
             int32_t connector_id = msg.evse.value().connectorId.value();
-            if (pEvse != nullptr && connector_id > 0 && connector_id <= pEvse->get_number_of_connectors()) {
+            if (pEvse != nullptr and connector_id > 0 and connector_id <= pEvse->get_number_of_connectors()) {
                 response.status = TriggerMessageStatusEnum::Accepted;
             }
         } else {
@@ -1472,10 +1472,10 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
     };
 
     switch (msg.requestedMessage) {
-    case MessageTriggerEnum::BootNotification: {
-        auto reason = BootReasonEnum::Triggered;
-        boot_notification_req(reason);
-    } break;
+    case MessageTriggerEnum::BootNotification:
+        boot_notification_req(BootReasonEnum::Triggered);
+        break;
+
     case MessageTriggerEnum::MeterValues: {
         auto send_meter_value = [&](int32_t evse_id, Evse& evse) {
             const auto meter_value =
@@ -1497,7 +1497,6 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
                 get_latest_meter_value_filtered(evse.get_meter_value(), ReadingContextEnum::Trigger,
                                                 ControllerComponentVariables::SampledDataTxUpdatedMeasurands);
 
-            this->meter_values_req(evse_id, std::vector<ocpp::v201::MeterValue>(1, meter_value));
             const auto& enhanced_transaction = evse.get_transaction();
             this->transaction_event_req(
                 TransactionEventEnum::Updated, DateTime(), enhanced_transaction->get_transaction(),
@@ -1508,7 +1507,7 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
     } break;
 
     case MessageTriggerEnum::StatusNotification:
-        if (pEvse != nullptr) {
+        if (pEvse != nullptr and msg.evse.value().connectorId.has_value()) {
             pEvse->trigger_status_notification_callback(msg.evse.value().connectorId.value());
         }
         break;
@@ -1516,6 +1515,7 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
     case MessageTriggerEnum::Heartbeat:
         this->heartbeat_req();
         break;
+
     default:
         EVLOG_error << "Sent a TriggerMessageResponse::Accepted while not following up with a message";
         break;

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -105,6 +105,10 @@ void Evse::trigger_status_notification_callbacks() {
     }
 }
 
+void Evse::trigger_status_notification_callback(const int32_t connector_id) {
+    this->status_notification_callback(connector_id, this->id_connector_map.at(connector_id)->get_state());
+}
+
 void Evse::on_meter_value(const MeterValue& meter_value) {
     std::lock_guard<std::mutex> lk(this->meter_value_mutex);
     this->meter_value = meter_value;


### PR DESCRIPTION
Still missing the following messages:
- PublishFirmwareStatusNotification
- SignChargingStationCertificate
- SignV2GCertificate
- SignCombinedCertificate

We are free to not implement messages as long as we return `NotImplemented` which is what we currently do.

Edit: I was able to implement LogStatusNotification and FirmwareStatusNotification as well but could not test it due to the logging not being implemented in everest/core yet or not being able to test the firmware update from the ocpp-testing code.