### PR TITLE
Binding json default construct to use initializer list based constructor

### DIFF
--- a/lib/ocpp/common/types.cpp
+++ b/lib/ocpp/common/types.cpp
@@ -157,7 +157,7 @@ std::ostream& operator<<(std::ostream& os, const SessionStartedReason& session_s
 
 void to_json(json& j, const Current& k) {
     // the required parts of the type
-    j = json({});
+    j = json({}, true);
     // the optional parts of the type
     if (k.DC) {
         j["DC"] = k.DC.value();
@@ -204,7 +204,7 @@ std::ostream& operator<<(std::ostream& os, const Current& k) {
 
 void to_json(json& j, const Voltage& k) {
     // the required parts of the type
-    j = json({});
+    j = json({}, true);
     // the optional parts of the type
     if (k.DC) {
         j["DC"] = k.DC.value();

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -185,7 +185,7 @@ json ChargePointConfiguration::get_user_config() {
         return json::parse(user_config_file);
     }
 
-    return json({});
+    return json({}, true);
 }
 
 void ChargePointConfiguration::setInUserConfig(std::string profile, std::string key, const json value) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -896,7 +896,7 @@ void ChargePointImpl::message_callback(const std::string& message) {
             EVLOG_warning << "Received an unsupported message: " << enhanced_message.messageType;
             // FIXME(kai): however, only send a CALLERROR when it is a CALL message we just received
             if (enhanced_message.messageTypeId == MessageTypeId::CALL) {
-                auto call_error = CallError(enhanced_message.uniqueId, "NotSupported", "", json({}));
+                auto call_error = CallError(enhanced_message.uniqueId, "NotSupported", "", json({}, true));
                 this->send(call_error);
             } else if (enhanced_message.messageTypeId == MessageTypeId::CALLERROR) {
                 auto call_messagetype =
@@ -953,7 +953,7 @@ void ChargePointImpl::message_callback(const std::string& message) {
         EVLOG_error << "JSON exception during handling of message: " << e.what();
         if (json_message.is_array() && json_message.size() > MESSAGE_ID) {
             auto call_error = CallError(MessageId(json_message.at(MESSAGE_ID).get<std::string>()), "FormationViolation",
-                                        e.what(), json({}));
+                                        e.what(), json({}, true));
             this->send(call_error);
         }
     }

--- a/lib/ocpp/v16/messages/ClearCache.cpp
+++ b/lib/ocpp/v16/messages/ClearCache.cpp
@@ -17,7 +17,7 @@ std::string ClearCacheRequest::get_type() const {
 
 void to_json(json& j, const ClearCacheRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/ClearChargingProfile.cpp
+++ b/lib/ocpp/v16/messages/ClearChargingProfile.cpp
@@ -19,7 +19,7 @@ std::string ClearChargingProfileRequest::get_type() const {
 
 void to_json(json& j, const ClearChargingProfileRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.id) {
         j["id"] = k.id.value();

--- a/lib/ocpp/v16/messages/DiagnosticsStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/DiagnosticsStatusNotification.cpp
@@ -43,7 +43,7 @@ std::string DiagnosticsStatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const DiagnosticsStatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/FirmwareStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/FirmwareStatusNotification.cpp
@@ -43,7 +43,7 @@ std::string FirmwareStatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const FirmwareStatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/GetConfiguration.cpp
+++ b/lib/ocpp/v16/messages/GetConfiguration.cpp
@@ -19,7 +19,7 @@ std::string GetConfigurationRequest::get_type() const {
 
 void to_json(json& j, const GetConfigurationRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.key) {
         if (j.size() == 0) {
@@ -60,7 +60,7 @@ std::string GetConfigurationResponse::get_type() const {
 
 void to_json(json& j, const GetConfigurationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.configurationKey) {
         if (j.size() == 0) {

--- a/lib/ocpp/v16/messages/GetDiagnostics.cpp
+++ b/lib/ocpp/v16/messages/GetDiagnostics.cpp
@@ -69,7 +69,7 @@ std::string GetDiagnosticsResponse::get_type() const {
 
 void to_json(json& j, const GetDiagnosticsResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.fileName) {
         j["fileName"] = k.fileName.value();

--- a/lib/ocpp/v16/messages/GetLocalListVersion.cpp
+++ b/lib/ocpp/v16/messages/GetLocalListVersion.cpp
@@ -17,7 +17,7 @@ std::string GetLocalListVersionRequest::get_type() const {
 
 void to_json(json& j, const GetLocalListVersionRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/Heartbeat.cpp
+++ b/lib/ocpp/v16/messages/Heartbeat.cpp
@@ -17,7 +17,7 @@ std::string HeartbeatRequest::get_type() const {
 
 void to_json(json& j, const HeartbeatRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/LogStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/LogStatusNotification.cpp
@@ -51,7 +51,7 @@ std::string LogStatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const LogStatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/MeterValues.cpp
+++ b/lib/ocpp/v16/messages/MeterValues.cpp
@@ -55,7 +55,7 @@ std::string MeterValuesResponse::get_type() const {
 
 void to_json(json& j, const MeterValuesResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/SecurityEventNotification.cpp
+++ b/lib/ocpp/v16/messages/SecurityEventNotification.cpp
@@ -53,7 +53,7 @@ std::string SecurityEventNotificationResponse::get_type() const {
 
 void to_json(json& j, const SecurityEventNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/SignedFirmwareStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/SignedFirmwareStatusNotification.cpp
@@ -51,7 +51,7 @@ std::string SignedFirmwareStatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const SignedFirmwareStatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/StatusNotification.cpp
+++ b/lib/ocpp/v16/messages/StatusNotification.cpp
@@ -73,7 +73,7 @@ std::string StatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const StatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v16/messages/StopTransaction.cpp
+++ b/lib/ocpp/v16/messages/StopTransaction.cpp
@@ -75,7 +75,7 @@ std::string StopTransactionResponse::get_type() const {
 
 void to_json(json& j, const StopTransactionResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.idTagInfo) {
         j["idTagInfo"] = k.idTagInfo.value();

--- a/lib/ocpp/v16/messages/UpdateFirmware.cpp
+++ b/lib/ocpp/v16/messages/UpdateFirmware.cpp
@@ -59,7 +59,7 @@ std::string UpdateFirmwareResponse::get_type() const {
 
 void to_json(json& j, const UpdateFirmwareResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     (void)k; // no elements to unpack, silence unused parameter warning
 }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -745,7 +745,7 @@ void ChargePoint::message_callback(const std::string& message) {
                 const auto error_message = "Received other message than BootNotificationResponse before "
                                            "having received an accepted BootNotificationResponse";
                 EVLOG_warning << error_message;
-                const auto call_error = CallError(enhanced_message.uniqueId, "SecurityError", "", json({}));
+                const auto call_error = CallError(enhanced_message.uniqueId, "SecurityError", "", json({}, true));
                 this->send(call_error);
             }
         }

--- a/lib/ocpp/v201/messages/ClearCache.cpp
+++ b/lib/ocpp/v201/messages/ClearCache.cpp
@@ -19,7 +19,7 @@ std::string ClearCacheRequest::get_type() const {
 
 void to_json(json& j, const ClearCacheRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/ClearChargingProfile.cpp
+++ b/lib/ocpp/v201/messages/ClearChargingProfile.cpp
@@ -19,7 +19,7 @@ std::string ClearChargingProfileRequest::get_type() const {
 
 void to_json(json& j, const ClearChargingProfileRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/ClearedChargingLimit.cpp
+++ b/lib/ocpp/v201/messages/ClearedChargingLimit.cpp
@@ -57,7 +57,7 @@ std::string ClearedChargingLimitResponse::get_type() const {
 
 void to_json(json& j, const ClearedChargingLimitResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/CostUpdated.cpp
+++ b/lib/ocpp/v201/messages/CostUpdated.cpp
@@ -53,7 +53,7 @@ std::string CostUpdatedResponse::get_type() const {
 
 void to_json(json& j, const CostUpdatedResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/FirmwareStatusNotification.cpp
+++ b/lib/ocpp/v201/messages/FirmwareStatusNotification.cpp
@@ -57,7 +57,7 @@ std::string FirmwareStatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const FirmwareStatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/GetInstalledCertificateIds.cpp
+++ b/lib/ocpp/v201/messages/GetInstalledCertificateIds.cpp
@@ -19,7 +19,7 @@ std::string GetInstalledCertificateIdsRequest::get_type() const {
 
 void to_json(json& j, const GetInstalledCertificateIdsRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/GetLocalListVersion.cpp
+++ b/lib/ocpp/v201/messages/GetLocalListVersion.cpp
@@ -19,7 +19,7 @@ std::string GetLocalListVersionRequest::get_type() const {
 
 void to_json(json& j, const GetLocalListVersionRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/GetTransactionStatus.cpp
+++ b/lib/ocpp/v201/messages/GetTransactionStatus.cpp
@@ -19,7 +19,7 @@ std::string GetTransactionStatusRequest::get_type() const {
 
 void to_json(json& j, const GetTransactionStatusRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/Heartbeat.cpp
+++ b/lib/ocpp/v201/messages/Heartbeat.cpp
@@ -19,7 +19,7 @@ std::string HeartbeatRequest::get_type() const {
 
 void to_json(json& j, const HeartbeatRequest& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/LogStatusNotification.cpp
+++ b/lib/ocpp/v201/messages/LogStatusNotification.cpp
@@ -57,7 +57,7 @@ std::string LogStatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const LogStatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/MeterValues.cpp
+++ b/lib/ocpp/v201/messages/MeterValues.cpp
@@ -55,7 +55,7 @@ std::string MeterValuesResponse::get_type() const {
 
 void to_json(json& j, const MeterValuesResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/NotifyChargingLimit.cpp
+++ b/lib/ocpp/v201/messages/NotifyChargingLimit.cpp
@@ -71,7 +71,7 @@ std::string NotifyChargingLimitResponse::get_type() const {
 
 void to_json(json& j, const NotifyChargingLimitResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/NotifyCustomerInformation.cpp
+++ b/lib/ocpp/v201/messages/NotifyCustomerInformation.cpp
@@ -63,7 +63,7 @@ std::string NotifyCustomerInformationResponse::get_type() const {
 
 void to_json(json& j, const NotifyCustomerInformationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/NotifyDisplayMessages.cpp
+++ b/lib/ocpp/v201/messages/NotifyDisplayMessages.cpp
@@ -71,7 +71,7 @@ std::string NotifyDisplayMessagesResponse::get_type() const {
 
 void to_json(json& j, const NotifyDisplayMessagesResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/NotifyEvent.cpp
+++ b/lib/ocpp/v201/messages/NotifyEvent.cpp
@@ -63,7 +63,7 @@ std::string NotifyEventResponse::get_type() const {
 
 void to_json(json& j, const NotifyEventResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/NotifyMonitoringReport.cpp
+++ b/lib/ocpp/v201/messages/NotifyMonitoringReport.cpp
@@ -75,7 +75,7 @@ std::string NotifyMonitoringReportResponse::get_type() const {
 
 void to_json(json& j, const NotifyMonitoringReportResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/NotifyReport.cpp
+++ b/lib/ocpp/v201/messages/NotifyReport.cpp
@@ -75,7 +75,7 @@ std::string NotifyReportResponse::get_type() const {
 
 void to_json(json& j, const NotifyReportResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/PublishFirmwareStatusNotification.cpp
+++ b/lib/ocpp/v201/messages/PublishFirmwareStatusNotification.cpp
@@ -71,7 +71,7 @@ std::string PublishFirmwareStatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const PublishFirmwareStatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/ReportChargingProfiles.cpp
+++ b/lib/ocpp/v201/messages/ReportChargingProfiles.cpp
@@ -65,7 +65,7 @@ std::string ReportChargingProfilesResponse::get_type() const {
 
 void to_json(json& j, const ReportChargingProfilesResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/ReservationStatusUpdate.cpp
+++ b/lib/ocpp/v201/messages/ReservationStatusUpdate.cpp
@@ -53,7 +53,7 @@ std::string ReservationStatusUpdateResponse::get_type() const {
 
 void to_json(json& j, const ReservationStatusUpdateResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/SecurityEventNotification.cpp
+++ b/lib/ocpp/v201/messages/SecurityEventNotification.cpp
@@ -59,7 +59,7 @@ std::string SecurityEventNotificationResponse::get_type() const {
 
 void to_json(json& j, const SecurityEventNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/StatusNotification.cpp
+++ b/lib/ocpp/v201/messages/StatusNotification.cpp
@@ -57,7 +57,7 @@ std::string StatusNotificationResponse::get_type() const {
 
 void to_json(json& j, const StatusNotificationResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/messages/TransactionEvent.cpp
+++ b/lib/ocpp/v201/messages/TransactionEvent.cpp
@@ -109,7 +109,7 @@ std::string TransactionEventResponse::get_type() const {
 
 void to_json(json& j, const TransactionEventResponse& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/lib/ocpp/v201/ocpp_types.cpp
+++ b/lib/ocpp/v201/ocpp_types.cpp
@@ -274,7 +274,7 @@ std::ostream& operator<<(std::ostream& os, const IdTokenInfo& k) {
 /// \brief Conversion from a given Modem \p k to a given json object \p j
 void to_json(json& j, const Modem& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();
@@ -435,7 +435,7 @@ std::ostream& operator<<(std::ostream& os, const EVSE& k) {
 /// \brief Conversion from a given ClearChargingProfile \p k to a given json object \p j
 void to_json(json& j, const ClearChargingProfile& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();
@@ -556,7 +556,7 @@ std::ostream& operator<<(std::ostream& os, const CertificateHashDataType& k) {
 /// \brief Conversion from a given ChargingProfileCriterion \p k to a given json object \p j
 void to_json(json& j, const ChargingProfileCriterion& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();
@@ -1046,7 +1046,7 @@ std::ostream& operator<<(std::ostream& os, const SignedMeterValue& k) {
 /// \brief Conversion from a given UnitOfMeasure \p k to a given json object \p j
 void to_json(json& j, const UnitOfMeasure& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();
@@ -1855,7 +1855,7 @@ std::ostream& operator<<(std::ostream& os, const MonitoringData& k) {
 /// \brief Conversion from a given VariableAttribute \p k to a given json object \p j
 void to_json(json& j, const VariableAttribute& k) {
     // the required parts of the message
-    j = json({});
+    j = json({}, true);
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();

--- a/src/code_generator/common/templates/message.cpp.jinja
+++ b/src/code_generator/common/templates/message.cpp.jinja
@@ -44,7 +44,7 @@ k.{{property.name}}
 {%- endif %}
 {%- endfor %}
 {% if not type.properties|selectattr('required')|list|length %}
-        j = json ({});
+        j = json ({}, true);
 {%- else %}
 };
 {%- endif %}

--- a/src/code_generator/common/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.cpp.jinja
@@ -38,7 +38,7 @@ k.{{property.name}}
 {%- endif %}
 {%- endfor %}
 {% if not type.properties|selectattr('required')|list|length %}
-        j = json ({});
+        j = json ({}, true);
 {%- else %}
 };
 {%- endif %}


### PR DESCRIPTION
GCC 7.3 generates a null string for json({}), and not {}. With this workaround, the right constructor is selected providing {}.

This is based on https://github.com/EVerest/libocpp/pull/178 but fixes the code generator to extend the fix to all messages of OCPP 1.6 and 2.0.1