### PR TITLE
Several updates to OCPP201 device model

### DIFF
--- a/config/v201/component_schemas/custom/EVSE_1.json
+++ b/config/v201/component_schemas/custom/EVSE_1.json
@@ -71,7 +71,7 @@
       "variable_name": "Power",
       "characteristics": {
         "unit": "W",
-        "maxLimit": 32000,
+        "maxLimit": 22000,
         "supportsMonitoring": true,
         "dataType": "decimal"
       },

--- a/config/v201/component_schemas/custom/EVSE_1.json
+++ b/config/v201/component_schemas/custom/EVSE_1.json
@@ -71,6 +71,7 @@
       "variable_name": "Power",
       "characteristics": {
         "unit": "W",
+        "maxLimit": 32000,
         "supportsMonitoring": true,
         "dataType": "decimal"
       },

--- a/config/v201/component_schemas/custom/EVSE_2.json
+++ b/config/v201/component_schemas/custom/EVSE_2.json
@@ -71,7 +71,7 @@
       "variable_name": "Power",
       "characteristics": {
         "unit": "W",
-        "maxLimit": 32000,
+        "maxLimit": 22000,
         "supportsMonitoring": true,
         "dataType": "decimal"
       },

--- a/config/v201/component_schemas/custom/EVSE_2.json
+++ b/config/v201/component_schemas/custom/EVSE_2.json
@@ -71,6 +71,7 @@
       "variable_name": "Power",
       "characteristics": {
         "unit": "W",
+        "maxLimit": 32000,
         "supportsMonitoring": true,
         "dataType": "decimal"
       },

--- a/config/v201/component_schemas/standardized/LocalAuthListCtrlr.json
+++ b/config/v201/component_schemas/standardized/LocalAuthListCtrlr.json
@@ -21,7 +21,7 @@
       "type": "boolean"
     },
     "BytesPerMessageSendLocalList": {
-      "variable_name": "BytesPerMessageSendLocalList",
+      "variable_name": "BytesPerMessage",
       "characteristics": {
         "supportsMonitoring": true,
         "dataType": "integer"
@@ -67,7 +67,7 @@
       "type": "integer"
     },
     "ItemsPerMessageSendLocalList": {
-      "variable_name": "ItemsPerMessageSendLocalList",
+      "variable_name": "ItemsPerMessage",
       "characteristics": {
         "supportsMonitoring": true,
         "dataType": "integer"

--- a/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
+++ b/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
@@ -89,7 +89,8 @@
       "variable_name": "MessageAttemptInterval",
       "characteristics": {
         "supportsMonitoring": true,
-        "dataType": "integer"
+        "dataType": "integer",
+        "unit": "s"
       },
       "attributes": [
         {
@@ -124,7 +125,7 @@
       "characteristics": {
         "valuesList": "1,2",
         "supportsMonitoring": true,
-        "dataType": "string"
+        "dataType": "SequenceList"
       },
       "attributes": [
         {

--- a/config/v201/component_schemas/standardized/TxCtrlr.json
+++ b/config/v201/component_schemas/standardized/TxCtrlr.json
@@ -134,7 +134,7 @@
     "TxStopPoint": {
       "variable_name": "TxStopPoint",
       "characteristics": {
-        "valuesList": "ParkingBayOccupancy,EVConnected,Authorized,PowerPathClosed,EnergyTransfer,DataSigned",
+        "valuesList": "ParkingBayOccupancy,EVConnected,Authorized,PowerPathClosed,EnergyTransfer",
         "supportsMonitoring": true,
         "dataType": "MemberList"
       },

--- a/config/v201/init_device_model_db.py
+++ b/config/v201/init_device_model_db.py
@@ -165,7 +165,7 @@ class DeviceModelDatabaseInitializer:
         data = (
             DATATYPE_ENCODING.get(characteristics.get("dataType")), characteristics.get("maxLimit"),
             characteristics.get(
-                "minLimit"), characteristics.get("supportsMonitoring"), None, characteristics.get("valuesList"))
+                "minLimit"), characteristics.get("supportsMonitoring"), characteristics.get("unit"), characteristics.get("valuesList"))
         cur.execute(("INSERT OR REPLACE INTO VARIABLE_CHARACTERISTICS (DATATYPE_ID, MAX_LIMIT, MIN_LIMIT,"
                      "SUPPORTS_MONITORING, UNIT, VALUES_LIST) VALUES(?,?,?,?,?,?)"), data)
 

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -678,7 +678,7 @@ const RequiredComponentVariable& BytesPerMessageSendLocalList = {
     ControllerComponents::LocalAuthListCtrlr,
     std::nullopt,
     std::optional<Variable>({
-        "BytesPerMessageSendLocalList",
+        "BytesPerMessage",
     }),
 };
 const ComponentVariable& LocalAuthListCtrlrEnabled = {
@@ -699,7 +699,7 @@ const RequiredComponentVariable& ItemsPerMessageSendLocalList = {
     ControllerComponents::LocalAuthListCtrlr,
     std::nullopt,
     std::optional<Variable>({
-        "ItemsPerMessageSendLocalList",
+        "ItemsPerMessage",
     }),
 };
 const ComponentVariable& LocalAuthListCtrlrStorage = {


### PR DESCRIPTION
* now considering unit in VariableCharacteristics of component schemas in initialization script
* added example maxLimit to EVSEPower variable
* fixed variable name of BytesPerMessage and ItemsPerMessage in LocalAuthListCtrlr
* added unit to MessageAttemptInterval of OCPPCommCtrlr
* changed dataType from variable NetworkConfigurationPriority from string to SequenceList
* Removed DataSigned from valuesList of TxStopPoint (as required by OCTT test case B_53)