### PR TITLE
Improved handling in case CSMS responds with CALLERROR or not at all to BootNotification.req

### DIFF
--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -38,7 +38,9 @@ struct MessageQueueConfig {
     bool queue_all_messages; // cf. OCPP 2.0.1. "QueueAllMessages" in OCPPCommCtrlr
 
     int message_timeout_seconds = 30;
-    int boot_notification_retry_interval_seconds = 60; // no retry interval defined in the spec
+    int boot_notification_retry_interval_seconds =
+        60; // interval for BootNotification.req in case response by CSMS is CALLERROR or CSMS does not respond at all
+            // (within specified MessageTimeout)
 };
 
 /// \brief Contains a OCPP message in json form with additional information
@@ -698,7 +700,7 @@ public:
             // Generate a new message ID for the retry
             this->in_flight->message[MESSAGE_ID] = this->createMessageId();
             // Spec does not define how to handle retries for BootNotification.req: We use the
-            // transaction_message_retry_interval
+            // the boot_notification_retry_interval_seconds
             this->in_flight->timestamp =
                 DateTime(this->in_flight->timestamp.to_time_point() +
                          std::chrono::seconds(this->config.boot_notification_retry_interval_seconds));

--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -38,6 +38,7 @@ struct MessageQueueConfig {
     bool queue_all_messages; // cf. OCPP 2.0.1. "QueueAllMessages" in OCPPCommCtrlr
 
     int message_timeout_seconds = 30;
+    int boot_notification_retry_interval_seconds = 60; // no retry interval defined in the spec
 };
 
 /// \brief Contains a OCPP message in json form with additional information
@@ -80,6 +81,9 @@ template <typename M> struct ControlMessage {
 
     /// \brief True for transactional messages containing updates (measurements) for a transaction
     bool isTransactionUpdateMessage() const;
+
+    /// \brief Determine whether message is a BootNotification.
+    bool isBootNotificationMessage() const;
 };
 
 /// \brief contains a message queue that makes sure that OCPPs synchronicity requirements are met
@@ -689,6 +693,22 @@ public:
                     this->in_flight->promise.set_value(enhanced_message);
                 }
             }
+        } else if (this->in_flight->isBootNotificationMessage()) {
+            EVLOG_warning << "Message is BootNotification.req and will therefore be sent again";
+            // Generate a new message ID for the retry
+            this->in_flight->message[MESSAGE_ID] = this->createMessageId();
+            // Spec does not define how to handle retries for BootNotification.req: We use the
+            // transaction_message_retry_interval
+            this->in_flight->timestamp =
+                DateTime(this->in_flight->timestamp.to_time_point() +
+                         std::chrono::seconds(this->config.boot_notification_retry_interval_seconds));
+            this->transaction_message_queue.push_front(this->in_flight);
+            this->notify_queue_timer.at(
+                [this]() {
+                    this->new_message = true;
+                    this->cv.notify_all();
+                },
+                this->in_flight->timestamp.to_time_point());
         } else {
             EVLOG_warning << "Message is not transaction related, dropping it";
             if (enhanced_message_opt) {

--- a/lib/ocpp/common/message_queue.cpp
+++ b/lib/ocpp/common/message_queue.cpp
@@ -26,6 +26,10 @@ template <> bool ControlMessage<v16::MessageType>::isTransactionUpdateMessage() 
     return (this->messageType == v16::MessageType::MeterValues);
 }
 
+template <> bool ControlMessage<v16::MessageType>::isBootNotificationMessage() const {
+    return this->messageType == v16::MessageType::BootNotification;
+}
+
 template <> ControlMessage<v201::MessageType>::ControlMessage(const json& message) {
     this->message = message.get<json::array_t>();
     this->messageType = v201::conversions::string_to_messagetype(message.at(CALL_ACTION));
@@ -46,6 +50,10 @@ template <> bool ControlMessage<v201::MessageType>::isTransactionUpdateMessage()
                v201::TransactionEventEnum::Updated;
     }
     return false;
+}
+
+template <> bool ControlMessage<v201::MessageType>::isBootNotificationMessage() const {
+    return this->messageType == v201::MessageType::BootNotification;
 }
 
 template <> v16::MessageType MessageQueue<v16::MessageType>::string_to_messagetype(const std::string& s) {

--- a/lib/ocpp/v16/types.cpp
+++ b/lib/ocpp/v16/types.cpp
@@ -173,7 +173,6 @@ std::string messagetype_to_string(MessageType m) {
     case MessageType::UpdateFirmwareResponse:
         return "UpdateFirmwareResponse";
     case MessageType::InternalError:
-        EVLOG_error << "No known string conversion for InternalError MessageType";
         return "InternalError";
     }
 

--- a/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/tests/lib/ocpp/common/test_message_queue.cpp
@@ -129,6 +129,10 @@ template <> bool ControlMessage<TestMessageType>::isTransactionUpdateMessage() c
     return this->messageType == TestMessageType::TRANSACTIONAL_UPDATE;
 }
 
+template <> bool ControlMessage<TestMessageType>::isBootNotificationMessage() const {
+    return this->messageType == TestMessageType::BootNotification;
+}
+
 /************************************************************************************************
  * ControlMessage
  *


### PR DESCRIPTION
* Added handling for BootNotification.req in case CSMS responds with CALLERROR or no response at all
* BootNotification now has special handling in the message queue so that it will be repeately sent in case of CALLERROR or no message timeout