### PR TITLE
Add auth cache storage size to de device model

### DIFF
--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -456,7 +456,26 @@
     },
     {
         "name": "AuthCacheCtrlr",
-        "variables": {}
+        "variables": {
+            "AuthCacheCtrlrAvailable": {
+                "variable_name": "Available",
+                "attributes": {
+                    "Actual": true
+                }
+            },
+            "AuthCacheCtrlrEnabled": {
+                "variable_name": "Enabled",
+                "attributes": {
+                    "Actual": false
+                }
+            },
+            "AuthCacheStorage": {
+                "variable_name": "Storage",
+                "attributes": {
+                    "Actual": 0
+                }
+            }
+        }
     },
     {
         "name": "ChargingStation",

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -187,6 +187,10 @@ private:
     MeterValue get_latest_meter_value_filtered(const MeterValue& meter_value, ReadingContextEnum context,
                                                const ComponentVariable& component_variable);
 
+    ///\brief Calculate and update the authorization cache size in the device model
+    ///
+    void update_authorization_cache_size();
+
     ///\brief Apply a local list request to the database if allowed
     ///
     ///\param request The local list request to apply

--- a/include/ocpp/v201/database_handler.hpp
+++ b/include/ocpp/v201/database_handler.hpp
@@ -56,6 +56,11 @@ public:
     /// \return
     bool authorization_cache_clear();
 
+    ///\brief Get the binary size of the authorization cache table
+    ///
+    ///\retval The size of the authorization cache table in bytes
+    size_t authorization_cache_get_binary_size();
+
     // Availability management
 
     void insert_availability(const int32_t evse_id, std::optional<int32_t> connector_id,

--- a/include/ocpp/v201/database_handler.hpp
+++ b/include/ocpp/v201/database_handler.hpp
@@ -41,20 +41,20 @@ public:
     /// \brief Inserts cache entry
     /// \param id_token_hash
     /// \param id_token_info
-    void insert_auth_cache_entry(const std::string& id_token_hash, const IdTokenInfo& id_token_info);
+    void authorization_cache_insert_entry(const std::string& id_token_hash, const IdTokenInfo& id_token_info);
 
     /// \brief Gets cache entry for given \p id_token_hash if present
     /// \param id_token_hash
     /// \return
-    std::optional<IdTokenInfo> get_auth_cache_entry(const std::string& id_token_hash);
+    std::optional<IdTokenInfo> authorization_cache_get_entry(const std::string& id_token_hash);
 
     /// \brief Deletes the cache entry for the given \p id_token_hash
     /// \param id_token_hash
-    void delete_auth_cache_entry(const std::string& id_token_hash);
+    void authorization_cache_delete_entry(const std::string& id_token_hash);
 
     /// \brief Deletes all entries of the AUTH_CACHE table. Returns true if the operation was successful, else false
     /// \return
-    bool clear_authorization_cache();
+    bool authorization_cache_clear();
 
     // Availability management
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1552,7 +1552,7 @@ void ChargePoint::handle_clear_cache_req(Call<ClearCacheRequest> call) {
 
     if (this->device_model->get_optional_value<bool>(ControllerComponentVariables::AuthCacheCtrlrEnabled)
             .value_or(true) and
-        this->database_handler->clear_authorization_cache()) {
+        this->database_handler->authorization_cache_clear()) {
         response.status = ClearCacheStatusEnum::Accepted;
     }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -382,13 +382,14 @@ AuthorizeResponse ChargePoint::validate_token(const IdToken id_token, const std:
             .value_or(false);
 
     if (auth_cache_enabled) {
-        const auto cache_entry = this->database_handler->get_auth_cache_entry(hashed_id_token);
+        const auto cache_entry = this->database_handler->authorization_cache_get_entry(hashed_id_token);
         if (cache_entry.has_value()) {
             if ((cache_entry.value().cacheExpiryDateTime.has_value() and
                  cache_entry.value().cacheExpiryDateTime.value().to_time_point() < DateTime().to_time_point())) {
                 EVLOG_info << "Found valid entry in AuthCache but expiry date passed: Removing from cache and sending "
                               "new request";
-                this->database_handler->delete_auth_cache_entry(hashed_id_token);
+                this->database_handler->authorization_cache_delete_entry(hashed_id_token);
+                this->update_authorization_cache_size();
             } else if (this->device_model->get_value<bool>(ControllerComponentVariables::LocalPreAuthorize) and
                        cache_entry.value().status == AuthorizationStatusEnum::Accepted) {
                 EVLOG_info << "Found valid entry in AuthCache";
@@ -411,7 +412,8 @@ AuthorizeResponse ChargePoint::validate_token(const IdToken id_token, const std:
     response = this->authorize_req(id_token, certificate, ocsp_request_data);
 
     if (auth_cache_enabled) {
-        this->database_handler->insert_auth_cache_entry(hashed_id_token, response.idTokenInfo);
+        this->database_handler->authorization_cache_insert_entry(hashed_id_token, response.idTokenInfo);
+        this->update_authorization_cache_size();
     }
 
     return response;
@@ -767,6 +769,16 @@ MeterValue ChargePoint::get_latest_meter_value_filtered(const MeterValue& meter_
         sampled_value.context = context;
     }
     return filtered_meter_value;
+}
+
+void ChargePoint::update_authorization_cache_size() {
+    auto& auth_cache_size = ControllerComponentVariables::AuthCacheStorage;
+    if (auth_cache_size.variable.has_value()) {
+        auto size = this->database_handler->authorization_cache_get_binary_size();
+        this->device_model->set_read_only_value(auth_cache_size.component, auth_cache_size.variable.value(),
+                                                AttributeEnum::Actual, std::to_string(size));
+        EVLOG_info << "*********** New auth cache size:" << size;
+    }
 }
 
 SendLocalListStatusEnum ChargePoint::apply_local_authorization_list(const SendLocalListRequest& request) {
@@ -1553,6 +1565,7 @@ void ChargePoint::handle_clear_cache_req(Call<ClearCacheRequest> call) {
     if (this->device_model->get_optional_value<bool>(ControllerComponentVariables::AuthCacheCtrlrEnabled)
             .value_or(true) and
         this->database_handler->authorization_cache_clear()) {
+        this->update_authorization_cache_size();
         response.status = ClearCacheStatusEnum::Accepted;
     }
 
@@ -1589,8 +1602,9 @@ void ChargePoint::handle_start_transaction_event_response(const EnhancedMessage<
         if (id_token.type != IdTokenEnum::Central and
             this->device_model->get_optional_value<bool>(ControllerComponentVariables::AuthCacheCtrlrEnabled)
                 .value_or(true)) {
-            this->database_handler->insert_auth_cache_entry(utils::generate_token_hash(id_token),
-                                                            msg.idTokenInfo.value());
+            this->database_handler->authorization_cache_insert_entry(utils::generate_token_hash(id_token),
+                                                                     msg.idTokenInfo.value());
+            this->update_authorization_cache_size();
         }
         if (msg.idTokenInfo.value().status != AuthorizationStatusEnum::Accepted) {
             if (this->device_model->get_value<bool>(ControllerComponentVariables::StopTxOnInvalidId)) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1113,7 +1113,7 @@ AuthorizeResponse ChargePoint::authorize_req(const IdToken id_token, const std::
     }
 
     ocpp::CallResult<AuthorizeResponse> call_result = enhanced_message.message;
-    if (response.idTokenInfo.cacheExpiryDateTime.has_value() or
+    if (call_result.msg.idTokenInfo.cacheExpiryDateTime.has_value() or
         !this->device_model->get_optional_value<int>(ControllerComponentVariables::AuthCacheLifeTime).has_value()) {
         return call_result.msg;
     }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -777,7 +777,6 @@ void ChargePoint::update_authorization_cache_size() {
         auto size = this->database_handler->authorization_cache_get_binary_size();
         this->device_model->set_read_only_value(auth_cache_size.component, auth_cache_size.variable.value(),
                                                 AttributeEnum::Actual, std::to_string(size));
-        EVLOG_info << "*********** New auth cache size:" << size;
     }
 }
 

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -67,7 +67,7 @@ void DatabaseHandler::close_connection() {
     }
 }
 
-void DatabaseHandler::insert_auth_cache_entry(const std::string& id_token_hash, const IdTokenInfo& id_token_info) {
+void DatabaseHandler::authorization_cache_insert_entry(const std::string& id_token_hash, const IdTokenInfo& id_token_info) {
     std::string sql = "INSERT OR REPLACE INTO AUTH_CACHE (ID_TOKEN_HASH, ID_TOKEN_INFO) VALUES "
                       "(@id_token_hash, @id_token_info)";
     SQLiteStatement insert_stmt(this->db, sql);
@@ -81,7 +81,7 @@ void DatabaseHandler::insert_auth_cache_entry(const std::string& id_token_hash, 
     }
 }
 
-std::optional<IdTokenInfo> DatabaseHandler::get_auth_cache_entry(const std::string& id_token_hash) {
+std::optional<IdTokenInfo> DatabaseHandler::authorization_cache_get_entry(const std::string& id_token_hash) {
     try {
         std::string sql = "SELECT ID_TOKEN_INFO FROM AUTH_CACHE WHERE ID_TOKEN_HASH = @id_token_hash";
         SQLiteStatement select_stmt(this->db, sql);
@@ -101,7 +101,7 @@ std::optional<IdTokenInfo> DatabaseHandler::get_auth_cache_entry(const std::stri
     }
 }
 
-void DatabaseHandler::delete_auth_cache_entry(const std::string& id_token_hash) {
+void DatabaseHandler::authorization_cache_delete_entry(const std::string& id_token_hash) {
     try {
         std::string sql = "DELETE FROM AUTH_CACHE WHERE ID_TOKEN_HASH = @id_token_hash";
         SQLiteStatement delete_stmt(this->db, sql);
@@ -116,7 +116,7 @@ void DatabaseHandler::delete_auth_cache_entry(const std::string& id_token_hash) 
     }
 }
 
-bool DatabaseHandler::clear_authorization_cache() {
+bool DatabaseHandler::authorization_cache_clear() {
     return this->clear_table("AUTH_CACHE");
 }
 

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -120,6 +120,21 @@ bool DatabaseHandler::authorization_cache_clear() {
     return this->clear_table("AUTH_CACHE");
 }
 
+size_t DatabaseHandler::authorization_cache_get_binary_size() {
+    try {
+        std::string sql = "SELECT SUM(\"payload\") FROM \"dbstat\" WHERE name='AUTH_CACHE';";
+        SQLiteStatement stmt(this->db, sql);
+
+        if (stmt.step() != SQLITE_ROW) {
+            throw std::runtime_error("Could not get local list count from database");
+        }
+
+        return stmt.column_int(0);
+    } catch (const std::exception& e) {
+        throw std::runtime_error("Could not get availability from database");
+    }
+}
+
 void DatabaseHandler::insert_availability(const int32_t evse_id, std::optional<int32_t> connector_id,
                                           const OperationalStatusEnum& operational_status, const bool replace) {
     std::string sql = "INSERT OR REPLACE INTO AVAILABILITY (EVSE_ID, CONNECTOR_ID, OPERATIONAL_STATUS) VALUES "

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -67,7 +67,8 @@ void DatabaseHandler::close_connection() {
     }
 }
 
-void DatabaseHandler::authorization_cache_insert_entry(const std::string& id_token_hash, const IdTokenInfo& id_token_info) {
+void DatabaseHandler::authorization_cache_insert_entry(const std::string& id_token_hash,
+                                                       const IdTokenInfo& id_token_info) {
     std::string sql = "INSERT OR REPLACE INTO AUTH_CACHE (ID_TOKEN_HASH, ID_TOKEN_INFO) VALUES "
                       "(@id_token_hash, @id_token_info)";
     SQLiteStatement insert_stmt(this->db, sql);

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -127,12 +127,12 @@ size_t DatabaseHandler::authorization_cache_get_binary_size() {
         SQLiteStatement stmt(this->db, sql);
 
         if (stmt.step() != SQLITE_ROW) {
-            throw std::runtime_error("Could not get local list count from database");
+            throw std::runtime_error("Could not get authorization cache binary size from database");
         }
 
         return stmt.column_int(0);
     } catch (const std::exception& e) {
-        throw std::runtime_error("Could not get availability from database");
+        throw std::runtime_error("Could not get authorization cache binary size from database");
     }
 }
 
@@ -287,7 +287,7 @@ int32_t DatabaseHandler::get_local_authorization_list_number_of_entries() {
 
         return stmt.column_int(0);
     } catch (const std::exception& e) {
-        throw std::runtime_error("Could not get availability from database");
+        throw std::runtime_error("Could not get local list count from database");
     }
 }
 

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -166,7 +166,7 @@ SetVariableStatusEnum DeviceModel::set_value(const Component& component, const V
 SetVariableStatusEnum DeviceModel::set_read_only_value(const Component& component, const Variable& variable,
                                                        const AttributeEnum& attribute_enum, const std::string& value) {
 
-    if (component == ControllerComponents::LocalAuthListCtrlr) {
+    if (component == ControllerComponents::AuthCacheCtrlr or component == ControllerComponents::LocalAuthListCtrlr) {
         return this->set_value_internal(component, variable, attribute_enum, value, true);
     }
     throw std::invalid_argument("Not allowed to set read only value for component " + component.name.get());


### PR DESCRIPTION
Also cleans up the auth cache interface in the database a bit by making the naming more uniform