### PR TITLE
Support for Custom Configuration Keys for OCPP1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.8.9
+    VERSION 0.9.0
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ This is defined in libocpp/include/ocpp/v16/charge_point.hpp and takes the follo
       ├── PnC.json
       ├── Reservation.json
       ├── Security.json
-      └── SmartCharging.json
+      ├── SmartCharging.json
+      └── Custom.json
   ```
   Here you can find:
   -  the aforementioned config files
@@ -170,7 +171,7 @@ This is defined in libocpp/include/ocpp/v16/charge_point.hpp and takes the follo
 
   - a *init.sql* file which contains the database schema used by libocpp for its sqlite database
 
-  - and a *profile_schemas* directory. This contains json schema files that are used to validate the libocpp config. The schemas are split up according to the OCPP1.6 feature profiles like Core, FirmwareManagement and so on. Additionally there is a schema for "Internal" configuration options (for example the ChargePointId, or CentralSystemURI). A "PnC" schema for the ISO 15118 Plug & Charge with OCPP 1.6 Application note, as well as a "Security" schema for the OCPP 1.6 Security Whitepaper (3rd edition) are provided as well. Finally there's a Config.json schema that ties everything together
+  - and a *profile_schemas* directory. This contains json schema files that are used to validate the libocpp config. The schemas are split up according to the OCPP1.6 feature profiles like Core, FirmwareManagement and so on. Additionally there is a schema for "Internal" configuration options (for example the ChargePointId, or CentralSystemURI). A "PnC" schema for the ISO 15118 Plug & Charge with OCPP 1.6 Application note, a "Security" schema for the OCPP 1.6 Security Whitepaper (3rd edition) and an exemplary "Custom" schema are provided as well. The Custom.json could be modified to be able to add custom configuration keys. Finally there's a Config.json schema that ties everything together
 
 - user_config_path: this points to a "user config", which we call a configuration file that's merged with the config that's provided in the "config" parameter. Here you can add, remove and overwrite settings without modifying the config passed in the first parameter directly. This is also used by libocpp to persistently modify config entries that are changed by the CSMS that should persist across restarts.
 
@@ -318,6 +319,9 @@ Some general notes: the "connector" parameter of some of the callbacks refers to
 - register_connection_state_changed_callback
 
   used to inform about the connection state to the CSMS (connected = true, disconnected = false)
+
+- register_configuration_key_changed_callback
+  used to react on a changed configuration key. This callback is called when the specified configuration key has been changed by the CSMS
 
 
 #### Functions that need to be triggered from the outside after new information is availble (on_... functions in the charge point API)

--- a/config/v16/CMakeLists.txt
+++ b/config/v16/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND OCPP1_6_PROFILE_SCHEMAS
      SmartCharging.json
      Security.json
      PnC.json
+     Custom.json
 )
 
 list(TRANSFORM OCPP1_6_PROFILE_SCHEMAS

--- a/config/v16/config-docker-tls.json
+++ b/config/v16/config-docker-tls.json
@@ -51,5 +51,8 @@
     "PnC": {
         "ISO15118PnCEnabled": true,
         "ContractValidationOffline": true
+    },
+    "Custom": {
+        "ExampleConfigurationKey": "example"
     }
 }

--- a/config/v16/config-docker.json
+++ b/config/v16/config-docker.json
@@ -5,7 +5,8 @@
         "ChargeBoxSerialNumber": "cp001",
         "ChargePointModel": "Yeti",
         "ChargePointVendor": "Pionix",
-        "FirmwareVersion": "0.1"
+        "FirmwareVersion": "0.1",
+        "AllowChargingProfileWithoutStartSchedule": true
     },
     "Core": {
         "AuthorizeRemoteTxRequests": false,
@@ -52,5 +53,8 @@
     "PnC": {
         "ISO15118PnCEnabled": true,
         "ContractValidationOffline": true
+    },
+    "Custom": {
+        "ExampleConfigurationKey": "example"
     }
 }

--- a/config/v16/config.json
+++ b/config/v16/config.json
@@ -51,5 +51,8 @@
     "PnC": {
         "ISO15118PnCEnabled": true,
         "ContractValidationOffline": true
+    },
+    "Custom": {
+        "ExampleConfigurationKey": "example"
     }
 }

--- a/config/v16/profile_schemas/Config.json
+++ b/config/v16/profile_schemas/Config.json
@@ -39,6 +39,10 @@
         "PnC": {
             "type": "object",
             "$ref": "PnC.json"
+        },
+        "Custom": {
+            "type": "object",
+            "$ref": "Custom.json"
         }
     },
     "additionalProperties": false

--- a/config/v16/profile_schemas/Custom.json
+++ b/config/v16/profile_schemas/Custom.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Json schema for Custom configuration keys",
+    "$comment": "This is just an example schema and can be modified according to custom requirements",
+    "type": "object",
+    "required": [],
+    "properties": {}
+  }
+  

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -9,6 +9,7 @@
 #include <ocpp/v16/types.hpp>
 
 #include <ocpp/v16/messages/DataTransfer.hpp>
+#include <ocpp/v16/messages/GetConfiguration.hpp>
 #include <ocpp/v16/messages/GetDiagnostics.hpp>
 #include <ocpp/v16/messages/GetLog.hpp>
 #include <ocpp/v16/messages/SignedUpdateFirmware.hpp>
@@ -406,6 +407,24 @@ public:
     /// \param callback
     void register_transaction_started_callback(
         const std::function<void(const int32_t connector, const int32_t transaction_id)>& callback);
+
+    /// \brief registers a \p callback function that can be used to react on changed configuration keys. This
+    /// callback is called when a configuration key has been changed by the CSMS
+    /// \param key the configuration key for which the callback is registered
+    /// \param callback executed when this configuration key changed
+    void register_configuration_key_changed_callback(const CiString<50>& key,
+                                                     const std::function<void(const KeyValue& key_value)>& callback);
+
+    /// \brief Gets the configured configuration key requested in the given \p request
+    /// \param request specifies the keys that should be returned. If empty or not set, all keys will be reported
+    /// \return a response containing the requested key(s) including the values and unkown keys if present
+    GetConfigurationResponse get_configuration_key(const GetConfigurationRequest& request);
+
+    /// \brief Sets a custom configuration key
+    /// \param key
+    /// \param value
+    /// \return Indicates the result of the operation
+    ConfigurationStatus set_custom_configuration_key(CiString<50> key, CiString<500> value);
 };
 
 } // namespace v16

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -15,6 +15,7 @@ namespace v16 {
 class ChargePointConfiguration {
 private:
     json config;
+    json custom_schema;
     std::filesystem::path user_config_path;
 
     std::set<SupportedFeatureProfiles> supported_feature_profiles;
@@ -379,6 +380,10 @@ public:
     int32_t getWaitForStopTransactionsOnResetTimeout();
     void setWaitForStopTransactionsOnResetTimeout(const int32_t wait_for_stop_transactions_on_reset_timeout);
     KeyValue getWaitForStopTransactionsOnResetTimeoutKeyValue();
+
+    // custom
+    std::optional<KeyValue> getCustomKeyValue(CiString<50> key);
+    ConfigurationStatus setCustomKey(CiString<50> key, CiString<500> value, bool force);
 
     std::optional<KeyValue> get(CiString<50> key);
 

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -124,6 +124,7 @@ private:
         data_transfer_callbacks;
     std::map<std::string, std::function<void(Call<DataTransferRequest> call)>> data_transfer_pnc_callbacks;
     std::mutex data_transfer_callbacks_mutex;
+    std::map<CiString<50>, std::function<void(const KeyValue& key_value)>> configuration_key_changed_callbacks;
 
     std::mutex stop_transaction_mutex;
     std::condition_variable stop_transaction_cv;
@@ -665,6 +666,24 @@ public:
     /// is received \param callback
     void register_transaction_started_callback(
         const std::function<void(int32_t connector, int32_t transaction_id)>& callback);
+
+    /// \brief registers a \p callback function that can be used to react on changed configuration keys. This
+    /// callback is called when a configuration key has been changed by the CSMS
+    /// \param key the configuration key for which the callback is registered
+    /// \param callback executed when this configuration key changed
+    void register_configuration_key_changed_callback(const CiString<50>& key,
+                                                     const std::function<void(const KeyValue& key_value)>& callback);
+
+    /// \brief Gets the configured configuration key requested in the given \p request
+    /// \param request specifies the keys that should be returned. If empty or not set, all keys will be reported
+    /// \return a response containing the requested key(s) including the values and unkown keys if present
+    GetConfigurationResponse get_configuration_key(const GetConfigurationRequest& request);
+
+    /// \brief Sets a custom configuration key
+    /// \param key
+    /// \param value
+    /// \return Indicates the result of the operation
+    ConfigurationStatus set_custom_configuration_key(CiString<50> key, CiString<500> value);
 };
 
 } // namespace v16

--- a/include/ocpp/v16/types.hpp
+++ b/include/ocpp/v16/types.hpp
@@ -125,7 +125,8 @@ enum SupportedFeatureProfiles {
     SmartCharging,
     RemoteTrigger,
     Security,
-    PnC
+    PnC,
+    Custom
 };
 namespace conversions {
 /// \brief Converts the given SupportedFeatureProfiles \p e to std::string

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -259,5 +259,18 @@ void ChargePoint::register_transaction_started_callback(
     this->charge_point->register_transaction_started_callback(callback);
 }
 
+void ChargePoint::register_configuration_key_changed_callback(
+    const CiString<50>& key, const std::function<void(const KeyValue& key_value)>& callback) {
+    this->charge_point->register_configuration_key_changed_callback(key, callback);
+}
+
+GetConfigurationResponse ChargePoint::get_configuration_key(const GetConfigurationRequest& request) {
+    return this->charge_point->get_configuration_key(request);
+}
+
+ConfigurationStatus ChargePoint::set_custom_configuration_key(CiString<50> key, CiString<500> value) {
+    return this->charge_point->set_custom_configuration_key(key, value);
+}
+
 } // namespace v16
 } // namespace ocpp

--- a/lib/ocpp/v16/types.cpp
+++ b/lib/ocpp/v16/types.cpp
@@ -449,6 +449,8 @@ std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
         return "Security";
     case SupportedFeatureProfiles::PnC:
         return "PnC";
+    case SupportedFeatureProfiles::Custom:
+        return "Custom";
     }
 
     throw std::out_of_range("No known string conversion for provided enum of type SupportedFeatureProfiles");
@@ -483,6 +485,9 @@ SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string&
     }
     if (s == "PnC") {
         return SupportedFeatureProfiles::PnC;
+    }
+    if (s == "Custom") {
+        return SupportedFeatureProfiles::Custom;
     }
 
     throw std::out_of_range("Provided string " + s +


### PR DESCRIPTION
Added support for custom configuration keys for 1.6. This includes:
* the option to register callbacks for specific keys that are executed when those keys change initiated by CSMS
* an API call  to retrieve configuration parameters
* an API call to set custom configuration key in case they have changed internally