### PR TITLE
Use sqlite_close_v2()

### DIFF
--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -129,7 +129,7 @@ void DatabaseHandler::open_connection() {
 }
 
 void DatabaseHandler::close_connection() {
-    if (sqlite3_close(this->db) == SQLITE_OK) {
+    if (sqlite3_close_v2(this->db) == SQLITE_OK) {
         EVLOG_debug << "Successfully closed database: " << this->database_file_path;
     } else {
         EVLOG_error << "Error closing database file: " << sqlite3_errmsg(this->db);


### PR DESCRIPTION
Use `sqlite3_close_v2()` instead of `sqlite3_close().` Since we use the close in a destructor and and a destructor shoudn't fail. We should use the `sqlite3_close_v2()` instead since it will automatically deallocate the database connection after all prepared statements are finalized, all BLOB handles are closed, and all backups have finished.

[sqlite_close documentation](https://www.sqlite.org/c3ref/close.html)