### PR TITLE
Approach to support openssl 1.1.1f and avoid selection via defintion …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ option(CMAKE_RUN_CLANG_TIDY "Run clang-tidy" OFF)
 option(LIBOCPP_BUILD_EXAMPLES "Build charge_point and central_system binaries." OFF)
 option(OCPP_INSTALL "Install the library (shared data might be installed anyway)" ${EVC_MAIN_PROJECT})
 
+if (${CMAKE_CXX_COMPILER_VERSION} LESS_EQUAL 7.3.0)
+	add_definitions(-DOPENSSL1_1_1F)
+else()
+	 option(BOOSTFILESYSTEM "Usage of boost/filesystem.hpp instead of std::filesystem" OFF)
+endif()
+
 # dependencies
 find_package(Boost COMPONENTS program_options regex system thread REQUIRED)
 find_package(SQLite3 REQUIRED)

--- a/include/ocpp/common/support_older_c++_versions.hpp
+++ b/include/ocpp/common/support_older_c++_versions.hpp
@@ -1,0 +1,33 @@
+/*
+ * support_older_c++_versions.hpp
+ *
+ */
+
+#ifndef LIB_LIBOCPPMYFORK_INCLUDE_OCPP_COMMON_SUPPORT_OLDER_C___VERSIONS_HPP_
+#define LIB_LIBOCPPMYFORK_INCLUDE_OCPP_COMMON_SUPPORT_OLDER_C___VERSIONS_HPP_
+
+#include <openssl/asn1.h>
+#include <openssl/ssl.h>
+#include <openssl/x509.h>
+
+#ifndef BOOSTFILESYSTEM
+#include <filesystem>
+#else
+namespace fs = boost::filesystem;
+#endif
+
+#ifndef OPENSSL1_1_1F
+//const unsigned char* cnStr = ASN1_STRING_get0_data(cnAsn1);
+extern const unsigned char *(*ansi_string_data_selected)(ASN1_STRING *);
+extern int (*ssl_ctx_set_cipher_list_selected)(SSL_CTX *ctx, const char *str);
+extern ASN1_TIME *(*x509_get_not_after_selected)(const X509 *x);
+//const unsigned char* cnStr = ASN1_STRING_get0_data(cnAsn1);
+#else
+extern unsigned char *(*ansi_string_data_selected)(ASN1_STRING *);
+xtern int (*ssl_ctx_set_cipher_list_selected)(SSL_CTX *ctx, const char *str);
+#define  x509_get_not_after_selected(x) X509_get_notAfter(x);
+
+#endif
+
+
+#endif /* LIB_LIBOCPPMYFORK_INCLUDE_OCPP_COMMON_SUPPORT_OLDER_C___VERSIONS_HPP_ */

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(ocpp
         ocpp/common/schemas.cpp
         ocpp/common/types.cpp
         ocpp/common/utils.cpp
+        ocpp/common/support_older_c++_versions.cpp
         ocpp/v16/charge_point.cpp
         ocpp/v16/database_handler.cpp
         ocpp/v16/charge_point_impl.cpp

--- a/lib/ocpp/common/pki_handler.cpp
+++ b/lib/ocpp/common/pki_handler.cpp
@@ -33,7 +33,7 @@ std::string X509Certificate::getCommonName() {
     int index = X509_NAME_get_index_by_NID(subject, nid, -1);
     X509_NAME_ENTRY* entry = X509_NAME_get_entry(subject, index);
     ASN1_STRING* cnAsn1 = X509_NAME_ENTRY_get_data(entry);
-    const unsigned char* cnStr = ASN1_STRING_get0_data(cnAsn1);
+    const unsigned char* cnStr = ansi_string_data_selected(cnAsn1);
     std::string commonName(reinterpret_cast<const char*>(cnStr), ASN1_STRING_length(cnAsn1));
     return commonName;
 }
@@ -702,7 +702,7 @@ int PkiHandler::validIn(const std::string& certificate) {
 int PkiHandler::getDaysUntilLeafExpires(const CertificateSigningUseEnum& certificate_signing_use) {
     std::shared_ptr<X509Certificate> cert = this->getLeafCertificate(certificate_signing_use);
     if (cert != nullptr) {
-        const ASN1_TIME* expires = X509_get0_notAfter(cert->x509);
+        const ASN1_TIME* expires = x509_get_not_after_selected(cert->x509);
         int days, seconds;
         ASN1_TIME_diff(&days, &seconds, NULL, expires);
         return days;

--- a/lib/ocpp/common/support_older_c++_versions.cpp
+++ b/lib/ocpp/common/support_older_c++_versions.cpp
@@ -1,0 +1,29 @@
+/*
+ * support_older_c++_versions.cpp
+ *
+ */
+#include <openssl/asn1.h>
+#include <openssl/ssl.h>
+ #include <openssl/x509.h>
+#include <openssl/x509.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/ocsp.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+
+#ifndef OPENSSL1_1_1F
+//const unsigned char* cnStr = ASN1_STRING_get0_data(cnAsn1);
+const unsigned char *(*ansi_string_data_selected)(ASN1_STRING *)=ASN1_STRING_get0_data;
+int (*ssl_ctx_set_cipher_list_selected)(SSL_CTX *ctx, const char *str)=SSL_CTX_set_ciphersuites;
+ASN1_TIME *(*x509_get_not_after_selected)(const X509 *x)=X509_get0_notAfter;
+//const unsigned char* cnStr = ASN1_STRING_get0_data(cnAsn1);
+#else
+unsigned char *(*ansi_string_data_selected)(ASN1_STRING *)=ASN1_STRING_data;
+int (*ssl_ctx_set_cipher_list_selected)(SSL_CTX *ctx, const char *str)=SSL_CTX_set_cipher_list;
+#define  x509_get_not_after_selected(x) X509_get_notAfter(x);
+
+#endif
+
+

--- a/lib/ocpp/common/websocket/websocket_tls.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls.cpp
@@ -157,7 +157,7 @@ tls_context WebsocketTLS::on_tls_init(std::string hostname, websocketpp::connect
             EVLOG_AND_THROW(std::runtime_error("Could not set TLSv1.2 cipher list"));
         }
 
-        rc = SSL_CTX_set_ciphersuites(context->native_handle(), this->connection_options.supported_ciphers_13.c_str());
+        rc = ssl_ctx_set_cipher_list_selected(context->native_handle(), this->connection_options.supported_ciphers_13.c_str());
         if (rc != 1) {
             EVLOG_debug << "SSL_CTX_set_cipher_list return value: " << rc;
         }


### PR DESCRIPTION
…by using function pointer.

Alternative is to use #if based selection inside the code files. A simple definition inside the header, leaded to multiple definition error during linking, that is why a work around via extern is presented. 

Maybe the way via #if is more convenient. The pull request is reasoned, that our openssl is not supporting the functions, and requires minor work around. See commit. Thank you for your time on that. 