### PR TITLE
Execute disonnected_callback only when websocket is disconnected

### DIFF
--- a/lib/ocpp/common/websocket/websocket_plain.cpp
+++ b/lib/ocpp/common/websocket/websocket_plain.cpp
@@ -232,8 +232,10 @@ void WebsocketPlain::on_close_plain(client* c, websocketpp::connection_hdl hdl) 
 
 void WebsocketPlain::on_fail_plain(client* c, websocketpp::connection_hdl hdl) {
     std::lock_guard<std::mutex> lk(this->connection_mutex);
+    if (this->m_is_connected) {
+        this->disconnected_callback();
+    }
     this->m_is_connected = false;
-    this->disconnected_callback();
     this->connection_attempts += 1;
     client::connection_ptr con = c->get_con_from_hdl(hdl);
     const auto ec = con->get_ec();

--- a/lib/ocpp/common/websocket/websocket_tls.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls.cpp
@@ -415,8 +415,10 @@ void WebsocketTLS::on_close_tls(tls_client* c, websocketpp::connection_hdl hdl) 
 }
 void WebsocketTLS::on_fail_tls(tls_client* c, websocketpp::connection_hdl hdl) {
     std::lock_guard<std::mutex> lk(this->connection_mutex);
+    if (this->m_is_connected) {
+        this->disconnected_callback();
+    }
     this->m_is_connected = false;
-    this->disconnected_callback();
     this->connection_attempts += 1;
     tls_client::connection_ptr con = c->get_con_from_hdl(hdl);
     const auto ec = con->get_ec();

--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -600,8 +600,10 @@ void WebsocketTlsTPM::on_conn_fail() {
     EVLOG_error << "OCPP client connection failed to TLS websocket server";
 
     std::lock_guard<std::mutex> lk(this->connection_mutex);
+    if (this->m_is_connected) {
+        this->disconnected_callback();
+    }
     this->m_is_connected = false;
-    this->disconnected_callback();
     this->connection_attempts += 1;
 
     // -1 indicates to always attempt to reconnect


### PR DESCRIPTION
Without this change, the disconnected_callback was executed also on reconnect attempts when the websocket is already disconnected. This leads to the situation that the time_disconnected of ChargePoint resets on reconnect attempts and therefore the handling of the OfflineThreshold is incorrect. This change only calls disconnected_callback if websocket is not already disconnected.

Fixes TC_B_57_CS