### PR TITLE
Enable the connect callback to update the connection state variable

### DIFF
--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -17,7 +17,7 @@ private:
     // unique_ptr holds address of base - requires WebSocketBase to have a virtual destructor
     std::unique_ptr<WebsocketBase> websocket;
     std::function<void(const int security_profile)> connected_callback;
-    std::function<void(const websocketpp::close::status::value reason)> closed_callback;
+    std::function<void(const websocketpp::close::status::value reason, const bool doFull)> closed_callback;
     std::function<void(const std::string& message)> message_callback;
     std::shared_ptr<MessageLogging> logging;
 
@@ -46,7 +46,8 @@ public:
 
     /// \brief register a \p callback that is called when the websocket connection has been closed and will not attempt
     /// to reconnect
-    void register_closed_callback(const std::function<void(const websocketpp::close::status::value reason)>& callback);
+    void register_closed_callback(
+        const std::function<void(const websocketpp::close::status::value reason, const bool doFull)>& callback);
 
     /// \brief register a \p callback that is called when the websocket receives a message
     void register_message_callback(const std::function<void(const std::string& message)>& callback);

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -45,7 +45,7 @@ protected:
     bool m_is_connected;
     WebsocketConnectionOptions connection_options;
     std::function<void(const int security_profile)> connected_callback;
-    std::function<void(const websocketpp::close::status::value reason)> closed_callback;
+    std::function<void(const websocketpp::close::status::value reason, const bool doFull)> closed_callback;
     std::function<void(const std::string& message)> message_callback;
     websocketpp::lib::shared_ptr<boost::asio::steady_timer> reconnect_timer;
     std::unique_ptr<Everest::SteadyTimer> ping_timer;
@@ -111,7 +111,8 @@ public:
 
     /// \brief register a \p callback that is called when the websocket connection has been closed and will not attempt
     /// to reconnect
-    void register_closed_callback(const std::function<void(const websocketpp::close::status::value reason)>& callback);
+    void register_closed_callback(
+        const std::function<void(const websocketpp::close::status::value reason, const bool doFull)>& callback);
 
     /// \brief register a \p callback that is called when the websocket receives a message
     void register_message_callback(const std::function<void(const std::string& message)>& callback);

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -59,11 +59,11 @@ void Websocket::register_connected_callback(const std::function<void(const int s
 }
 
 void Websocket::register_closed_callback(
-    const std::function<void(const websocketpp::close::status::value reason)>& callback) {
+    const std::function<void(const websocketpp::close::status::value reason, const bool doFull)>& callback) {
     this->closed_callback = callback;
-    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason) {
+    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason, const bool doFull) {
         this->logging->sys("Disconnected");
-        this->closed_callback(reason);
+        this->closed_callback(reason, doFull);
     });
 }
 

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -61,10 +61,11 @@ void Websocket::register_connected_callback(const std::function<void(const int s
 void Websocket::register_closed_callback(
     const std::function<void(const websocketpp::close::status::value reason, const bool doFull)>& callback) {
     this->closed_callback = callback;
-    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason, const bool doFull) {
-        this->logging->sys("Disconnected");
-        this->closed_callback(reason, doFull);
-    });
+    this->websocket->register_closed_callback(
+        [this](const websocketpp::close::status::value reason, const bool doFull) {
+            this->logging->sys("Disconnected");
+            this->closed_callback(reason, doFull);
+        });
 }
 
 void Websocket::register_message_callback(const std::function<void(const std::string& message)>& callback) {

--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -38,7 +38,7 @@ void WebsocketBase::register_connected_callback(const std::function<void(const i
 }
 
 void WebsocketBase::register_closed_callback(
-    const std::function<void(const websocketpp::close::status::value reason)>& callback) {
+    const std::function<void(const websocketpp::close::status::value reason)>& callback, const bool doFull) {
     this->closed_callback = callback;
 }
 

--- a/lib/ocpp/common/websocket/websocket_plain.cpp
+++ b/lib/ocpp/common/websocket/websocket_plain.cpp
@@ -201,9 +201,10 @@ void WebsocketPlain::on_close_plain(client* c, websocketpp::connection_hdl hdl) 
                << "), reason: " << con->get_remote_close_reason();
     // dont reconnect on service restart code
     if (con->get_remote_close_code() != websocketpp::close::status::normal) {
+        this->closed_callback(con->get_remote_close_code(), false);
         this->reconnect(error_code, this->get_reconnect_interval());
     } else {
-        this->closed_callback(con->get_remote_close_code());
+        this->closed_callback(con->get_remote_close_code(), true);
     }
 }
 
@@ -234,7 +235,7 @@ void WebsocketPlain::close(websocketpp::close::status::value code, const std::st
     if (ec) {
         EVLOG_error << "Error initiating close of plain websocket: " << ec.message();
         // on_close_plain won't be called here so we have to call the closed_callback manually
-        this->closed_callback(websocketpp::close::status::abnormal_close);
+        this->closed_callback(websocketpp::close::status::abnormal_close, true);
     } else {
         EVLOG_info << "Closed plain websocket successfully.";
     }

--- a/lib/ocpp/common/websocket/websocket_tls.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls.cpp
@@ -291,9 +291,10 @@ void WebsocketTLS::on_close_tls(tls_client* c, websocketpp::connection_hdl hdl) 
                << "), reason: " << con->get_remote_close_reason();
     // dont reconnect on normal close
     if (con->get_remote_close_code() != websocketpp::close::status::normal) {
+        this->closed_callback(con->get_remote_close_code(), false);
         this->reconnect(error_code, this->get_reconnect_interval());
     } else {
-        this->closed_callback(con->get_remote_close_code());
+        this->closed_callback(con->get_remote_close_code(), true);
     }
 }
 void WebsocketTLS::on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl) {
@@ -328,7 +329,7 @@ void WebsocketTLS::close(websocketpp::close::status::value code, const std::stri
     if (ec) {
         EVLOG_error << "Error initiating close of TLS websocket: " << ec.message();
         // on_close_tls wont be called here so we have to call the closed_callback manually
-        this->closed_callback(websocketpp::close::status::abnormal_close);
+        this->closed_callback(websocketpp::close::status::abnormal_close, true);
     } else {
         EVLOG_info << "Closed TLS websocket successfully.";
     }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -153,22 +153,24 @@ void ChargePointImpl::init_websocket() {
         this->message_queue->resume(); //
         this->connected_callback();    //
     });
-    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason) {
+    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason, const bool doFull) {
         if (this->connection_state_changed_callback != nullptr) {
             this->connection_state_changed_callback(false);
         }
-        this->message_queue->pause(); //
-        if (this->ocsp_request_timer != nullptr) {
-            this->ocsp_request_timer->stop();
-        }
-        if (this->switch_security_profile_callback != nullptr) {
-            this->switch_security_profile_callback();
-        }
-        if (this->client_certificate_timer != nullptr) {
-            this->client_certificate_timer->stop();
-        }
-        if (this->v2g_certificate_timer != nullptr) {
-            this->v2g_certificate_timer->stop();
+        if (doFull) {
+            this->message_queue->pause(); //
+            if (this->ocsp_request_timer != nullptr) {
+                this->ocsp_request_timer->stop();
+            }
+            if (this->switch_security_profile_callback != nullptr) {
+                this->switch_security_profile_callback();
+            }
+            if (this->client_certificate_timer != nullptr) {
+                this->client_certificate_timer->stop();
+            }
+            if (this->v2g_certificate_timer != nullptr) {
+                this->v2g_certificate_timer->stop();
+            }
         }
     });
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -153,26 +153,27 @@ void ChargePointImpl::init_websocket() {
         this->message_queue->resume(); //
         this->connected_callback();    //
     });
