### PR TITLE
Extended Use of SecurityEventNotification.req in OCPP1.6

### DIFF
--- a/config/v16/profile_schemas/Security.json
+++ b/config/v16/profile_schemas/Security.json
@@ -41,6 +41,12 @@
             "maximum": 3,
             "description": "This configuration key is used to set the security profile used by the Charge Point",
             "readOnly": false
+        },
+        "DisableSecurityEventNotifications": {
+            "type": "boolean",
+            "description": "When set to true, no SecurityEventNotification.req messages will be sent by the Charge Point",
+            "readOnly": false,
+            "default": false
         }
     }
 }

--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -593,6 +593,7 @@ inline const std::string INVALIDFIRMWARESIGNATURE = "InvalidFirmwareSignature";
 inline const std::string INVALIDFIRMWARESIGNINGCERTIFICATE = "InvalidFirmwareSigningCertificate";
 inline const std::string INVALIDCSMSCERTIFICATE = "InvalidCsmsCertificate";
 inline const std::string INVALIDCHARGINGSTATIONCERTIFICATE = "InvalidChargingStationCertificate";
+inline const std::string INVALIDCHARGEPOINTCERTIFICATE = "InvalidChargePointCertificate"; // for OCPP1.6
 inline const std::string INVALIDTLSVERSION = "InvalidTLSVersion";
 inline const std::string INVALIDTLSCIPHERSUITE = "InvalidTLSCipherSuite";
 } // namespace security_events

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -73,15 +73,19 @@ public:
     /// \param connector_status_map initial state of connectors including connector 0 with reduced set of states
     /// (Available, Unavailable, Faulted). connector_status_map is empty, last availability states from the persistant
     /// storage will be used
+    /// \param bootreason reason for calling the start function
     /// \return
-    bool start(const std::map<int, ChargePointStatus>& connector_status_map = {});
+    bool start(const std::map<int, ChargePointStatus>& connector_status_map = {},
+               BootReasonEnum bootreason = BootReasonEnum::PowerUp);
 
     /// \brief Restarts the ChargePoint if it has been stopped before. The ChargePoint is reinitialized, connects to the
     /// websocket and starts to communicate OCPP messages again
     /// \param connector_status_map initial state of connectors including connector 0 with reduced set of states
     /// (Available, Unavailable, Faulted). connector_status_map is empty, last availability states from the persistant
     /// storage will be used
-    bool restart(const std::map<int, ChargePointStatus>& connector_status_map = {});
+    /// \param bootreason reason for calling the start function
+    bool restart(const std::map<int, ChargePointStatus>& connector_status_map = {},
+                 BootReasonEnum bootreason = BootReasonEnum::ApplicationReset);
 
     // \brief Resets the internal state machine for the connectors using the given \p connector_status_map
     /// \param connector_status_map state of connectors including connector 0 with reduced set of states (Available,

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -335,7 +335,6 @@ public:
     void setDisableSecurityEventNotifications(bool disable_security_event_notifications);
     KeyValue getDisableSecurityEventNotificationsKeyValue();
 
-
     // Local Auth List Management Profile
     bool getLocalAuthListEnabled();
     void setLocalAuthListEnabled(bool local_auth_list_enabled);

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -330,6 +330,12 @@ public:
     void setSecurityProfile(int32_t security_profile);
     KeyValue getSecurityProfileKeyValue();
 
