### PR TITLE
Sync Operative state to connector states. 

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -591,6 +591,10 @@ public:
     /// becomes unavailable
     void on_unavailable(const int32_t evse_id, const int32_t connector_id);
 
+    /// \brief Set Unavailable on Operative conditions
+    /// becomes operative again
+    void mark_unavailable(const int32_t evse_id, const int32_t connector_id);
+
     /// \brief Event handler that should be called when the connector on the given \p evse_id and \p connector_id
     /// becomes operative again
     void on_operative(const int32_t evse_id, const int32_t connector_id);

--- a/include/ocpp/v201/connector.hpp
+++ b/include/ocpp/v201/connector.hpp
@@ -59,6 +59,7 @@ public:
     /// \brief Get the state object
     /// \return ConnectorStatusEnum
     ConnectorStatusEnum get_state();
+    void set_initial_state(const ConnectorStatusEnum new_state);
 
     /// \brief Submits the given \p event to the state machine controller
     /// \param event

--- a/include/ocpp/v201/enums.hpp
+++ b/include/ocpp/v201/enums.hpp
@@ -1781,6 +1781,7 @@ enum class ConnectorStatusEnum {
     Occupied,
     Reserved,
     Unavailable,
+    UnavailableOccupied,
     Faulted,
 };
 
@@ -1835,6 +1836,7 @@ enum class TriggerReasonEnum {
     Trigger,
     UnlockCommand,
     StopAuthorized,
+    EnergyTransfer,
     EVDeparted,
     EVDetected,
     RemoteStop,

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -116,6 +116,11 @@ public:
     /// \return ConnectorStatusEnum
     ConnectorStatusEnum get_state(const int32_t connector_id);
 
+    /// \brief Set the state of the connector with the given \p connector_id
+    /// \param connector_id id of the connector of the evse
+    /// \return ConnectorStatusEnum
+    void set_state(ConnectorStatusEnum status, const int32_t connector_id);
+
     /// \brief Submits the given \p event to the state machine controller of the connector with the given
     /// \p connector_id
     /// \param connector_id id of the connector of the evse

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -485,6 +485,10 @@ void ChargePoint::on_operative(const int32_t evse_id, const int32_t connector_id
     this->evses.at(evse_id)->submit_event(connector_id, ConnectorEvent::ReturnToOperativeState);
 }
 
+void ChargePoint::mark_unavailable(const int32_t evse_id, const int32_t connector_id) {
+    this->evses.at(evse_id)->set_state(ConnectorStatusEnum::Unavailable, connector_id);
+}
+
 void ChargePoint::on_faulted(const int32_t evse_id, const int32_t connector_id) {
     this->evses.at(evse_id)->submit_event(connector_id, ConnectorEvent::Error);
 }

--- a/lib/ocpp/v201/enums.cpp
+++ b/lib/ocpp/v201/enums.cpp
@@ -3365,6 +3365,8 @@ std::string connector_status_enum_to_string(ConnectorStatusEnum e) {
         return "Reserved";
     case ConnectorStatusEnum::Unavailable:
         return "Unavailable";
+    case ConnectorStatusEnum::UnavailableOccupied:
+        return "Occupied";
     case ConnectorStatusEnum::Faulted:
         return "Faulted";
     }
@@ -3377,6 +3379,7 @@ ConnectorStatusEnum string_to_connector_status_enum(const std::string& s) {
         return ConnectorStatusEnum::Available;
     }
     if (s == "Occupied") {
+        // Either Occupied or UnavailableOccupied
         return ConnectorStatusEnum::Occupied;
     }
     if (s == "Reserved") {
@@ -3469,6 +3472,8 @@ std::string trigger_reason_enum_to_string(TriggerReasonEnum e) {
         return "EVDeparted";
     case TriggerReasonEnum::EVDetected:
         return "EVDetected";
+    case TriggerReasonEnum::EnergyTransfer:
+        return "EnergyTransfer";
     case TriggerReasonEnum::RemoteStop:
         return "RemoteStop";
     case TriggerReasonEnum::RemoteStart:
@@ -3532,6 +3537,9 @@ TriggerReasonEnum string_to_trigger_reason_enum(const std::string& s) {
     }
     if (s == "EVDetected") {
         return TriggerReasonEnum::EVDetected;
+    }
+    if (s == "EnergyTransfer") {
+        return TriggerReasonEnum::EnergyTransfer;
     }
     if (s == "RemoteStop") {
         return TriggerReasonEnum::RemoteStop;

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -198,6 +198,13 @@ ConnectorStatusEnum Evse::get_state(const int32_t connector_id) {
     return this->id_connector_map.at(connector_id)->get_state();
 }
 
+void Evse::set_state(ConnectorStatusEnum status, const int32_t connector_id) {
+    if (const auto iter = id_connector_map.find(connector_id) == id_connector_map.end()) {
+        EVLOG_AND_THROW(std::runtime_error("Unable to get_state for Connector"));
+    }
+    this->id_connector_map.at(connector_id)->set_initial_state(status);
+}
+
 void Evse::submit_event(const int32_t connector_id, ConnectorEvent event) {
     return this->id_connector_map.at(connector_id)->submit_event(event);
 }


### PR DESCRIPTION
Maintain Operative status when made Unavailable.
Pre init Connector status after loading Operative state of the ChargePoint and EVSE's