### PR TITLE
Write SecurityProfile to device model

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -482,10 +482,23 @@ void ChargePoint::init_websocket() {
         return;
     }
 
+    const auto& security_profile_cv = ControllerComponentVariables::SecurityProfile;
+    if (security_profile_cv.variable.has_value()) {
+        this->device_model->set_read_only_value(security_profile_cv.component, security_profile_cv.variable.value(),
+                                                AttributeEnum::Actual,
+                                                std::to_string(network_connection_profile.value().securityProfile));
+    }
+
     this->websocket = std::make_unique<Websocket>(connection_options, this->evse_security, this->logging);
     this->websocket->register_connected_callback([this](const int security_profile) {
         this->message_queue->resume();
         this->websocket_connection_status = WebsocketConnectionStatusEnum::Connected;
+
+        const auto& security_profile_cv = ControllerComponentVariables::SecurityProfile;
+        if (security_profile_cv.variable.has_value()) {
+            this->device_model->set_read_only_value(security_profile_cv.component, security_profile_cv.variable.value(),
+                                                    AttributeEnum::Actual, std::to_string(security_profile));
+        }
 
         if (this->registration_status == RegistrationStatusEnum::Accepted) {
             // handle offline threshold

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -166,7 +166,8 @@ SetVariableStatusEnum DeviceModel::set_value(const Component& component, const V
 SetVariableStatusEnum DeviceModel::set_read_only_value(const Component& component, const Variable& variable,
                                                        const AttributeEnum& attribute_enum, const std::string& value) {
 
-    if (component == ControllerComponents::AuthCacheCtrlr or component == ControllerComponents::LocalAuthListCtrlr) {
+    if (component == ControllerComponents::AuthCacheCtrlr or component == ControllerComponents::LocalAuthListCtrlr or
+        component == ControllerComponents::SecurityCtrlr) {
         return this->set_value_internal(component, variable, attribute_enum, value, true);
     }
     throw std::invalid_argument("Not allowed to set read only value for component " + component.name.get());


### PR DESCRIPTION
writing security profile to device model on init websocket and connected callback. This fixes TC_A_22_CS