### PR TITLE
OCPP201: Improved handling of ChangeAvailability.req

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -183,7 +183,16 @@ private:
     void handle_message(const EnhancedMessage<v201::MessageType>& message);
     void message_callback(const std::string& message);
     void update_aligned_data_interval();
-    bool is_change_availability_possible(const ChangeAvailabilityRequest& req);
+
+    /// \brief Helper function to determine if there is any active transaction for the given \p evse
+    /// \param evse if optional is not set, this function will check if there is any transaction active f or the whole
+    /// charging station
+    /// \return
+    bool any_transaction_active(const std::optional<EVSE>& evse);
+
+    /// \brief Helper function to determine if the requested change results in a state that the Connector(s) is/are
+    /// already in \param request \return
+    bool is_already_in_state(const ChangeAvailabilityRequest& request);
     bool is_valid_evse(const EVSE& evse);
     void handle_scheduled_change_availability_requests(const int32_t evse_id);
     void handle_variable_changed(const SetVariableData& set_variable_data);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -898,20 +898,17 @@ bool ChargePoint::any_transaction_active(const std::optional<EVSE>& evse) {
         }
         return false;
     }
-
-    if (this->evses.at(evse.value().id)->has_active_transaction()) {
-        return true;
-    } else {
-        return false;
-    }
+    return this->evses.at(evse.value().id)->has_active_transaction();
 }
 
 bool operational_status_matches_connector_status(ConnectorStatusEnum connector_status,
                                                  OperationalStatusEnum operational_status) {
-    return (operational_status == OperationalStatusEnum::Inoperative and
-            connector_status == ConnectorStatusEnum::Unavailable) or
-           (operational_status == OperationalStatusEnum::Operative and
-            (connector_status != ConnectorStatusEnum::Unavailable or connector_status != ConnectorStatusEnum::Faulted));
+    if (operational_status == OperationalStatusEnum::Operative) {
+        return connector_status != ConnectorStatusEnum::Unavailable and
+               connector_status != ConnectorStatusEnum::Faulted;
+    } else {
+        return connector_status == ConnectorStatusEnum::Unavailable or connector_status == ConnectorStatusEnum::Faulted;
+    }
 }
 
 bool ChargePoint::is_already_in_state(const ChangeAvailabilityRequest& request) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -889,17 +889,59 @@ void ChargePoint::update_aligned_data_interval() {
     }
 }
 
-bool ChargePoint::is_change_availability_possible(const ChangeAvailabilityRequest& req) {
-    if (req.evse.has_value() and this->evses.at(req.evse.value().id)->has_active_transaction()) {
-        return false;
-    } else {
+bool ChargePoint::any_transaction_active(const std::optional<EVSE>& evse) {
+    if (!evse.has_value()) {
         for (auto const& [evse_id, evse] : this->evses) {
             if (evse->has_active_transaction()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if (this->evses.at(evse.value().id)->has_active_transaction()) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool operational_status_matches_connector_status(ConnectorStatusEnum connector_status,
+                                                 OperationalStatusEnum operational_status) {
+    return (operational_status == OperationalStatusEnum::Inoperative and
+            connector_status == ConnectorStatusEnum::Unavailable) or
+           (operational_status == OperationalStatusEnum::Operative and
+            (connector_status != ConnectorStatusEnum::Unavailable or connector_status != ConnectorStatusEnum::Faulted));
+}
+
+bool ChargePoint::is_already_in_state(const ChangeAvailabilityRequest& request) {
+    if (!request.evse.has_value()) {
+        for (const auto& [evse_id, evse] : this->evses) {
+            for (int connector_id = 1; connector_id <= evse->get_number_of_connectors(); connector_id++) {
+                auto status = evse->get_state(connector_id);
+                if (!operational_status_matches_connector_status(status, request.operationalStatus)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    const auto evse_id = request.evse.value().id;
+    if (request.evse.value().connectorId.has_value()) {
+        const auto connector_id = request.evse.value().connectorId.value();
+        const auto status = this->evses.at(evse_id)->get_state(connector_id);
+        return operational_status_matches_connector_status(status, request.operationalStatus);
+    } else {
+        for (int connector_id = 1; connector_id <= this->evses.at(evse_id)->get_number_of_connectors();
+             connector_id++) {
+            auto status = this->evses.at(evse_id)->get_state(connector_id);
+            if (!operational_status_matches_connector_status(status, request.operationalStatus)) {
                 return false;
             }
         }
+        return true;
     }
-    return true;
 }
 
 bool ChargePoint::is_valid_evse(const EVSE& evse) {
@@ -912,7 +954,7 @@ void ChargePoint::handle_scheduled_change_availability_requests(const int32_t ev
     if (this->scheduled_change_availability_requests.count(evse_id)) {
         EVLOG_info << "Found scheduled ChangeAvailability.req for evse_id:" << evse_id;
         const auto req = this->scheduled_change_availability_requests[evse_id];
-        if (this->is_change_availability_possible(req)) {
+        if (!this->any_transaction_active(req.evse)) {
             EVLOG_info << "Changing availability of evse:" << evse_id;
             this->callbacks.change_availability_callback(req, true);
             this->scheduled_change_availability_requests.erase(evse_id);
@@ -1911,15 +1953,20 @@ void ChargePoint::handle_change_availability_req(Call<ChangeAvailabilityRequest>
         return;
     }
 
-    const auto is_change_availability_possible = this->is_change_availability_possible(msg);
+    const auto transaction_active = this->any_transaction_active(msg.evse);
+    const auto is_already_in_state = this->is_already_in_state(msg);
 
-    if (is_change_availability_possible) {
+    auto evse_id = 0; // represents the whole charging station
+    if (msg.evse.has_value()) {
+        evse_id = msg.evse.value().id;
+    }
+
+    if (!transaction_active or is_already_in_state) {
         response.status = ChangeAvailabilityStatusEnum::Accepted;
+        // remove any scheduled availability request in case no transaction is scheduled or the component is already in
+        // correct state to override possible requests that have been scheduled before
+        this->scheduled_change_availability_requests.erase(evse_id);
     } else {
-        auto evse_id = 0; // represents the whole charging station
-        if (msg.evse.has_value()) {
-            evse_id = msg.evse.value().id;
-        }
         // add to map of scheduled operational_states. This also overrides successive ChangeAvailability.req with
         // the same EVSE, which is propably desirable
         this->scheduled_change_availability_requests[evse_id] = msg;
@@ -1930,8 +1977,8 @@ void ChargePoint::handle_change_availability_req(Call<ChangeAvailabilityRequest>
     ocpp::CallResult<ChangeAvailabilityResponse> call_result(response, call.uniqueId);
     this->send<ChangeAvailabilityResponse>(call_result);
 
-    // execute change availability if possible
-    if (is_change_availability_possible) {
+    if (!transaction_active) {
+        // execute change availability if possible
         this->callbacks.change_availability_callback(msg, true);
     }
 }


### PR DESCRIPTION
* in case of an active transaction we were responding with `Scheduled` instead of `Accepted` to a ChangeAvailability.req(status=Operative) - this has been fixed and is required by G03.FR.03 and G04.FR.04
* now overrding or removing scheduled availability changes if needed