### PR TITLE
OCPP1.6: Support for vendor errors 

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -225,12 +225,23 @@ public:
     /// the state machine.
     /// \param connector
     /// \param error_code
-    void on_error(int32_t connector, const ChargePointErrorCode& error_code);
+    /// \param info Additional free format information related to the error
+    /// \param vendor_id This identifies the vendor-specific implementation
+    /// \param vendor_error_code This contains the vendor-specific error code
+    void on_error(int32_t connector, const ChargePointErrorCode& error_code,
+                  const std::optional<CiString<50>>& info = std::nullopt,
+                  const std::optional<CiString<255>>& vendor_id = std::nullopt,
+                  const std::optional<CiString<50>>& vendor_error_code = std::nullopt);
 
     /// \brief This function should be called if a fault is detected that prevents further charging operations. The \p
     /// error_code indicates the reason for the fault.
-    /// \param error_code
-    void on_fault(int32_t connector, const ChargePointErrorCode& error_code);
+    /// \param info Additional free format information related to the error
+    /// \param vendor_id This identifies the vendor-specific implementation
+    /// \param vendor_error_code This contains the vendor-specific error code
+    void on_fault(int32_t connector, const ChargePointErrorCode& error_code,
+                  const std::optional<CiString<50>>& info = std::nullopt,
+                  const std::optional<CiString<255>>& vendor_id = std::nullopt,
+                  const std::optional<CiString<50>>& vendor_error_code = std::nullopt);
 
     /// \brief Chargepoint notifies about new log status \p log_status . This function should be called during a
     /// Diagnostics / Log upload to indicate the current \p log_status .

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -208,7 +208,10 @@ private:
                                       const ocpp::DateTime& datetime);
     void send_meter_value(int32_t connector, MeterValue meter_value);
     void status_notification(const int32_t connector, const ChargePointErrorCode errorCode,
-                             const ChargePointStatus status, const ocpp::DateTime& timestamp);
+                             const ChargePointStatus status, const ocpp::DateTime& timestamp,
+                             const std::optional<CiString<50>>& info = std::nullopt,
+                             const std::optional<CiString<255>>& vendor_id = std::nullopt,
+                             const std::optional<CiString<50>>& vendor_error_code = std::nullopt);
     void diagnostic_status_notification(DiagnosticsStatus status);
     void firmware_status_notification(FirmwareStatus status);
     void log_status_notification(UploadLogStatusEnumType status, int requestId);
@@ -518,12 +521,19 @@ public:
     /// the state machine.
     /// \param connector
     /// \param error_code
-    void on_error(int32_t connector, const ChargePointErrorCode& error);
+    /// \param info Additional free format information related to the error
+    /// \param vendor_id This identifies the vendor-specific implementation
+    /// \param vendor_error_code This contains the vendor-specific error code
+    void on_error(int32_t connector, const ChargePointErrorCode& error_code, const std::optional<CiString<50>>& info,
+                  const std::optional<CiString<255>>& vendor_id, const std::optional<CiString<50>>& vendor_error_code);
 
     /// \brief This function should be called if a fault is detected that prevents further charging operations. The \p
     /// error_code indicates the reason for the fault.
-    /// \param error_code
-    void on_fault(int32_t connector, const ChargePointErrorCode& error_code);
+    /// \param info Additional free format information related to the error
+    /// \param vendor_id This identifies the vendor-specific implementation
+    /// \param vendor_error_code This contains the vendor-specific error code
+    void on_fault(int32_t connector, const ChargePointErrorCode& error_code, const std::optional<CiString<50>>& info,
+                  const std::optional<CiString<255>>& vendor_id, const std::optional<CiString<50>>& vendor_error_code);
 
     /// \brief Chargepoint notifies about new log status \p log_status . This function should be called during a
     /// Diagnostics / Log upload to indicate the current \p log_status .

--- a/include/ocpp/v16/charge_point_state_machine.hpp
+++ b/include/ocpp/v16/charge_point_state_machine.hpp
@@ -45,12 +45,18 @@ using FSMDefinition = std::map<FSMState, FSMStateTransitions>;
 class ChargePointFSM {
 public:
     using StatusNotificationCallback = std::function<void(
-        const ChargePointStatus status, const ChargePointErrorCode error_code, const ocpp::DateTime& timestamp)>;
+        const ChargePointStatus status, const ChargePointErrorCode error_code, const ocpp::DateTime& timestamp,
+        const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
+        const std::optional<CiString<50>>& vendor_error_code)>;
     explicit ChargePointFSM(const StatusNotificationCallback& status_notification_callback, FSMState initial_state);
 
     bool handle_event(FSMEvent event, const ocpp::DateTime timestamp);
-    bool handle_error(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp);
-    bool handle_fault(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp);
+    bool handle_error(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
+                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
+                      const std::optional<CiString<50>>& vendor_error_code);
+    bool handle_fault(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
+                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
+                      const std::optional<CiString<50>>& vendor_error_code);
 
     FSMState get_state() const;
 
@@ -65,15 +71,20 @@ private:
 
 class ChargePointStates {
 public:
-    using ConnectorStatusCallback =
-        std::function<void(const int connector_id, const ChargePointErrorCode errorCode, const ChargePointStatus status,
-                           const ocpp::DateTime& timestamp)>;
+    using ConnectorStatusCallback = std::function<void(
+        const int connector_id, const ChargePointErrorCode errorCode, const ChargePointStatus status,
+        const ocpp::DateTime& timestamp, const std::optional<CiString<50>>& info,
+        const std::optional<CiString<255>>& vendor_id, const std::optional<CiString<50>>& vendor_error_code)>;
     ChargePointStates(const ConnectorStatusCallback& connector_status_callback);
     void reset(std::map<int, ChargePointStatus> connector_status_map);
 
     void submit_event(const int connector_id, FSMEvent event, const ocpp::DateTime& timestamp);
-    void submit_fault(const int connector_id, const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp);
-    void submit_error(const int connector_id, const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp);
+    void submit_fault(const int connector_id, const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
+                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
+                      const std::optional<CiString<50>>& vendor_error_code);
+    void submit_error(const int connector_id, const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
+                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
+                      const std::optional<CiString<50>>& vendor_error_code);
 
     ChargePointStatus get_state(int connector_id);
 

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -121,12 +121,16 @@ void ChargePoint::on_resume_charging(int32_t connector) {
     this->charge_point->on_resume_charging(connector);
 }
 
-void ChargePoint::on_error(int32_t connector, const ChargePointErrorCode& error_code) {
-    this->charge_point->on_error(connector, error_code);
+void ChargePoint::on_error(int32_t connector, const ChargePointErrorCode& error_code,
+                           const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
+                           const std::optional<CiString<50>>& vendor_error_code) {
+    this->charge_point->on_error(connector, error_code, info, vendor_id, vendor_error_code);
 }
 
-void ChargePoint::on_fault(int32_t connector, const ChargePointErrorCode& error_code) {
-    this->charge_point->on_fault(connector, error_code);
+void ChargePoint::on_fault(int32_t connector, const ChargePointErrorCode& error_code,
+                           const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
+                           const std::optional<CiString<50>>& vendor_error_code) {
+    this->charge_point->on_fault(connector, error_code, info, vendor_id, vendor_error_code);
 }
 
 void ChargePoint::on_log_status_notification(int32_t request_id, std::string log_status) {


### PR DESCRIPTION
Added option to supply vendorErrorCode, vendorId and info in situations of error or fault and applied respective changes in chargepoint state machine