### PR TITLE
Do not send InstallScheduled when changing connectors to unavailable

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -220,11 +220,6 @@ void ChargePoint::on_firmware_update_status_notification(int32_t request_id,
     }
 
     if (this->firmware_status_before_installing == req.status) {
-        this->firmware_status = FirmwareStatusEnum::InstallScheduled;
-        req.status = firmware_status;
-        ocpp::Call<FirmwareStatusNotificationRequest> call(req, this->message_queue->createMessageId());
-        this->send_async<FirmwareStatusNotificationRequest>(call);
-
         this->change_all_connectors_to_unavailable_for_firmware_update();
     }
 }


### PR DESCRIPTION
This was accidentally sent all the time but is only valid if there is a transaction ongoing

Fix verified against OCTT tests
    TC_L_01_CS
    TC_L_02_CS
    TC_L_03_CS
    TC_L_05_CS
    TC_L_06_CS
    TC_L_07_CS
    TC_L_08_CS
    TC_L_10_CS
    TC_L_15_CS
    TC_L_18_CS