### PR TITLE
Feature/fk block enable request

### DIFF
--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -322,7 +322,8 @@ private:
     //    otherwise the OCPP connector id is appended to the `accepted_connector_availability_changes` vector
     void preprocess_change_availability_request(const ChangeAvailabilityRequest& request,
                                                 ChangeAvailabilityResponse& response,
-                                                std::vector<int32_t>& accepted_connector_availability_changes);
+                                                std::vector<int32_t>& accepted_connector_availability_changes,
+                                                bool is_internal_request);
 
     // \brief TExecutes availability change for the provided connectors:
     // - if persist == true: store availability in database


### PR DESCRIPTION
Enables users to set a custom variable `BlockRemoteSetAvailableRequests` to block incoming ChangeAvailability requests that set the CS / a connector operative (cf. comments in code).

(Choice as "custom variable" is to allow users to set this at runtime via the OCPP interface)