### PR TITLE
OCPP1.6: Report reason in StatusNotification.req in on_session_started and on_plugin_timeout

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -168,9 +168,9 @@ public:
     /// authorization or the connection of cable and/or EV to the given \p connector
     /// \param connector
     /// \param session_id unique id of the session
-    /// \param reason "Authorized" or "EVConnected" TODO(piet): Convert to enum
+    /// \param reason for the initiation of the session
     /// \param session_logging_path optional filesystem path to where the session log should be written
-    void on_session_started(int32_t connector, const std::string& session_id, const std::string& reason,
+    void on_session_started(int32_t connector, const std::string& session_id, const SessionStartedReason reason,
                             const std::optional<std::string>& session_logging_path);
 
     /// \brief Notifies chargepoint that a session has been stopped at the given \p connector. This function must be

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -468,9 +468,9 @@ public:
     /// authorization or the connection of cable and/or EV to the given \p connector
     /// \param connector
     /// \param session_id unique id of the session
-    /// \param reason "Authorized" or "EVConnected" TODO(piet): Convert to enum
+    /// \param reason for the initiation of the session
     /// \param session_logging_path optional filesystem path to where the session log should be written
-    void on_session_started(int32_t connector, const std::string& session_id, const std::string& reason,
+    void on_session_started(int32_t connector, const std::string& session_id, const SessionStartedReason reason,
                             const std::optional<std::string>& session_logging_path);
 
     /// \brief Notifies chargepoint that a session has been stopped at the given \p connector. This function must be
@@ -575,7 +575,7 @@ public:
     void on_disabled(int32_t connector);
 
     /// \brief Notifies chargepoint that a ConnectionTimeout occured for the given \p connector . This function should
-    /// be called when an EV is plugged in but the authorization is present within the specified ConnectionTimeout
+    /// be called when an EV is plugged in but the authorization is not present within the specified ConnectionTimeout
     void on_plugin_timeout(int32_t connector);
 
     /// \brief Notifies chargepoint that a SecurityEvent occurs. This will send a SecurityEventNotification.req to the

--- a/include/ocpp/v16/charge_point_state_machine.hpp
+++ b/include/ocpp/v16/charge_point_state_machine.hpp
@@ -50,7 +50,7 @@ public:
         const std::optional<CiString<50>>& vendor_error_code)>;
     explicit ChargePointFSM(const StatusNotificationCallback& status_notification_callback, FSMState initial_state);
 
-    bool handle_event(FSMEvent event, const ocpp::DateTime timestamp);
+    bool handle_event(FSMEvent event, const ocpp::DateTime timestamp, const std::optional<CiString<50>>& info);
     bool handle_error(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
                       const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
                       const std::optional<CiString<50>>& vendor_error_code);
@@ -78,7 +78,8 @@ public:
     ChargePointStates(const ConnectorStatusCallback& connector_status_callback);
     void reset(std::map<int, ChargePointStatus> connector_status_map);
 
-    void submit_event(const int connector_id, FSMEvent event, const ocpp::DateTime& timestamp);
+    void submit_event(const int connector_id, FSMEvent event, const ocpp::DateTime& timestamp,
+                      const std::optional<CiString<50>>& info = std::nullopt);
     void submit_fault(const int connector_id, const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
                       const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
                       const std::optional<CiString<50>>& vendor_error_code);

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -83,7 +83,8 @@ void ChargePoint::on_max_current_offered(int32_t connector, int32_t max_current)
     this->charge_point->on_max_current_offered(connector, max_current);
 }
 
-void ChargePoint::on_session_started(int32_t connector, const std::string& session_id, const std::string& reason,
+void ChargePoint::on_session_started(int32_t connector, const std::string& session_id,
+                                     const ocpp::SessionStartedReason reason,
                                      const std::optional<std::string>& session_logging_path) {
 
     this->charge_point->on_session_started(connector, session_id, reason, session_logging_path);


### PR DESCRIPTION
* changed argument reason of on_session_started from string to SessionStartedReason
* using reason of on_session_started to use it for the info field of StatusNotification.req
* when on_plugin_timeout is called: reporting ConnectionTimeout reason for the info field of StatusNotification.req

Companion PR: https://github.com/EVerest/everest-core/pull/495