### PR TITLE
Binding json default construct to use initializer list based constructor

### DIFF
--- a/lib/ocpp/v16/messages/GetDiagnostics.cpp
+++ b/lib/ocpp/v16/messages/GetDiagnostics.cpp
@@ -69,7 +69,7 @@ std::string GetDiagnosticsResponse::get_type() const {
 
 void to_json(json& j, const GetDiagnosticsResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({},true);
     // the optional parts of the message
     if (k.fileName) {
         j["fileName"] = k.fileName.value();

--- a/lib/ocpp/v16/messages/Heartbeat.cpp
+++ b/lib/ocpp/v16/messages/Heartbeat.cpp
@@ -17,7 +17,7 @@ std::string HeartbeatRequest::get_type() const {
 
 void to_json(json& j, const HeartbeatRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({},true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/UpdateFirmware.cpp
+++ b/lib/ocpp/v16/messages/UpdateFirmware.cpp
@@ -59,7 +59,7 @@ std::string UpdateFirmwareResponse::get_type() const {
 
 void to_json(json& j, const UpdateFirmwareResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({},true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }


### PR DESCRIPTION
The gcc 7.3 generates for json({}) null string, and not {}. With the proposed workaround, the right constructor is selected providing {}. See [link](https://github.com/nlohmann/json/issues/2046)