### PR TITLE
Add function to device model that allows setting read-only values for certain components

### DIFF
--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -71,12 +71,12 @@ private:
 
     /// \brief Sets the variable_id attribute \p value specified by \p component_id , \p variable_id and \p
     /// attribute_enum \param component_id \param variable_id \param attribute_enum \param value
-    /// \param forceReadOnly If this is true, only read-only variables can be changed,
-    ///                      otherwise only non read-only variables can be changed
+    /// \param force_read_only If this is true, only read-only variables can be changed,
+    ///                        otherwise only non read-only variables can be changed
     /// \return Result of the requested operation
     SetVariableStatusEnum set_value_internal(const Component& component_id, const Variable& variable_id,
                                              const AttributeEnum& attribute_enum, const std::string& value,
-                                             bool forceReadOnly);
+                                             bool force_read_only);
 
 public:
     /// \brief Constructor for the device model

--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -69,6 +69,15 @@ private:
     bool component_criteria_match(const Component& component_id,
                                   const std::vector<ComponentCriterionEnum>& component_criteria);
 
+    /// \brief Sets the variable_id attribute \p value specified by \p component_id , \p variable_id and \p
+    /// attribute_enum \param component_id \param variable_id \param attribute_enum \param value
+    /// \param forceReadOnly If this is true, only read-only variables can be changed,
+    ///                      otherwise only non read-only variables can be changed
+    /// \return Result of the requested operation
+    SetVariableStatusEnum set_value_internal(const Component& component_id, const Variable& variable_id,
+                                             const AttributeEnum& attribute_enum, const std::string& value,
+                                             bool forceReadOnly);
+
 public:
     /// \brief Constructor for the device model
     /// \param storage_address address fo device model storage
@@ -136,10 +145,24 @@ public:
     }
 
     /// \brief Sets the variable_id attribute \p value specified by \p component_id , \p variable_id and \p
-    /// attribute_enum \param component_id \param variable_id \param attribute_enum \param value \return Result of the
-    /// requested operation
+    /// attribute_enum
+    /// \param component_id
+    /// \param variable_id
+    /// \param attribute_enum
+    /// \param value
+    /// \return Result of the requested operation
     SetVariableStatusEnum set_value(const Component& component_id, const Variable& variable_id,
                                     const AttributeEnum& attribute_enum, const std::string& value);
+
+    /// \brief Sets the variable_id attribute \p value specified by \p component_id , \p variable_id and \p
+    /// attribute_enum for read only variables only. Only works on certain allowed components.
+    /// \param component_id
+    /// \param variable_id
+    /// \param attribute_enum
+    /// \param value
+    /// \return Result of the requested operation
+    SetVariableStatusEnum set_read_only_value(const Component& component_id, const Variable& variable_id,
+                                              const AttributeEnum& attribute_enum, const std::string& value);
 
     /// \brief Gets the VariableMetaData for the given \p component_id and \p variable_id
     /// \param component_id

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -2,6 +2,7 @@
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
 #include <ocpp/common/utils.hpp>
+#include <ocpp/v201/ctrlr_component_variables.hpp>
 #include <ocpp/v201/device_model.hpp>
 #include <ocpp/v201/device_model_storage_sqlite.hpp>
 
@@ -115,13 +116,9 @@ GetVariableStatusEnum DeviceModel::request_value(const Component& component_id, 
     return GetVariableStatusEnum::Accepted;
 }
 
