### PR TITLE
Fix regression: Add message queue "resuming" state

### DIFF
--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -731,9 +731,7 @@ public:
             EVLOG_debug << "Delaying message queue resume by " << delay_on_reconnect.count() << " seconds";
             u_int64_t expected_pause_resume_ctr = this->pause_resume_ctr;
             this->resume_timer.timeout(
-                [this, expected_pause_resume_ctr] {
-                    this->resume_now(expected_pause_resume_ctr);
-                }, delay_on_reconnect);
+                [this, expected_pause_resume_ctr] { this->resume_now(expected_pause_resume_ctr); }, delay_on_reconnect);
         } else {
             this->resume_now(this->pause_resume_ctr);
         }

--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -274,6 +274,7 @@ public:
         config(config),
         external_notify(external_notify),
         paused(true),
+        resuming(false),
         running(true),
         new_message(false),
         uuid_generator(boost::uuids::random_generator()) {


### PR DESCRIPTION
Normally, while the message queue is paused, non-transaction messages are dropped.

A previous PR introduced a regression: The message queue does not immediately resume when calling the `resume()` method, it only does so after a short delay. During this short delay, libocpp was trying to send `StatusNotification` messages to the CSMS, which were being dropped, leading to test failures.

This PR fixes this regression by adding a third condition on the message queue, "resuming". The message queue is resuming if it's paused, but `resume()` has been called and the queue will be resumed shortly. While the queue is resuming, non-transaction messages are not dropped.