### PR TITLE
OCPP 2.0.1: Remove optional StatusNotifications on reset

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -2221,15 +2221,6 @@ void ChargePoint::handle_reset_req(Call<ResetRequest> call) {
     }
 
     if (response.status == ResetStatusEnum::Accepted) {
-        if (call.msg.evseId.has_value()) {
-            // B11.FR.08
-            this->evses.at(call.msg.evseId.value())->submit_event(1, ConnectorEvent::Unavailable);
-        } else {
-            // B11.FR.03
-            for (auto const& [evse_id, evse] : this->evses) {
-                evse->submit_event(1, ConnectorEvent::Unavailable);
-            }
-        }
         this->callbacks.reset_callback(call.msg.evseId, ResetEnum::Immediate);
     }
 }


### PR DESCRIPTION
This PR removes some "Unavailable" StatusNotifications sent before a reset. Those are optional (B11.FR.03, B11.FR.08), and omitting them helps with passing some tests.