-    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason, const bool doFull) {
-        if (this->connection_state_changed_callback != nullptr) {
-            this->connection_state_changed_callback(false);
-        }
-        if (doFull) {
-            this->message_queue->pause(); //
-            if (this->ocsp_request_timer != nullptr) {
-                this->ocsp_request_timer->stop();
+    this->websocket->register_closed_callback(
+        [this](const websocketpp::close::status::value reason, const bool doFull) {
+            if (this->connection_state_changed_callback != nullptr) {
+                this->connection_state_changed_callback(false);
             }
-            if (this->switch_security_profile_callback != nullptr) {
-                this->switch_security_profile_callback();
+            if (doFull) {
+                this->message_queue->pause(); //
+                if (this->ocsp_request_timer != nullptr) {
+                    this->ocsp_request_timer->stop();
+                }
+                if (this->switch_security_profile_callback != nullptr) {
+                    this->switch_security_profile_callback();
+                }
+                if (this->client_certificate_timer != nullptr) {
+                    this->client_certificate_timer->stop();
+                }
+                if (this->v2g_certificate_timer != nullptr) {
+                    this->v2g_certificate_timer->stop();
+                }
             }
-            if (this->client_certificate_timer != nullptr) {
-                this->client_certificate_timer->stop();
-            }
-            if (this->v2g_certificate_timer != nullptr) {
-                this->v2g_certificate_timer->stop();
-            }
-        }
-    });
+        });
 
     this->websocket->register_message_callback([this](const std::string& message) { this->message_callback(message); });
 }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -577,7 +577,7 @@ void ChargePoint::init_websocket() {
     });
 
     this->websocket->register_closed_callback(
-        [this, connection_options, configuration_slot](const websocketpp::close::status::value reason) {
+        [this, connection_options, configuration_slot](const websocketpp::close::status::value reason, const bool doFull) {
             EVLOG_warning << "Failed to connect to NetworkConfigurationPriority: "
                           << this->network_configuration_priority + 1
                           << " which is configurationSlot: " << configuration_slot;


### PR DESCRIPTION
After a reconnect, the connection call back is retriggered to inform the upper business logic that the connection is valid again. A boolean is used to avoid the reinit of the Message queue.
