### PR TITLE
Added disconnected callback to websocket to track disconnected_time (for OfflineThreshold) correctly

### DIFF
--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -17,6 +17,7 @@ private:
     // unique_ptr holds address of base - requires WebSocketBase to have a virtual destructor
     std::unique_ptr<WebsocketBase> websocket;
     std::function<void(const int security_profile)> connected_callback;
+    std::function<void()> disconnected_callback;
     std::function<void(const websocketpp::close::status::value reason)> closed_callback;
     std::function<void(const std::string& message)> message_callback;
     std::shared_ptr<MessageLogging> logging;
@@ -43,6 +44,9 @@ public:
 
     /// \brief register a \p callback that is called when the websocket is connected successfully
     void register_connected_callback(const std::function<void(const int security_profile)>& callback);
+
+    /// \brief register a \p callback that is called when the websocket connection is disconnected
+    void register_disconnected_callback(const std::function<void()>& callback);
 
     /// \brief register a \p callback that is called when the websocket connection has been closed and will not attempt
     /// to reconnect

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -45,6 +45,7 @@ protected:
     bool m_is_connected;
     WebsocketConnectionOptions connection_options;
     std::function<void(const int security_profile)> connected_callback;
+    std::function<void()> disconnected_callback;
     std::function<void(const websocketpp::close::status::value reason)> closed_callback;
     std::function<void(const std::string& message)> message_callback;
     websocketpp::lib::shared_ptr<boost::asio::steady_timer> reconnect_timer;
@@ -108,6 +109,9 @@ public:
 
     /// \brief register a \p callback that is called when the websocket is connected successfully
     void register_connected_callback(const std::function<void(const int security_profile)>& callback);
+
+    /// \brief register a \p callback that is called when the websocket connection is disconnected
+    void register_disconnected_callback(const std::function<void()>& callback);
 
     /// \brief register a \p callback that is called when the websocket connection has been closed and will not attempt
     /// to reconnect

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -141,7 +141,6 @@ private:
 
     // states
     RegistrationStatusEnum registration_status;
-    WebsocketConnectionStatusEnum websocket_connection_status;
     OperationalStatusEnum operational_state;
     FirmwareStatusEnum firmware_status;
     int32_t firmware_status_id;

--- a/include/ocpp/v201/types.hpp
+++ b/include/ocpp/v201/types.hpp
@@ -157,26 +157,6 @@ MessageType string_to_messagetype(const std::string& s);
 /// \returns an output stream with the MessageType written to
 std::ostream& operator<<(std::ostream& os, const MessageType& message_type);
 
-enum class WebsocketConnectionStatusEnum {
-    Connected,
-    Disconnected
-};
-
-namespace conversions {
-/// \brief Converts the given WebsocketConnectionStatusEnum \p m to std::string
-/// \returns a string representation of the WebsocketConnectionStatusEnum
-std::string websocket_connection_status_to_string(WebsocketConnectionStatusEnum m);
-
-/// \brief Converts the given std::string \p s to WebsocketConnectionStatusEnum
-/// \returns a WebsocketConnectionStatusEnum from a string representation
-WebsocketConnectionStatusEnum string_to_websocket_connection_status(const std::string& s);
-
-} // namespace conversions
-
-/// \brief Writes the string representation of the given \p websocket_connection_status to the given output stream \p os
-/// \returns an output stream with the WebsocketConnectionStatusEnum written to
-std::ostream& operator<<(std::ostream& os, const WebsocketConnectionStatusEnum& websocket_connection_status);
-
 } // namespace v201
 } // namespace ocpp
 

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -58,13 +58,20 @@ void Websocket::register_connected_callback(const std::function<void(const int s
     });
 }
 
