### PR TITLE
Configurable CentralSystemURI for OCPP1.6

### DIFF
--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -18,7 +18,7 @@
         },
         "CentralSystemURI": {
             "type": "string",
-            "readOnly": true,
+            "readOnly": false,
             "minLength": 1
         },
         "ChargeBoxSerialNumber": {

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -42,6 +42,7 @@ public:
     std::string getChargePointId();
     KeyValue getChargePointIdKeyValue();
     std::string getCentralSystemURI();
+    void setCentralSystemURI(std::string central_system_uri);
     KeyValue getCentralSystemURIKeyValue();
     std::string getChargeBoxSerialNumber();
     KeyValue getChargeBoxSerialNumberKeyValue();


### PR DESCRIPTION
made CentralSystemURI of OCPP1.6 writable by CSMS. Change to this configuration key is applied only after reboot