### PR TITLE
Usage of is token reserved for connector callback in remotestart

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -447,8 +447,8 @@ public:
     /// \p id_token. The is_token_reserved_for_connector_callback is called when a RemoteStartTransaction.req is
     /// received.
     /// \param callback
-    void register_is_token_reserved_for_connector_callback(const std::function<bool(const int32_t connector,
-        const std::string& id_token)>& callback);
+    void register_is_token_reserved_for_connector_callback(
+    	const std::function<bool(const int32_t connector, const std::string& id_token)>& callback);
 
 
 };

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -449,8 +449,6 @@ public:
     /// \param callback
     void register_is_token_reserved_for_connector_callback(
     	const std::function<bool(const int32_t connector, const std::string& id_token)>& callback);
-
-
 };
 
 } // namespace v16

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -441,6 +441,16 @@ public:
     /// \param value
     /// \return Indicates the result of the operation
     ConfigurationStatus set_custom_configuration_key(CiString<50> key, CiString<500> value);
+
+
+    /// \brief registers a \p callback function that can be used to check, if the \p connector is reserved for the given
+    /// \p id_token. The is_token_reserved_for_connector_callback is called when a RemoteStartTransaction.req is
+    /// received.
+    /// \param callback
+    void register_is_token_reserved_for_connector_callback(const std::function<bool(const int32_t connector,
+    													   const std::string& id_token)>& callback);
+
+
 };
 
 } // namespace v16

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -448,7 +448,7 @@ public:
     /// received.
     /// \param callback
     void register_is_token_reserved_for_connector_callback(const std::function<bool(const int32_t connector,
-    													   const std::string& id_token)>& callback);
+        const std::string& id_token)>& callback);
 
 
 };

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -442,13 +442,12 @@ public:
     /// \return Indicates the result of the operation
     ConfigurationStatus set_custom_configuration_key(CiString<50> key, CiString<500> value);
 
-
     /// \brief registers a \p callback function that can be used to check, if the \p connector is reserved for the given
     /// \p id_token. The is_token_reserved_for_connector_callback is called when a RemoteStartTransaction.req is
     /// received.
     /// \param callback
     void register_is_token_reserved_for_connector_callback(
-    	const std::function<bool(const int32_t connector, const std::string& id_token)>& callback);
+        const std::function<bool(const int32_t connector, const std::string& id_token)>& callback);
 };
 
 } // namespace v16

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -696,7 +696,6 @@ public:
     void register_is_token_reserved_for_connector_callback(
         const std::function<bool(const int32_t connector, const std::string& id_token)>& callback);
 
-
     /// \brief Gets the configured configuration key requested in the given \p request
     /// \param request specifies the keys that should be returned. If empty or not set, all keys will be reported
     /// \return a response containing the requested key(s) including the values and unkown keys if present

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -168,6 +168,7 @@ private:
     std::function<void(int32_t connection_timeout)> set_connection_timeout_callback;
 
     std::function<void(const int32_t connector, const int32_t transaction_id)> transaction_started_callback;
+    std::function<bool(const int32_t connector, const std::string& id_token)> is_token_reserved_for_connector_callback;
 
     // iso15118 callback
     std::function<void(const int32_t connector, const ocpp::v201::Get15118EVCertificateResponse& certificate_response,
@@ -687,6 +688,14 @@ public:
     /// called only if the SecurityEvent occured internally within libocpp
     void register_security_event_callback(
         const std::function<void(const std::string& type, const std::string& tech_info)>& callback);
+
+    /// \brief registers a \p callback function that can be used to check, if the \p connector is reserved for the given
+    /// \p id_token. The is_token_reserved_for_connector_callback is called when a RemoteStartTransaction.req is
+    /// received.
+    /// \param callback
+    void register_is_token_reserved_for_connector_callback(
+        const std::function<bool(const int32_t connector, const std::string& id_token)>& callback);
+
 
     /// \brief Gets the configured configuration key requested in the given \p request
     /// \param request specifies the keys that should be returned. If empty or not set, all keys will be reported

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -284,7 +284,7 @@ ConfigurationStatus ChargePoint::set_custom_configuration_key(CiString<50> key, 
 }
 
 void ChargePoint::register_is_token_reserved_for_connector_callback(
-               const std::function<bool(const int32_t connector, const std::string& id_token)>& callback){
+               const std::function<bool(const int32_t connector, const std::string& id_token)>& callback) {
     this->charge_point->register_is_token_reserved_for_connector_callback(callback);
 }
 

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -283,5 +283,11 @@ ConfigurationStatus ChargePoint::set_custom_configuration_key(CiString<50> key, 
     return this->charge_point->set_custom_configuration_key(key, value);
 }
 
+void ChargePoint::register_is_token_reserved_for_connector_callback(
+               const std::function<bool(const int32_t connector, const std::string& id_token)>& callback){
+    this->charge_point->register_is_token_reserved_for_connector_callback(callback);
+}
+
+
 } // namespace v16
 } // namespace ocpp

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -288,6 +288,5 @@ void ChargePoint::register_is_token_reserved_for_connector_callback(
     this->charge_point->register_is_token_reserved_for_connector_callback(callback);
 }
 