+void Websocket::register_disconnected_callback(const std::function<void()>& callback) {
+    this->disconnected_callback = callback;
+
+    this->websocket->register_disconnected_callback([this]() {
+        this->logging->sys("Disconnected");
+        this->disconnected_callback();
+    });
+}
+
 void Websocket::register_closed_callback(
     const std::function<void(const websocketpp::close::status::value reason)>& callback) {
     this->closed_callback = callback;
-    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason) {
-        this->logging->sys("Disconnected");
-        this->closed_callback(reason);
-    });
+    this->websocket->register_closed_callback(
+        [this](const websocketpp::close::status::value reason) { this->closed_callback(reason); });
 }
 
 void Websocket::register_message_callback(const std::function<void(const std::string& message)>& callback) {

--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -37,6 +37,10 @@ void WebsocketBase::register_connected_callback(const std::function<void(const i
     this->connected_callback = callback;
 }
 
+void WebsocketBase::register_disconnected_callback(const std::function<void()>& callback) {
+    this->disconnected_callback = callback;
+}
+
 void WebsocketBase::register_closed_callback(
     const std::function<void(const websocketpp::close::status::value reason)>& callback) {
     this->closed_callback = callback;

--- a/lib/ocpp/common/websocket/websocket_tls.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls.cpp
@@ -282,6 +282,7 @@ void WebsocketTLS::on_message_tls(websocketpp::connection_hdl hdl, tls_client::m
 void WebsocketTLS::on_close_tls(tls_client* c, websocketpp::connection_hdl hdl) {
     std::lock_guard<std::mutex> lk(this->connection_mutex);
     this->m_is_connected = false;
+    this->disconnected_callback();
     this->cancel_reconnect_timer();
     tls_client::connection_ptr con = c->get_con_from_hdl(hdl);
     auto error_code = con->get_ec();
@@ -299,6 +300,7 @@ void WebsocketTLS::on_close_tls(tls_client* c, websocketpp::connection_hdl hdl) 
 void WebsocketTLS::on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl) {
     std::lock_guard<std::mutex> lk(this->connection_mutex);
     this->m_is_connected = false;
+    this->disconnected_callback();
     this->connection_attempts += 1;
     tls_client::connection_ptr con = c->get_con_from_hdl(hdl);
     const auto ec = con->get_ec();

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -153,7 +153,7 @@ void ChargePointImpl::init_websocket() {
         this->message_queue->resume(); //
         this->connected_callback();    //
     });
-    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason) {
+    this->websocket->register_disconnected_callback([this]() {
         if (this->connection_state_changed_callback != nullptr) {
             this->connection_state_changed_callback(false);
         }
@@ -161,14 +161,16 @@ void ChargePointImpl::init_websocket() {
         if (this->ocsp_request_timer != nullptr) {
             this->ocsp_request_timer->stop();
         }
-        if (this->switch_security_profile_callback != nullptr) {
-            this->switch_security_profile_callback();
-        }
         if (this->client_certificate_timer != nullptr) {
             this->client_certificate_timer->stop();
         }
         if (this->v2g_certificate_timer != nullptr) {
             this->v2g_certificate_timer->stop();
+        }
+    });
+    this->websocket->register_closed_callback([this](const websocketpp::close::status::value reason) {
+        if (this->switch_security_profile_callback != nullptr) {
+            this->switch_security_profile_callback();
         }
     });
 

--- a/lib/ocpp/v201/types.cpp
+++ b/lib/ocpp/v201/types.cpp
@@ -543,37 +543,5 @@ std::ostream& operator<<(std::ostream& os, const MessageType& message_type) {
     return os;
 }
 
-namespace conversions {
-
-std::string websocket_connection_status_to_string(WebsocketConnectionStatusEnum m) {
-    switch (m) {
-    case WebsocketConnectionStatusEnum::Connected:
-        return "Connected";
-    case WebsocketConnectionStatusEnum::Disconnected:
-        return "Disconnected";
-    default:
-        throw std::out_of_range("No known string conversion for provided enum of type MessageType");
-    }
-}
-
-/// \brief Converts the given std::string \p s to WebsocketConnectionStatusEnum
-/// \returns a WebsocketConnectionStatusEnum from a string representation
-WebsocketConnectionStatusEnum string_to_websocket_connection_status(const std::string& s) {
-    if (s == "Connected") {
-        return WebsocketConnectionStatusEnum::Connected;
-    } else if (s == "Disconnected") {
-        return WebsocketConnectionStatusEnum::Disconnected;
-    }
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type WebsocketConnectionStatusEnum");
-}
-
-} // namespace conversions
-
-std::ostream& operator<<(std::ostream& os, const WebsocketConnectionStatusEnum& websocket_connection_status) {
-    os << conversions::websocket_connection_status_to_string(websocket_connection_status);
-    return os;
-}
-
 } // namespace v201
 } // namespace ocpp


### PR DESCRIPTION
closed_callback isn't always executed when the websocket disconnects / fails. The websocket attempts to reconnect independently without executing the closed callback in certain situations. Therefore a disconnected_callback is added to the websocket in order to notify the chargepoint in case of a disconnect, so that the disconnected_time can be tracked properly