+    // // Security profile - optional with default
+    bool getDisableSecurityEventNotifications();
+    void setDisableSecurityEventNotifications(bool disable_security_event_notifications);
+    KeyValue getDisableSecurityEventNotificationsKeyValue();
+
+
     // Local Auth List Management Profile
     bool getLocalAuthListEnabled();
     void setLocalAuthListEnabled(bool local_auth_list_enabled);

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -86,6 +86,7 @@ namespace v16 {
 class ChargePointImpl : ocpp::ChargingStationBase {
 private:
     bool initialized;
+    BootReasonEnum bootreason;
     ChargePointConnectionState connection_state;
     bool boot_notification_callerror;
     RegistrationStatus registration_status;
@@ -373,15 +374,18 @@ public:
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint and initializes a
     /// BootNotification.req
     /// \param connector_status_map initial state of connectors including connector 0 with reduced set of states
-    /// (Available, Unavailable, Faulted) \return
-    bool start(const std::map<int, ChargePointStatus>& connector_status_map);
+    /// (Available, Unavailable, Faulted)
+    /// \param bootreason reason for calling the start function
+    /// \return
+    bool start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason);
 
     /// \brief Restarts the ChargePoint if it has been stopped before. The ChargePoint is reinitialized, connects to the
     /// websocket and starts to communicate OCPP messages again
     /// \param connector_status_map initial state of connectors including connector 0 with reduced set of states
     /// (Available, Unavailable, Faulted). connector_status_map is empty, last availability states from the persistant
     /// storage will be used
-    bool restart(const std::map<int, ChargePointStatus>& connector_status_map);
+    /// \param bootreason reason for calling the restart function
+    bool restart(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason);
 
     /// \brief Resets the internal state machine for the connectors using the given \p connector_status_map
     /// \param connector_status_map state of connectors including connector 0 with reduced set of states (Available,

--- a/include/ocpp/v16/types.hpp
+++ b/include/ocpp/v16/types.hpp
@@ -186,6 +186,19 @@ struct AvailabilityChange {
     bool persist;
 };
 
+/// \brief BootReasonEnum contains the different boot reasons of the charge point (copied from OCPP2.0.1 definition)
+enum BootReasonEnum {
+    ApplicationReset,
+    FirmwareUpdate,
+    LocalReset,
+    PowerUp,
+    RemoteReset,
+    ScheduledReset,
+    Triggered,
+    Unknown,
+    Watchdog
+};
+
 } // namespace v16
 } // namespace ocpp
 

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -21,12 +21,12 @@ ChargePoint::ChargePoint(const std::string& config, const fs::path& share_path, 
 
 ChargePoint::~ChargePoint() = default;
 
-bool ChargePoint::start(const std::map<int, ChargePointStatus>& connector_status_map) {
-    return this->charge_point->start(connector_status_map);
+bool ChargePoint::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {
+    return this->charge_point->start(connector_status_map, bootreason);
 }
 
-bool ChargePoint::restart(const std::map<int, ChargePointStatus>& connector_status_map) {
-    return this->charge_point->restart(connector_status_map);
+bool ChargePoint::restart(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {
+    return this->charge_point->restart(connector_status_map, bootreason);
 }
 
 bool ChargePoint::stop() {

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -1719,6 +1719,23 @@ KeyValue ChargePointConfiguration::getSecurityProfileKeyValue() {
     return kv;
 }
 
+bool ChargePointConfiguration::getDisableSecurityEventNotifications() {
+    return this->config["Security"]["DisableSecurityEventNotifications"];
+}
+
+void ChargePointConfiguration::setDisableSecurityEventNotifications(bool disable_security_event_notifications) {
+    this->config["Security"]["DisableSecurityEventNotifications"] = disable_security_event_notifications;
+    this->setInUserConfig("Security", "DisableSecurityEventNotifications", disable_security_event_notifications);
+}
+
+KeyValue ChargePointConfiguration::getDisableSecurityEventNotificationsKeyValue() {
+    KeyValue kv;
+    kv.key = "DisableSecurityEventNotifications";
+    kv.readonly = false;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getDisableSecurityEventNotifications()));
+    return kv;
+}
+
 // Local Auth List Management Profile
 bool ChargePointConfiguration::getLocalAuthListEnabled() {
     if (this->config.contains("LocalAuthListManagement")) {
@@ -2287,6 +2304,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     if (key == "SecurityProfile") {
         return this->getSecurityProfileKeyValue();
     }
+    if (key == "DisableSecurityEventNotifications") {
+        return this->getDisableSecurityEventNotificationsKeyValue();
+    }
     if (key == "StopTransactionOnEVSideDisconnect") {
         return this->getStopTransactionOnEVSideDisconnectKeyValue();
     }
@@ -2529,6 +2549,9 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
     }
     if (key == "CpoName") {
         this->setCpoName(value.get());
+    }
+    if (key == "DisableSecurityEventNotifications") {
+        this->setDisableSecurityEventNotifications(ocpp::conversions::string_to_bool(value.get()));
     }
     if (key == "HeartbeatInterval") {
         try {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2243,7 +2243,7 @@ void ChargePointImpl::handleCertificateSignedRequest(ocpp::Call<CertificateSigne
     this->send<CertificateSignedResponse>(call_result);
 
     if (response.status == CertificateSignedStatusEnumType::Rejected) {
-        this->securityEventNotification(ocpp::security_events::INVALIDCHARGINGSTATIONCERTIFICATE,
+        this->securityEventNotification(ocpp::security_events::INVALIDCHARGEPOINTCERTIFICATE,
                                         ocpp::conversions::install_certificate_result_to_string(result), true);
     }
 
@@ -2972,7 +2972,7 @@ void ChargePointImpl::handle_data_transfer_pnc_certificate_signed(Call<DataTrans
         this->send<DataTransferResponse>(call_result);
 
         if (certificate_response.status == CertificateSignedStatusEnumType::Rejected) {
-            this->securityEventNotification(ocpp::security_events::INVALIDCHARGINGSTATIONCERTIFICATE, tech_info, true);
+            this->securityEventNotification(ocpp::security_events::INVALIDCHARGEPOINTCERTIFICATE, tech_info, true);
         }
     } catch (const json::exception& e) {
         EVLOG_warning << "Could not parse data of DataTransfer message CertificateSigned.req: " << e.what();

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -28,6 +28,7 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
     ocpp::ChargingStationBase(evse_security, security_configuration),
     boot_notification_callerror(false),
     initialized(false),
+    bootreason(BootReasonEnum::PowerUp),
     connection_state(ChargePointConnectionState::Disconnected),
     registration_status(RegistrationStatus::Pending),
     diagnostics_status(DiagnosticsStatus::Idle),
@@ -789,7 +790,8 @@ void ChargePointImpl::send_meter_value(int32_t connector, MeterValue meter_value
     this->send<MeterValuesRequest>(call, initiated_by_trigger_message);
 }
 
-bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_status_map) {
+bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {
+    this->bootreason = bootreason;
     this->init_state_machine(connector_status_map);
     this->init_websocket();
     this->websocket->connect();
@@ -800,7 +802,7 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     return true;
 }
 
-bool ChargePointImpl::restart(const std::map<int, ChargePointStatus>& connector_status_map) {
+bool ChargePointImpl::restart(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {
     if (this->stopped) {
         EVLOG_info << "Restarting OCPP Chargepoint";
         this->database_handler->open_db_connection(this->configuration->getNumberOfConnectors());
@@ -808,7 +810,7 @@ bool ChargePointImpl::restart(const std::map<int, ChargePointStatus>& connector_
         this->message_queue = this->create_message_queue();
         this->initialized = true;
 
-        return this->start(connector_status_map);
+        return this->start(connector_status_map, bootreason);
     } else {
         EVLOG_warning << "Attempting to restart Chargepoint while it has not been stopped before";
         return false;
@@ -1013,6 +1015,7 @@ void ChargePointImpl::message_callback(const std::string& message) {
             auto call_error = CallError(MessageId(json_message.at(MESSAGE_ID).get<std::string>()), "FormationViolation",
                                         e.what(), json({}, true));
             this->send(call_error);
+            this->securityEventNotification(ocpp::security_events::INVALIDMESSAGES, message, true);
         }
     }
 }
@@ -1196,6 +1199,17 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
 
         if (this->is_pnc_enabled()) {
             this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
+        }
+
+        if (this->bootreason == BootReasonEnum::RemoteReset) {
+            this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+                                            "Charging Station rebooted due to requested remote reset!", true);
+        } else if (this->bootreason == BootReasonEnum::ScheduledReset) {
+            this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+                                            "Charging Station rebooted due to a scheduled reset!", true);
+        } else if (this->bootreason == BootReasonEnum::PowerUp) {
+            this->securityEventNotification(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
+                                            "The Charge Point has booted", true);
         }
 
         this->stop_pending_transactions();
@@ -2229,7 +2243,7 @@ void ChargePointImpl::handleCertificateSignedRequest(ocpp::Call<CertificateSigne
     this->send<CertificateSignedResponse>(call_result);
 
     if (response.status == CertificateSignedStatusEnumType::Rejected) {
-        this->securityEventNotification("InvalidChargePointCertificate",
+        this->securityEventNotification(ocpp::security_events::INVALIDCHARGINGSTATIONCERTIFICATE,
                                         ocpp::conversions::install_certificate_result_to_string(result), true);
     }
 
@@ -2312,7 +2326,7 @@ void ChargePointImpl::handleInstallCertificateRequest(ocpp::Call<InstallCertific
     this->send<InstallCertificateResponse>(call_result);
 
     if (response.status == InstallCertificateStatusEnumType::Rejected) {
-        this->securityEventNotification("InvalidCentralSystemCertificate",
+        this->securityEventNotification(ocpp::security_events::INVALIDCSMSCERTIFICATE,
                                         ocpp::conversions::install_certificate_result_to_string(result), true);
     }
 }
@@ -2348,7 +2362,8 @@ void ChargePointImpl::handleSignedUpdateFirmware(ocpp::Call<SignedUpdateFirmware
     }
 
     if (response.status == UpdateFirmwareStatusEnumType::InvalidCertificate) {
-        this->securityEventNotification("InvalidFirmwareSigningCertificate", "Certificate is invalid.", true);
+        this->securityEventNotification(ocpp::security_events::INVALIDFIRMWARESIGNINGCERTIFICATE,
+                                        "Certificate is invalid.", true);
     }
 }
 
@@ -2413,7 +2428,7 @@ void ChargePointImpl::signed_firmware_update_status_notification(FirmwareStatusE
     this->send<SignedFirmwareStatusNotificationRequest>(call, initiated_by_trigger_message);
 
     if (status == FirmwareStatusEnumType::InvalidSignature) {
-        this->securityEventNotification("InvalidFirmwareSignature", "", true);
+        this->securityEventNotification(ocpp::security_events::INVALIDFIRMWARESIGNATURE, "", true);
     }
 
     if (this->firmware_update_is_pending) {
@@ -2957,7 +2972,7 @@ void ChargePointImpl::handle_data_transfer_pnc_certificate_signed(Call<DataTrans
         this->send<DataTransferResponse>(call_result);
 
         if (certificate_response.status == CertificateSignedStatusEnumType::Rejected) {
-            this->securityEventNotification("InvalidChargePointCertificate", tech_info, true);
+            this->securityEventNotification(ocpp::security_events::INVALIDCHARGINGSTATIONCERTIFICATE, tech_info, true);
         }
     } catch (const json::exception& e) {
         EVLOG_warning << "Could not parse data of DataTransfer message CertificateSigned.req: " << e.what();
@@ -3423,6 +3438,10 @@ void ChargePointImpl::on_firmware_update_status_notification(int32_t request_id,
         }
     } catch (const std::out_of_range& e) {
         EVLOG_debug << "Could not convert incoming FirmwareStatusNotification to OCPP type";
+    }
+
+    if (firmware_update_status == FirmwareStatusNotification::Installed) {
+        this->securityEventNotification(ocpp::security_events::FIRMWARE_UPDATED, "Firmware update was installed", true);
     }
 }
 


### PR DESCRIPTION
* Sending SecurityEventNotification in OCPP1.6 on startup if StartUpOfTheDevice or ResetOrReboot
* added optional BootReason to charge_point start function
* added optional BootReason to charge_point restart function
* using string definitions for all SecurityEventNotifications in 1.6