### PR TITLE
Localised per-thread conn data for a clean disconnect

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -240,7 +240,8 @@ WebsocketConnectionOptions ChargePointImpl::get_ws_connection_options() {
                                                   this->configuration->getUseSslDefaultVerifyPaths(),
                                                   this->configuration->getAdditionalRootCertificateCheck(),
                                                   this->configuration->getHostName(),
-                                                  this->configuration->getVerifyCsmsCommonName()};
+                                                  this->configuration->getVerifyCsmsCommonName(),
+                                                  this->configuration->getUseTPM()};
     return connection_options;
 }
 


### PR DESCRIPTION
- updated thread notify for fast message sending
- fixed the issue in which a message send could timeout due to a wait in the processing thread
- clearer message log
- localized per-thread connection data for a clean state