### PR TITLE
OCPP1.6: Add internal availability change request API

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -18,6 +18,7 @@
 #include <ocpp/v16/messages/UpdateFirmware.hpp>
 
 // for OCPP1.6 PnC
+#include "ocpp/v16/messages/ChangeAvailability.hpp"
 #include <ocpp/v201/messages/Authorize.hpp>
 #include <ocpp/v201/messages/CertificateSigned.hpp>
 #include <ocpp/v201/messages/DeleteCertificate.hpp>
@@ -275,6 +276,10 @@ public:
     /// \param type type of the security event
     /// \param tech_info additional info of the security event
     void on_security_event(const std::string& type, const std::string& tech_info);
+
+    /// \brief Handles an internal ChangeAvailabilityRequest (in the same way as if it was emitted by the CSMS).
+    /// \param request
+    ChangeAvailabilityResponse on_change_availability(const ChangeAvailabilityRequest& request);
 
     /// registers a \p callback function that can be used to receive a arbitrary data transfer for the given \p
     /// vendorId and \p messageId

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -316,18 +316,22 @@ private:
     void handleSendLocalListRequest(Call<SendLocalListRequest> call);
     void handleGetLocalListVersionRequest(Call<GetLocalListVersionRequest> call);
 
-    // Preprocess a ChangeAvailabilityRequest: Determine response;
+    // //brief Preprocess a ChangeAvailabilityRequest: Determine response;
     // - if connector is 0, availability change is also propagated for all connectors
-    // - for each connector (except "0"), if transaction is ongoing the change is scheduled, otherwise the id is added
-    // to the `accepted_connector_availability_changes` vector
+    // - for each connector (except "0"), if transaction is ongoing the change is scheduled,
+    //    otherwise the OCPP connector id is appended to the `accepted_connector_availability_changes` vector
     void preprocess_change_availability_request(const ChangeAvailabilityRequest& request,
                                                 ChangeAvailabilityResponse& response,
                                                 std::vector<int32_t>& accepted_connector_availability_changes);
 
-    // Executes availability change for the provided connectors:
-    // - store availability in database
-    // - submit state event (for the whole evse if "0" in set of connectors; otherwise for each connector individually)
+    // \brief TExecutes availability change for the provided connectors:
+    // - if persist == true: store availability in database
+    // - submit state event (for the whole ChargePoint if "0" in set of connectors; otherwise for each connector
+    // individually)
     // - call according EVSE enable or disable callback, respectively
+    /// \param changed_connectors list of OCPP connector ids (and 0 for whole chargepoint)
+    /// \param availability new availabillity
+    /// \param persist if true, persists availability in database
     void execute_connectors_availability_change(const std::vector<int32_t>& changed_connectors,
                                                 const ocpp::v16::AvailabilityType availability, bool persist);
 

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -316,6 +316,10 @@ private:
     void handleSendLocalListRequest(Call<SendLocalListRequest> call);
     void handleGetLocalListVersionRequest(Call<GetLocalListVersionRequest> call);
 
+    // Handle internal or external ChangeAvailabilityRequest
+    void change_availability(const ChangeAvailabilityRequest& request,
+                             std::function<void(const ChangeAvailabilityResponse&)> response_callback);
+
 public:
     /// \brief The main entrypoint for libOCPP for OCPP 1.6
     /// \param config a nlohmann json config object that contains the libocpp 1.6 config. There are example configs that
@@ -550,6 +554,10 @@ public:
     /// \param type type of the security event
     /// \param tech_info additional info of the security event
     void on_security_event(const std::string& type, const std::string& tech_info);
+
+    /// \brief Handles an internal ChangeAvailabilityRequest (in the same way as if it was emitted by the CSMS).
+    /// \param request
+    ChangeAvailabilityResponse on_change_availability(const ChangeAvailabilityRequest& request);
 
     /// registers a \p callback function that can be used to receive a arbitrary data transfer for the given \p
     /// vendorId and \p messageId

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -163,7 +163,7 @@ void ChargePoint::on_security_event(const std::string& type, const std::string& 
 }
 
 ChangeAvailabilityResponse ChargePoint::on_change_availability(const ChangeAvailabilityRequest& request) {
-    this->charge_point->on_change_availability(request);
+    return this->charge_point->on_change_availability(request);
 }
 
 void ChargePoint::register_data_transfer_callback(

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -162,6 +162,10 @@ void ChargePoint::on_security_event(const std::string& type, const std::string& 
     this->charge_point->on_security_event(type, tech_info);
 }
 
+ChangeAvailabilityResponse ChargePoint::on_change_availability(const ChangeAvailabilityRequest& request) {
+    this->charge_point->on_change_availability(request);
+}
+
 void ChargePoint::register_data_transfer_callback(
     const CiString<255>& vendorId, const CiString<50>& messageId,
     const std::function<DataTransferResponse(const std::optional<std::string>& msg)>& callback) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3581,7 +3581,6 @@ void ChargePointImpl::on_security_event(const std::string& type, const std::stri
 }
 
 ChangeAvailabilityResponse ChargePointImpl::on_change_availability(const ChangeAvailabilityRequest& request) {
-
     EVLOG_debug << "Received internal ChangeAvailabilityRequest for connector " << request.connectorId << " to state "
                 << conversions::availability_type_to_string(request.type);
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1226,7 +1226,6 @@ void ChargePointImpl::preprocess_change_availability_request(
     // connector. is that case this change must be scheduled and we should report an availability status
     // of "Scheduled"
 
-
     // check if connector exists
     if (request.connectorId <= this->configuration->getNumberOfConnectors() && request.connectorId >= 0) {
         bool transaction_running = false;


### PR DESCRIPTION
Adds an internal API for availability change request (to be used in generic OCPP interface in EVerest). This allows for internally emitted availability change requests.

In detail:
- adds a public  `on_change_availability` method to `ocpp::v16::ChargePoint` and   `ocpp::v16::ChargePointImpl`
- refactors ` `ocpp::v16::ChargePointImpl:: handleChangeAvailabilityRequest `:
   - extract methods `preprocess_change_availability_request` and `execute_connectors_availability_change` (see docstrings for details) Note: the `preprocess_change_availability_request` is slightly simplified by just creating a list of connector ids that are valid for an availability change (instead of as primarily a map that used to only contain "Accepted" enums as values in the former implementation)
   - re-use `execute_connectors_availability_change` also in `handleStopTransactionResponse` 
   - re-use as well in in implementation of  `on_change_availability`