-DeviceModel::DeviceModel(const std::string& storage_address) {
-    this->storage = std::make_unique<DeviceModelStorageSqlite>(storage_address);
-    this->device_model = this->storage->get_device_model();
-};
-
-SetVariableStatusEnum DeviceModel::set_value(const Component& component, const Variable& variable,
-                                             const AttributeEnum& attribute_enum, const std::string& value) {
+SetVariableStatusEnum DeviceModel::set_value_internal(const Component& component, const Variable& variable,
+                                                      const AttributeEnum& attribute_enum, const std::string& value,
+                                                      bool forceReadOnly) {
 
     if (this->device_model.find(component) == this->device_model.end()) {
         return SetVariableStatusEnum::UnknownComponent;
@@ -144,13 +141,36 @@ SetVariableStatusEnum DeviceModel::set_value(const Component& component, const V
         return SetVariableStatusEnum::NotSupportedAttributeType;
     }
 
-    if (!attribute.value().mutability.has_value() or attribute.value().mutability.value() == MutabilityEnum::ReadOnly) {
+    // If forceReadOnly is false we don't allow read only
+    // If forceReadOnly is true we only allow read only
+    if (!attribute.value().mutability.has_value() or
+        (attribute.value().mutability.value() == MutabilityEnum::ReadOnly and !forceReadOnly) or
+        ((attribute.value().mutability.value() != MutabilityEnum::ReadOnly) and forceReadOnly)) {
         return SetVariableStatusEnum::Rejected;
     }
 
     const auto success = this->storage->set_variable_attribute_value(component, variable, attribute_enum, value);
     return success ? SetVariableStatusEnum::Accepted : SetVariableStatusEnum::Rejected;
 };
+
+DeviceModel::DeviceModel(const std::string& storage_address) {
+    this->storage = std::make_unique<DeviceModelStorageSqlite>(storage_address);
+    this->device_model = this->storage->get_device_model();
+};
+
+SetVariableStatusEnum DeviceModel::set_value(const Component& component, const Variable& variable,
+                                             const AttributeEnum& attribute_enum, const std::string& value) {
+    return this->set_value_internal(component, variable, attribute_enum, value, false);
+};
+
+SetVariableStatusEnum DeviceModel::set_read_only_value(const Component& component, const Variable& variable,
+                                                       const AttributeEnum& attribute_enum, const std::string& value) {
+
+    if (component == ControllerComponents::LocalAuthListCtrlr) {
+        return this->set_value_internal(component, variable, attribute_enum, value, true);
+    }
+    throw std::invalid_argument("Not allowed to set read only value for component " + component.name.get());
+}
 
 std::optional<VariableMetaData> DeviceModel::get_variable_meta_data(const Component& component,
                                                                     const Variable& variable) {

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -118,7 +118,7 @@ GetVariableStatusEnum DeviceModel::request_value(const Component& component_id, 
 
 SetVariableStatusEnum DeviceModel::set_value_internal(const Component& component, const Variable& variable,
                                                       const AttributeEnum& attribute_enum, const std::string& value,
-                                                      bool forceReadOnly) {
+                                                      bool force_read_only) {
 
     if (this->device_model.find(component) == this->device_model.end()) {
         return SetVariableStatusEnum::UnknownComponent;
@@ -141,11 +141,11 @@ SetVariableStatusEnum DeviceModel::set_value_internal(const Component& component
         return SetVariableStatusEnum::NotSupportedAttributeType;
     }
 
-    // If forceReadOnly is false we don't allow read only
-    // If forceReadOnly is true we only allow read only
+    // If force_read_only is false, don't allow read only
+    // If force_read_only is true, only allow read only
     if (!attribute.value().mutability.has_value() or
-        (attribute.value().mutability.value() == MutabilityEnum::ReadOnly and !forceReadOnly) or
-        ((attribute.value().mutability.value() != MutabilityEnum::ReadOnly) and forceReadOnly)) {
+        ((attribute.value().mutability.value() == MutabilityEnum::ReadOnly) and !force_read_only) or
+        ((attribute.value().mutability.value() != MutabilityEnum::ReadOnly) and force_read_only)) {
         return SetVariableStatusEnum::Rejected;
     }
 


### PR DESCRIPTION
Currently only `LocalAuthListCtrlr` is allowed. In the future some other components might be selected carefully to allow read only changes.