### PR TITLE
Security Log file option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .cache/
 workspace.yaml
 CMakeLists.txt.user
+__pycache__
 !doc/build-with-fetchcontent

--- a/config/v16/config-docker.json
+++ b/config/v16/config-docker.json
@@ -7,7 +7,8 @@
         "ChargePointVendor": "Pionix",
         "FirmwareVersion": "0.1",
         "AllowChargingProfileWithoutStartSchedule": true,
-        "UseTPM" : false
+        "UseTPM" : false,
+        "LogMessagesFormat": ["html","security"]
     },
     "Core": {
         "AuthorizeRemoteTxRequests": false,

--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -140,7 +140,7 @@
             "default": true
         },
         "LogMessagesFormat": {
-            "$comment": "Supported log formats are console, log, html, console_detailed and session_logging",
+            "$comment": "Supported log formats are console, log, html, console_detailed, session_logging, callback and security. \"security\" logs security events into a seperate logfile",
             "type": "array",
             "items": {
                 "type": "string"
@@ -149,7 +149,8 @@
             "default": [
                 "log",
                 "html",
-                "session_logging"
+                "session_logging",
+                "security"
             ]
         },
         "SupportedChargingProfilePurposeTypes": {

--- a/config/v201/component_schemas/standardized/InternalCtrlr.json
+++ b/config/v201/component_schemas/standardized/InternalCtrlr.json
@@ -261,7 +261,7 @@
       "LogMessagesFormat": {
           "variable_name": "LogMessagesFormat",
           "characteristics": {
-              "valuesList": "log,html,console,console_detailed",
+              "valuesList": "log,html,console,console_detailed,security",
               "supportsMonitoring": true,
               "dataType": "MemberList"
           },
@@ -271,8 +271,8 @@
                   "mutability": "ReadOnly"
               }
           ],
-          "description": "Supported log formats are console, log, html, console_detailed and callback",
-          "default": "log,html",
+          "description": "Supported log formats are console, log, html, console_detailed, callback and security. \"security\" logs security events into a seperate logfile",
+          "default": "log,html,security",
           "type": "string"
       },
       "SupportedChargingProfilePurposeTypes": {

--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -257,7 +257,7 @@
             "LogMessagesFormat": {
                 "variable_name": "LogMessagesFormat",
                 "attributes": {
-                    "Actual": "log,html"
+                    "Actual": "log,html,security"
                 }
             },
             "SupportedCriteria": {

--- a/include/ocpp/common/ocpp_logging.hpp
+++ b/include/ocpp/common/ocpp_logging.hpp
@@ -30,9 +30,11 @@ private:
     bool detailed_log_to_console;
     bool log_to_file;
     bool log_to_html;
+    bool log_security;
     bool session_logging;
     std::ofstream output_file;
     std::ofstream html_log_file;
+    std::ofstream security_log_file;
     std::mutex output_file_mutex;
     std::function<void(const std::string& message, MessageDirection direction)> message_callback;
     std::map<std::string, std::string> lookup_map;
@@ -47,13 +49,15 @@ public:
     /// \brief Creates a new Websocket object with the providede \p configuration
     explicit MessageLogging(
         bool log_messages, const std::string& message_log_path, const std::string& output_file_name,
-        bool log_to_console, bool detailed_log_to_console, bool log_to_file, bool log_to_html, bool session_logging,
+        bool log_to_console, bool detailed_log_to_console, bool log_to_file, bool log_to_html, bool log_security,
+        bool session_logging,
         std::function<void(const std::string& message, MessageDirection direction)> message_callback);
     ~MessageLogging();
 
     void charge_point(const std::string& message_type, const std::string& json_str);
     void central_system(const std::string& message_type, const std::string& json_str);
     void sys(const std::string& msg);
+    void security(const std::string& msg);
     void start_session_logging(const std::string& session_id, const std::string& log_path);
     void stop_session_logging(const std::string& session_id);
     std::string get_message_log_path();

--- a/lib/ocpp/common/ocpp_logging.cpp
+++ b/lib/ocpp/common/ocpp_logging.cpp
@@ -14,7 +14,7 @@ namespace ocpp {
 
 MessageLogging::MessageLogging(
     bool log_messages, const std::string& message_log_path, const std::string& output_file_name, bool log_to_console,
-    bool detailed_log_to_console, bool log_to_file, bool log_to_html, bool session_logging,
+    bool detailed_log_to_console, bool log_to_file, bool log_to_html, bool log_security, bool session_logging,
     std::function<void(const std::string& message, MessageDirection direction)> message_callback) :
     log_messages(log_messages),
     message_log_path(message_log_path),
@@ -23,6 +23,7 @@ MessageLogging::MessageLogging(
     detailed_log_to_console(detailed_log_to_console),
     log_to_file(log_to_file),
     log_to_html(log_to_html),
+    log_security(log_security),
     session_logging(session_logging),
     message_callback(message_callback) {
 
@@ -69,6 +70,10 @@ MessageLogging::MessageLogging(
                                    "</style>";
             this->html_log_file << "</head><body><table class=\"log\">\n";
         }
+        if (this->log_security) {
+            EVLOG_info << "Logging SecurityEvents to file";
+            this->security_log_file.open(message_log_path + "/" + output_file_name + ".security.log");
+        }
         sys("Session logging started.");
     }
 }
@@ -82,6 +87,10 @@ MessageLogging::~MessageLogging() {
         if (this->log_to_html) {
             this->html_log_file << "</table></body></html>\n";
             this->html_log_file.close();
+        }
+
+        if (this->log_security) {
+            this->security_log_file.close();
         }
     }
 }
@@ -122,6 +131,11 @@ void MessageLogging::sys(const std::string& msg) {
             log_output(2, msg, "");
         }
     }
+}
+
+void MessageLogging::security(const std::string& msg) {
+    this->security_log_file << msg << "\n";
+    this->security_log_file.flush();
 }
 
 void MessageLogging::log_output(unsigned int typ, const std::string& message_type, const std::string& json_str) {
@@ -206,7 +220,7 @@ FormattedMessageWithType MessageLogging::format_message(const std::string& messa
 void MessageLogging::start_session_logging(const std::string& session_id, const std::string& log_path) {
     std::scoped_lock lock(this->session_id_logging_mutex);
     this->session_id_logging[session_id] = std::make_shared<ocpp::MessageLogging>(
-        true, log_path, "incomplete-ocpp", false, false, false, true, false, nullptr);
+        true, log_path, "incomplete-ocpp", false, false, false, true, false, false, nullptr);
 }
 
 void MessageLogging::stop_session_logging(const std::string& session_id) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -50,11 +50,12 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
         std::find(log_formats.begin(), log_formats.end(), "console_detailed") != log_formats.end();
     bool log_to_file = std::find(log_formats.begin(), log_formats.end(), "log") != log_formats.end();
     bool log_to_html = std::find(log_formats.begin(), log_formats.end(), "html") != log_formats.end();
+    bool log_security = std::find(log_formats.begin(), log_formats.end(), "security") != log_formats.end();
     bool session_logging = std::find(log_formats.begin(), log_formats.end(), "session_logging") != log_formats.end();
 
     this->logging = std::make_shared<ocpp::MessageLogging>(
         this->configuration->getLogMessages(), this->message_log_path, DateTime().to_rfc3339(), log_to_console,
-        detailed_log_to_console, log_to_file, log_to_html, session_logging, nullptr);
+        detailed_log_to_console, log_to_file, log_to_html, log_security, session_logging, nullptr);
 
     this->boot_notification_timer =
         std::make_unique<Everest::SteadyTimer>(&this->io_service, [this]() { this->boot_notification(); });
@@ -2358,6 +2359,8 @@ void ChargePointImpl::securityEventNotification(const std::string& type, const s
     req.type = type;
     req.techInfo.emplace(tech_info);
     req.timestamp = ocpp::DateTime();
+
+    this->logging->security(json(req).dump());
 
     ocpp::Call<SecurityEventNotificationRequest> call(req, this->message_queue->createMessageId());
     this->send<SecurityEventNotificationRequest>(call);


### PR DESCRIPTION
Added option for writing SecurityEvents to a security log file for ocpp1.6 and ocpp2.0.1.
This can be enabled by adding "security" to LogMessagesFormat configuration parameter.