### PR TITLE
OCPP1.6: Fix build examples

### DIFF
--- a/src/charge_point.cpp
+++ b/src/charge_point.cpp
@@ -277,7 +277,7 @@ int main(int argc, char* argv[]) {
             } else if (command == "start_transaction") {
                 if (!transaction_running) {
                     uuid = boost::lexical_cast<std::string>(boost::uuids::random_generator()());
-                    charge_point->on_session_started(1, uuid, "EVConnected", std::nullopt);
+                    charge_point->on_session_started(1, uuid, ocpp::SessionStartedReason::EVConnected, std::nullopt);
                     const auto result = charge_point->authorize_id_token(ocpp::CiString<20>(std::string("DEADBEEF")));
                     if (result.status == ocpp::v16::AuthorizationStatus::Accepted) {
                         charge_point->on_transaction_started(1, uuid, "DEADBEEF", 0, std::nullopt, ocpp::DateTime(),


### PR DESCRIPTION
changed type from string to ocpp::SessionStartedReason in 1.6 build examples