-
 } // namespace v16
 } // namespace ocpp

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -284,7 +284,7 @@ ConfigurationStatus ChargePoint::set_custom_configuration_key(CiString<50> key, 
 }
 
 void ChargePoint::register_is_token_reserved_for_connector_callback(
-               const std::function<bool(const int32_t connector, const std::string& id_token)>& callback) {
+    const std::function<bool(const int32_t connector, const std::string& id_token)>& callback) {
     this->charge_point->register_is_token_reserved_for_connector_callback(callback);
 }
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1479,37 +1479,37 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
         }
     }
 
-    // Check if at least one conenctor is able to execute RemoteStart (optainable == true).
-    bool optainable = true;
+    // Check if at least one conenctor is able to execute RemoteStart (obtainable == true).
+    bool obtainable = true;
     for (const auto connector : referenced_connectors) {
-        optainable = true;
+        obtainable = true;
 
         if (this->status->get_state(connector) == ChargePointStatus::Unavailable or
             this->status->get_state(connector) == ChargePointStatus::Faulted) {
-            optainable = false;
+            obtainable = false;
             continue;
         }
 
         if (this->transaction_handler->get_transaction(connector) != nullptr ||
             this->status->get_state(connector) == ChargePointStatus::Finishing) {
-            optainable = false;
+            obtainable = false;
             continue;
         }
 
         if (this->is_token_reserved_for_connector_callback != nullptr &&
             this->status->get_state(connector) == ChargePointStatus::Reserved &&
             !this->is_token_reserved_for_connector_callback(connector, call.msg.idTag.get())) {
-            optainable = false;
+            obtainable = false;
             continue;
         }
 
-        if (optainable) {
+        if (obtainable) {
             // at least one connector can do the remote start
             break;
         }
     }
 
-    if (!optainable) {
+    if (!obtainable) {
         EVLOG_debug << "Received RemoteStartTransactionRequest for reserved connector and rejected";
         response.status = RemoteStartStopStatus::Rejected;
         ocpp::CallResult<RemoteStartTransactionResponse> call_result(response, call.uniqueId);

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1473,7 +1473,7 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
             return;
         }
        referenced_connectors.push_back(call.msg.connectorId.value());
-    }else{
+    } else {
     	for (int connector = 1; connector <= this->configuration->getNumberOfConnectors(); connector++) {
     		referenced_connectors.push_back(connector);
     	}
@@ -3417,7 +3417,7 @@ void ChargePointImpl::register_security_event_callback(
 }
 
 void ChargePointImpl::register_is_token_reserved_for_connector_callback(
-    const std::function<bool(const int32_t connector, const std::string& id_token)>& callback){
+    const std::function<bool(const int32_t connector, const std::string& id_token)>& callback) {
     this->is_token_reserved_for_connector_callback = callback;
 }
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1474,15 +1474,15 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
         }
         referenced_connectors.push_back(call.msg.connectorId.value());
     } else {
-    	for (int connector = 1; connector <= this->configuration->getNumberOfConnectors(); connector++) {
-    		referenced_connectors.push_back(connector);
-    	}
+        for (int connector = 1; connector <= this->configuration->getNumberOfConnectors(); connector++) {
+            referenced_connectors.push_back(connector);
+        }
     }
 
     // Check if at least one conenctor is able to execute RemoteStart (optainable == true).
     bool optainable = true;
