### PR TITLE
Change data transfer API for 1.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.9.4
+    VERSION 0.9.5
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -139,8 +139,8 @@ public:
     /// \param messageId
     /// \param data
     /// \return
-    DataTransferResponse data_transfer(const CiString<255>& vendorId, const CiString<50>& messageId,
-                                       const std::string& data);
+    DataTransferResponse data_transfer(const CiString<255>& vendorId, const std::optional<CiString<50>>& messageId,
+                                       const std::optional<std::string>& data);
 
     /// \brief Calculates ChargingProfiles configured by the CSMS of all connectors from now until now + given \p
     /// duration_s
@@ -284,6 +284,12 @@ public:
     void register_data_transfer_callback(
         const CiString<255>& vendorId, const CiString<50>& messageId,
         const std::function<DataTransferResponse(const std::optional<std::string>& msg)>& callback);
+
+    /// registers a \p callback function that can be used to handle arbitrary data transfers for all vendorId an
+    /// messageId
+    /// \param callback
+    void register_data_transfer_callback(
+        const std::function<DataTransferResponse(const DataTransferRequest& request)>& callback);
 
     /// \brief registers a \p callback function that can be used to enable the evse. The enable_evse_callback is called
     /// when a ChangeAvailaibility.req is received.

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -123,6 +123,7 @@ private:
     std::map<std::string,
              std::map<std::string, std::function<DataTransferResponse(const std::optional<std::string>& msg)>>>
         data_transfer_callbacks;
+    std::function<DataTransferResponse(const DataTransferRequest& request)> data_transfer_callback;
     std::map<std::string, std::function<void(Call<DataTransferRequest> call)>> data_transfer_pnc_callbacks;
     std::mutex data_transfer_callbacks_mutex;
     std::map<CiString<50>, std::function<void(const KeyValue& key_value)>> configuration_key_changed_callbacks;
@@ -402,8 +403,8 @@ public:
     /// \param messageId
     /// \param data
     /// \return
-    DataTransferResponse data_transfer(const CiString<255>& vendorId, const CiString<50>& messageId,
-                                       const std::string& data);
+    DataTransferResponse data_transfer(const CiString<255>& vendorId, const std::optional<CiString<50>>& messageId,
+                                       const std::optional<std::string>& data);
 
     /// \brief Calculates ChargingProfiles configured by the CSMS of all connectors from now until now + given \p
     /// duration_s
@@ -547,6 +548,12 @@ public:
     void register_data_transfer_callback(
         const CiString<255>& vendorId, const CiString<50>& messageId,
         const std::function<DataTransferResponse(const std::optional<std::string>& msg)>& callback);
+
+    /// registers a \p callback function that can be used to handle arbitrary data transfers for all vendorId an
+    /// messageId
+    /// \param callback
+    void register_data_transfer_callback(
+        const std::function<DataTransferResponse(const DataTransferRequest& request)>& callback);
 
     /// \brief registers a \p callback function that can be used to enable the evse. The enable_evse_callback is called
     /// when a ChangeAvailaibility.req is received.

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -64,8 +64,9 @@ void ChargePoint::data_transfer_pnc_get_15118_ev_certificate(
                                                                    certificate_action);
 }
 
-DataTransferResponse ChargePoint::data_transfer(const CiString<255>& vendorId, const CiString<50>& messageId,
-                                                const std::string& data) {
+DataTransferResponse ChargePoint::data_transfer(const CiString<255>& vendorId,
+                                                const std::optional<CiString<50>>& messageId,
+                                                const std::optional<std::string>& data) {
     return this->charge_point->data_transfer(vendorId, messageId, data);
 }
 
@@ -165,6 +166,11 @@ void ChargePoint::register_data_transfer_callback(
     const CiString<255>& vendorId, const CiString<50>& messageId,
     const std::function<DataTransferResponse(const std::optional<std::string>& msg)>& callback) {
     this->charge_point->register_data_transfer_callback(vendorId, messageId, callback);
+}
+
+void ChargePoint::register_data_transfer_callback(
+    const std::function<DataTransferResponse(const DataTransferRequest& request)>& callback) {
+    this->charge_point->register_data_transfer_callback(callback);
 }
 
 void ChargePoint::register_enable_evse_callback(const std::function<bool(int32_t connector)>& callback) {


### PR DESCRIPTION
Change function signature of data_transfer to take optional parameters

Add register_data_transfer_callback function that registeres a general callback for all data transfers. This callback is only called if no specific callbacks for a vendorId or messageId were installed