### PR TITLE
pg_websocket_v_dtor - Correct WebSocket type destructor behavior

### DIFF
--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -14,6 +14,7 @@ namespace ocpp {
 ///
 class Websocket {
 private:
+    // unique_ptr holds address of base - requires WebSocketBase to have a virtual destructor
     std::unique_ptr<WebsocketBase> websocket;
     std::function<void(const int security_profile)> connected_callback;
     std::function<void(const websocketpp::close::status::value reason)> closed_callback;

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -79,7 +79,7 @@ protected:
 public:
     /// \brief Creates a new WebsocketBase object with the providede \p connection_options
     explicit WebsocketBase(const WebsocketConnectionOptions& connection_options);
-    ~WebsocketBase();
+    virtual ~WebsocketBase();
 
     /// \brief connect to a websocket
     /// \returns true if the websocket is initialized and a connection attempt is made

--- a/include/ocpp/common/websocket/websocket_plain.hpp
+++ b/include/ocpp/common/websocket/websocket_plain.hpp
@@ -21,7 +21,7 @@ using websocketpp::lib::placeholders::_2;
 ///
 /// \brief contains a websocket abstraction that can connect to plaintext websocket endpoints (ws://)
 ///
-class WebsocketPlain : public WebsocketBase {
+class WebsocketPlain final : public WebsocketBase {
 private:
     client ws_client;
     websocketpp::lib::shared_ptr<websocketpp::lib::thread> websocket_thread;

--- a/include/ocpp/common/websocket/websocket_tls.hpp
+++ b/include/ocpp/common/websocket/websocket_tls.hpp
@@ -20,7 +20,7 @@ using websocketpp::lib::placeholders::_2;
 ///
 /// \brief contains a websocket abstraction that can connect to TLS and non-TLS websocket endpoints
 ///
-class WebsocketTLS : public WebsocketBase {
+class WebsocketTLS final : public WebsocketBase {
 private:
     tls_client wss_client;
     std::shared_ptr<PkiHandler> pki_handler;


### PR DESCRIPTION
The std::unique_ptr<WebSocketBase> websocket object holds the address of the base WebSocket. Its destructor won't join with the websocket_thread as it does in WebSocketTLS and WebSocketPlain's destructors. Assuming stop_perpetual can finish all work, and the Asio handling thread exits, the join(s) should be called. If stop_perpetual stays busy, then the join will wait indefinitely. If it stays busy and join isn't called, as occurs without this change, then reconnects can fail. If stop_perpetual doesn't stay busy, and join isn't called, we have a race. 