### PR TITLE
Close libocpp gracefully

### DIFF
--- a/include/ocpp/common/charging_station_base.hpp
+++ b/include/ocpp/common/charging_station_base.hpp
@@ -39,7 +39,7 @@ public:
     /// implementation
     explicit ChargingStationBase(const std::shared_ptr<EvseSecurity> evse_security,
                                  const std::optional<SecurityConfiguration> security_configuration = std::nullopt);
-    virtual ~ChargingStationBase(){};
+    virtual ~ChargingStationBase();
 };
 
 } // namespace ocpp

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -410,7 +410,8 @@ public:
     void connect_websocket();
 
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
-    void disconnect_websocket();
+    /// \param code Optional websocket close status code (default: normal).
+    void disconnect_websocket(websocketpp::close::status::value code = websocketpp::close::status::normal);
 
     /// \brief Chargepoint notifies about new firmware update status firmware_update_status. This function should be
     ///        called during a Firmware Update to indicate the current firmware_update_status.

--- a/lib/ocpp/common/charging_station_base.cpp
+++ b/lib/ocpp/common/charging_station_base.cpp
@@ -22,8 +22,7 @@ ChargingStationBase::ChargingStationBase(const std::shared_ptr<EvseSecurity> evs
     this->io_service_thread = std::thread([this]() { this->io_service.run(); });
 }
 
-ChargingStationBase::~ChargingStationBase()
-{
+ChargingStationBase::~ChargingStationBase() {
     work->get_io_context().stop();
     io_service.stop();
     io_service_thread.join();

--- a/lib/ocpp/common/charging_station_base.cpp
+++ b/lib/ocpp/common/charging_station_base.cpp
@@ -22,6 +22,13 @@ ChargingStationBase::ChargingStationBase(const std::shared_ptr<EvseSecurity> evs
     this->io_service_thread = std::thread([this]() { this->io_service.run(); });
 }
 
+ChargingStationBase::~ChargingStationBase()
+{
+    work->get_io_context().stop();
+    io_service.stop();
+    io_service_thread.join();
+}
+
 std::string ChargingStationBase::uuid() {
     std::stringstream s;
     s << this->uuid_generator();

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -151,7 +151,7 @@ void ChargePoint::stop() {
     this->heartbeat_timer.stop();
     this->boot_notification_timer.stop();
     this->websocket_timer.stop();
-    this->websocket->disconnect(websocketpp::close::status::normal);
+    this->disconnect_websocket();
     this->message_queue->stop();
 }
 
@@ -164,9 +164,11 @@ void ChargePoint::connect_websocket() {
 }
 
 void ChargePoint::disconnect_websocket() {
-    if (this->websocket->is_connected()) {
-        this->disable_automatic_websocket_reconnects = true;
-        this->websocket->disconnect(websocketpp::close::status::normal);
+    if (this->websocket != nullptr) {
+        if (this->websocket->is_connected()) {
+            this->disable_automatic_websocket_reconnects = true;
+            this->websocket->disconnect(websocketpp::close::status::normal);
+        }
     }
 }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -151,7 +151,7 @@ void ChargePoint::stop() {
     this->heartbeat_timer.stop();
     this->boot_notification_timer.stop();
     this->websocket_timer.stop();
-    this->disconnect_websocket();
+    this->disconnect_websocket(websocketpp::close::status::going_away);
     this->message_queue->stop();
 }
 
@@ -163,11 +163,11 @@ void ChargePoint::connect_websocket() {
     }
 }
 
-void ChargePoint::disconnect_websocket() {
+void ChargePoint::disconnect_websocket(websocketpp::close::status::value code) {
     if (this->websocket != nullptr) {
         if (this->websocket->is_connected()) {
             this->disable_automatic_websocket_reconnects = true;
-            this->websocket->disconnect(websocketpp::close::status::normal);
+            this->websocket->disconnect(code);
         }
     }
 }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -151,7 +151,7 @@ void ChargePoint::stop() {
     this->heartbeat_timer.stop();
     this->boot_notification_timer.stop();
     this->websocket_timer.stop();
-    this->websocket->disconnect(websocketpp::close::status::going_away);
+    this->websocket->disconnect(websocketpp::close::status::normal);
     this->message_queue->stop();
 }
 


### PR DESCRIPTION
To allow closing libocpp gracefully, some error checking to `ChargePoint::stop()` is added so it does not Segfault after an exception during init/start. Also active threads should be joined.