### PR TITLE
DateTime/seconds_precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if(CMAKE_RUN_CLANG_TIDY)
 endif()
 
 if(BUILD_TESTING_LIBOCPP)
+    include(CTest)
     add_subdirectory(tests)
 endif()
 

--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -35,7 +35,7 @@ struct Message {
 /// \brief Contains a DateTime implementation that can parse and create RFC 3339 compatible strings
 class DateTimeImpl {
 private:
-    std::chrono::time_point<date::utc_clock> timepoint;
+    std::chrono::time_point<date::utc_clock, std::chrono::seconds> timepoint;
 
 public:
     /// \brief Creates a new DateTimeImpl object with the current utc time

--- a/lib/ocpp/common/types.cpp
+++ b/lib/ocpp/common/types.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
+#include <chrono>
 #include <everest/logging.hpp>
 #include <ocpp/common/call_types.hpp>
 #include <ocpp/common/types.hpp>
@@ -27,10 +28,11 @@ DateTime& DateTime::operator=(const char* c) {
 }
 
 DateTimeImpl::DateTimeImpl() {
-    this->timepoint = date::utc_clock::now();
+    this->timepoint = std::chrono::time_point_cast<std::chrono::seconds>(date::utc_clock::now());
 }
 
-DateTimeImpl::DateTimeImpl(std::chrono::time_point<date::utc_clock> timepoint) : timepoint(timepoint) {
+DateTimeImpl::DateTimeImpl(std::chrono::time_point<date::utc_clock> timepoint) :
+    timepoint(std::chrono::time_point_cast<std::chrono::seconds>(timepoint)) {
 }
 
 DateTimeImpl::DateTimeImpl(const std::string& timepoint_str) {


### PR DESCRIPTION
This draft-PR serves to quickly reproduce the failing `MessageQueueTest: test_clean_up_non_transactional_queue`, see
- https://github.com/EVerest/libocpp/issues/384

It should later fix it.