### PR TITLE
OCPP 1.6 Fix: add flag for pending firmware update

### DIFF
--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -91,6 +91,7 @@ private:
     RegistrationStatus registration_status;
     DiagnosticsStatus diagnostics_status;
     FirmwareStatus firmware_status;
+    bool firmware_update_is_pending = false;
     UploadLogStatusEnumType log_status;
     std::string message_log_path;
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2380,7 +2380,7 @@ void ChargePointImpl::signed_firmware_update_status_notification(FirmwareStatusE
     req.requestId = requestId;
 
     // The "SignatureVerified" status signals a firmware update is pending which will cause connectors to be set
-    // unavailable (now or after pending transactions are stopped); in case of a status that signals failed firmware
+    // inoperative (now or after pending transactions are stopped); in case of a status that signals a failed firmware
     // update this is revoked
     if (status == FirmwareStatusEnumType::SignatureVerified) {
         this->firmware_update_is_pending = true;
@@ -3411,9 +3411,9 @@ void ChargePointImpl::firmware_status_notification(FirmwareStatus status) {
     FirmwareStatusNotificationRequest req;
     req.status = status;
 
-    // The "Downloaded" status signals a firmware update is pending which will cause connectors to be set unavailable
-    // (now or after pending transactions are stopped); in case of a status that signals failed firmware update this is
-    // revoked
+    // The "Downloaded" status signals a firmware update is pending which will cause connectors to be set inoperative
+    // (now or after pending transactions are stopped); in case of a status that signals a failed firmware update this
+    // is// revoked
     if (status == FirmwareStatus::Downloaded) {
         this->firmware_update_is_pending = true;
     } else if (status == FirmwareStatus::DownloadFailed || status == FirmwareStatus::InstallationFailed) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -824,6 +824,9 @@ void ChargePointImpl::change_all_connectors_to_unavailable_for_firmware_update()
     int32_t number_of_connectors = this->configuration->getNumberOfConnectors();
     for (int32_t connector = 1; connector <= number_of_connectors; connector++) {
         if (this->transaction_handler->transaction_active(connector)) {
+            EVLOG_debug << "change_all_connectors_to_unavailable_for_firmware_update: detected running Transaction on "
+                           "connector "
+                        << connector;
             transaction_running = true;
             std::lock_guard<std::mutex> change_availability_lock(change_availability_mutex);
             this->change_availability_queue[connector] = {AvailabilityType::Inoperative, false};
@@ -1805,8 +1808,7 @@ void ChargePointImpl::handleStopTransactionResponse(const EnhancedMessage<v16::M
     // when this transaction was stopped because of a Reset.req this signals that StopTransaction.conf has been received
     this->stop_transaction_cv.notify_one();
 
-    if (this->firmware_status == FirmwareStatus::Downloaded or
-        this->signed_firmware_status == FirmwareStatusEnumType::SignatureVerified) {
+    if (this->firmware_update_is_pending) {
         this->change_all_connectors_to_unavailable_for_firmware_update();
     }
 }
@@ -2371,10 +2373,20 @@ void ChargePointImpl::log_status_notification(UploadLogStatusEnumType status, in
 }
 
 void ChargePointImpl::signed_firmware_update_status_notification(FirmwareStatusEnumType status, int requestId) {
-    EVLOG_debug << "Sending FirmwareUpdateStatusNotification";
+    EVLOG_debug << "Sending FirmwareUpdateStatusNotification with status"
+                << conversions::firmware_status_enum_type_to_string(status);
     SignedFirmwareStatusNotificationRequest req;
     req.status = status;
     req.requestId = requestId;
+
+    if (status == FirmwareStatusEnumType::SignatureVerified) {
+        this->firmware_update_is_pending = true;
+    } else if (status == FirmwareStatusEnumType::InstallationFailed ||
+               status == FirmwareStatusEnumType::DownloadFailed ||
+               status == FirmwareStatusEnumType::InstallVerificationFailed ||
+               status == FirmwareStatusEnumType::InvalidSignature) {
+        this->firmware_update_is_pending = false;
+    }
 
     this->signed_firmware_status = status;
     this->signed_firmware_status_request_id = requestId;
@@ -2386,7 +2398,7 @@ void ChargePointImpl::signed_firmware_update_status_notification(FirmwareStatusE
         this->securityEventNotification("InvalidFirmwareSignature", "", true);
     }
 
-    if (this->signed_firmware_status == FirmwareStatusEnumType::SignatureVerified) {
+    if (this->firmware_update_is_pending) {
         this->change_all_connectors_to_unavailable_for_firmware_update();
     }
 }
@@ -3390,14 +3402,23 @@ void ChargePointImpl::diagnostic_status_notification(DiagnosticsStatus status) {
 }
 
 void ChargePointImpl::firmware_status_notification(FirmwareStatus status) {
+
+    EVLOG_debug << "Received FirmwareUpdateStatusNotification with status"
+                << conversions::firmware_status_to_string(status);
     FirmwareStatusNotificationRequest req;
     req.status = status;
+    if (status == FirmwareStatus::Downloaded) {
+        this->firmware_update_is_pending = true;
+    } else if (status == FirmwareStatus::DownloadFailed || status == FirmwareStatus::InstallationFailed) {
+        this->firmware_update_is_pending = false;
+    }
+
     this->firmware_status = status;
 
     ocpp::Call<FirmwareStatusNotificationRequest> call(req, this->message_queue->createMessageId());
     this->send_async<FirmwareStatusNotificationRequest>(call);
 
-    if (this->firmware_status == FirmwareStatus::Downloaded) {
+    if (this->firmware_update_is_pending) {
         this->change_all_connectors_to_unavailable_for_firmware_update();
     }
 }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3413,7 +3413,7 @@ void ChargePointImpl::firmware_status_notification(FirmwareStatus status) {
 
     // The "Downloaded" status signals a firmware update is pending which will cause connectors to be set inoperative
     // (now or after pending transactions are stopped); in case of a status that signals a failed firmware update this
-    // is// revoked
+    // is revoked
     if (status == FirmwareStatus::Downloaded) {
         this->firmware_update_is_pending = true;
     } else if (status == FirmwareStatus::DownloadFailed || status == FirmwareStatus::InstallationFailed) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2379,6 +2379,9 @@ void ChargePointImpl::signed_firmware_update_status_notification(FirmwareStatusE
     req.status = status;
     req.requestId = requestId;
 
+    // The "SignatureVerified" status signals a firmware update is pending which will cause connectors to be set
+    // unavailable (now or after pending transactions are stopped); in case of a status that signals failed firmware
+    // update this is revoked
     if (status == FirmwareStatusEnumType::SignatureVerified) {
         this->firmware_update_is_pending = true;
     } else if (status == FirmwareStatusEnumType::InstallationFailed ||
@@ -3407,6 +3410,10 @@ void ChargePointImpl::firmware_status_notification(FirmwareStatus status) {
                 << conversions::firmware_status_to_string(status);
     FirmwareStatusNotificationRequest req;
     req.status = status;
+
+    // The "Downloaded" status signals a firmware update is pending which will cause connectors to be set unavailable
+    // (now or after pending transactions are stopped); in case of a status that signals failed firmware update this is
+    // revoked
     if (status == FirmwareStatus::Downloaded) {
         this->firmware_update_is_pending = true;
     } else if (status == FirmwareStatus::DownloadFailed || status == FirmwareStatus::InstallationFailed) {


### PR DESCRIPTION
In OCPP 1.6 , a flag that signals a pending firmware update is introduced. This fixes a bug in case the last received firmware status while a pending update is not "Downloaded" but something else (such as "Installing").