-    for (const auto connector: referenced_connectors) {
-    	optainable = true;
+    for (const auto connector : referenced_connectors) {
+        optainable = true;
 
         if (this->status->get_state(connector) == ChargePointStatus::Unavailable or
             this->status->get_state(connector) == ChargePointStatus::Faulted) {
@@ -1491,30 +1491,30 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
         }
 
         if (this->transaction_handler->get_transaction(connector) != nullptr ||
-                this->status->get_state(connector) == ChargePointStatus::Finishing) {
-        	optainable = false;
-        	continue;
+            this->status->get_state(connector) == ChargePointStatus::Finishing) {
+            optainable = false;
+            continue;
         }
 
-    	if (this->is_token_reserved_for_connector_callback != nullptr &&
-    			this->status->get_state(connector) == ChargePointStatus::Reserved &&
-				!this->is_token_reserved_for_connector_callback(connector, call.msg.idTag.get())) {
-    		optainable = false;
-    		continue;
-    	}
+        if (this->is_token_reserved_for_connector_callback != nullptr &&
+            this->status->get_state(connector) == ChargePointStatus::Reserved &&
+            !this->is_token_reserved_for_connector_callback(connector, call.msg.idTag.get())) {
+            optainable = false;
+            continue;
+        }
 
-    	if (optainable) {
-    		// at least one connector can do the remote start
-    		break;
-    	}
-     }
+        if (optainable) {
+            // at least one connector can do the remote start
+            break;
+        }
+    }
 
     if (!optainable) {
-		EVLOG_debug << "Received RemoteStartTransactionRequest for reserved connector and rejected";
-			response.status = RemoteStartStopStatus::Rejected;
-		ocpp::CallResult<RemoteStartTransactionResponse> call_result(response, call.uniqueId);
-		this->send<RemoteStartTransactionResponse>(call_result);
-		return;
+        EVLOG_debug << "Received RemoteStartTransactionRequest for reserved connector and rejected";
+        response.status = RemoteStartStopStatus::Rejected;
+        ocpp::CallResult<RemoteStartTransactionResponse> call_result(response, call.uniqueId);
+        this->send<RemoteStartTransactionResponse>(call_result);
+        return;
     }
 
     if (call.msg.chargingProfile) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3388,6 +3388,11 @@ void ChargePointImpl::register_security_event_callback(
     this->security_event_callback = callback;
 }
 
+void ChargePointImpl::register_is_token_reserved_for_connector_callback(
+    const std::function<bool(const int32_t connector, const std::string& id_token)>& callback){
+    this->is_token_reserved_for_connector_callback = callback;
+}
+
 void ChargePointImpl::on_reservation_start(int32_t connector) {
     this->status->submit_event(connector, FSMEvent::ReserveConnector);
 }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1472,22 +1472,22 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
             this->send<RemoteStartTransactionResponse>(call_result);
             return;
         }
-       referenced_connectors.push_back(call.msg.connectorId.value());
+        referenced_connectors.push_back(call.msg.connectorId.value());
     } else {
     	for (int connector = 1; connector <= this->configuration->getNumberOfConnectors(); connector++) {
     		referenced_connectors.push_back(connector);
     	}
     }
 
-    //Check if at least one conenctor is able to execute RemoteStart (optainable == true).
+    // Check if at least one conenctor is able to execute RemoteStart (optainable == true).
     bool optainable = true;
     for (const auto connector: referenced_connectors) {
     	optainable = true;
 
         if (this->status->get_state(connector) == ChargePointStatus::Unavailable or
-                this->status->get_state(connector) == ChargePointStatus::Faulted) {
-             optainable = false;
-             continue;
+            this->status->get_state(connector) == ChargePointStatus::Faulted) {
+            optainable = false;
+            continue;
         }
 
         if (this->transaction_handler->get_transaction(connector) != nullptr ||


### PR DESCRIPTION
A reject of the remotestart is checked and the conditions for this cases are evaluted in terms of reservation or unavailabiltiy. E.g. if all chargepoints are reserved for another id, the remotestart.req is rejected. 