### PR TITLE
Move disconnected_time to websocket

### DIFF
--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -41,6 +41,8 @@ public:
     /// \brief indicates if the websocket is connected
     bool is_connected();
 
+    std::chrono::time_point<std::chrono::steady_clock> get_disconnected_time_point();
+
     /// \brief register a \p callback that is called when the websocket is connected successfully
     void register_connected_callback(const std::function<void(const int security_profile)>& callback);
 

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -58,6 +58,7 @@ protected:
     int connection_attempts;
     bool shutting_down;
     bool reconnecting;
+    std::chrono::time_point<std::chrono::steady_clock> disconnected_time_point;
 
     /// \brief Indicates if the required callbacks are registered
     /// \returns true if the websocket is properly initialized
@@ -102,6 +103,8 @@ public:
 
     /// \brief indicates if the websocket is connected
     bool is_connected();
+
+    std::chrono::time_point<std::chrono::steady_clock> get_disconnected_time_point();
 
     /// \brief closes the websocket
     virtual void close(websocketpp::close::status::value code, const std::string& reason) = 0;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -137,7 +137,6 @@ private:
 
     // states
     RegistrationStatusEnum registration_status;
-    WebsocketConnectionStatusEnum websocket_connection_status;
     OperationalStatusEnum operational_state;
     FirmwareStatusEnum firmware_status;
     int32_t firmware_status_id;

--- a/include/ocpp/v201/types.hpp
+++ b/include/ocpp/v201/types.hpp
@@ -157,26 +157,6 @@ MessageType string_to_messagetype(const std::string& s);
 /// \returns an output stream with the MessageType written to
 std::ostream& operator<<(std::ostream& os, const MessageType& message_type);
 
-enum class WebsocketConnectionStatusEnum {
-    Connected,
-    Disconnected
-};
-
-namespace conversions {
-/// \brief Converts the given WebsocketConnectionStatusEnum \p m to std::string
-/// \returns a string representation of the WebsocketConnectionStatusEnum
-std::string websocket_connection_status_to_string(WebsocketConnectionStatusEnum m);
-
-/// \brief Converts the given std::string \p s to WebsocketConnectionStatusEnum
-/// \returns a WebsocketConnectionStatusEnum from a string representation
-WebsocketConnectionStatusEnum string_to_websocket_connection_status(const std::string& s);
-
-} // namespace conversions
-
-/// \brief Writes the string representation of the given \p websocket_connection_status to the given output stream \p os
-/// \returns an output stream with the WebsocketConnectionStatusEnum written to
-std::ostream& operator<<(std::ostream& os, const WebsocketConnectionStatusEnum& websocket_connection_status);
-
 } // namespace v201
 } // namespace ocpp
 

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -49,6 +49,10 @@ bool Websocket::is_connected() {
     return this->websocket->is_connected();
 }
 
+std::chrono::time_point<std::chrono::steady_clock> Websocket::get_disconnected_time_point() {
+    return this->websocket->get_disconnected_time_point();
+}
+
 void Websocket::register_connected_callback(const std::function<void(const int security_profile)>& callback) {
     this->connected_callback = callback;
 

--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -86,6 +86,10 @@ bool WebsocketBase::is_connected() {
     return this->m_is_connected;
 }
 
+std::chrono::time_point<std::chrono::steady_clock> WebsocketBase::get_disconnected_time_point() {
+    return this->disconnected_time_point;
+}
+
 std::optional<std::string> WebsocketBase::getAuthorizationHeader() {
     std::optional<std::string> auth_header = std::nullopt;
     const auto authorization_key = this->connection_options.authorization_key;

--- a/lib/ocpp/common/websocket/websocket_plain.cpp
+++ b/lib/ocpp/common/websocket/websocket_plain.cpp
@@ -175,6 +175,7 @@ void WebsocketPlain::on_open_plain(client* c, websocketpp::connection_hdl hdl) {
     this->reconnecting = false;
     this->set_websocket_ping_interval(this->connection_options.ping_interval_s);
     this->connected_callback(this->connection_options.security_profile);
+    this->disconnected_time_point = std::chrono::time_point<std::chrono::steady_clock>();
 }
 
 void WebsocketPlain::on_message_plain(websocketpp::connection_hdl hdl, client::message_ptr msg) {
@@ -193,6 +194,8 @@ void WebsocketPlain::on_message_plain(websocketpp::connection_hdl hdl, client::m
 void WebsocketPlain::on_close_plain(client* c, websocketpp::connection_hdl hdl) {
     std::lock_guard<std::mutex> lk(this->connection_mutex);
     this->m_is_connected = false;
+    // Get the current time point using steady_clock
+    this->disconnected_time_point = std::chrono::steady_clock::now();
     this->cancel_reconnect_timer();
     client::connection_ptr con = c->get_con_from_hdl(hdl);
     auto error_code = con->get_ec();
@@ -210,6 +213,8 @@ void WebsocketPlain::on_close_plain(client* c, websocketpp::connection_hdl hdl) 
 void WebsocketPlain::on_fail_plain(client* c, websocketpp::connection_hdl hdl) {
     std::lock_guard<std::mutex> lk(this->connection_mutex);
     this->m_is_connected = false;
+    // Get the current time point using steady_clock
+    this->disconnected_time_point = std::chrono::steady_clock::now();
     this->connection_attempts += 1;
     client::connection_ptr con = c->get_con_from_hdl(hdl);
     const auto ec = con->get_ec();

--- a/lib/ocpp/v201/types.cpp
+++ b/lib/ocpp/v201/types.cpp
@@ -543,37 +543,5 @@ std::ostream& operator<<(std::ostream& os, const MessageType& message_type) {
     return os;
 }
 
-namespace conversions {
-
-std::string websocket_connection_status_to_string(WebsocketConnectionStatusEnum m) {
-    switch (m) {
-    case WebsocketConnectionStatusEnum::Connected:
-        return "Connected";
-    case WebsocketConnectionStatusEnum::Disconnected:
-        return "Disconnected";
-    default:
-        throw std::out_of_range("No known string conversion for provided enum of type MessageType");
-    }
-}
-
-/// \brief Converts the given std::string \p s to WebsocketConnectionStatusEnum
-/// \returns a WebsocketConnectionStatusEnum from a string representation
-WebsocketConnectionStatusEnum string_to_websocket_connection_status(const std::string& s) {
-    if (s == "Connected") {
-        return WebsocketConnectionStatusEnum::Connected;
-    } else if (s == "Disconnected") {
-        return WebsocketConnectionStatusEnum::Disconnected;
-    }
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type WebsocketConnectionStatusEnum");
-}
-
-} // namespace conversions
-
-std::ostream& operator<<(std::ostream& os, const WebsocketConnectionStatusEnum& websocket_connection_status) {
-    os << conversions::websocket_connection_status_to_string(websocket_connection_status);
-    return os;
-}
-
 } // namespace v201
 } // namespace ocpp


### PR DESCRIPTION
moved disconnected time to websocket, because closed_callback isnt always executed when the websocket disconnects / fails. The websocket attempts to reconnect independently without executing the closed callback in certain situations