### PR TITLE
Number of fixes to the Metervalue implementation for 2.0.1

### DIFF
--- a/config/v201/component_schemas/custom/Connector_1_1.json
+++ b/config/v201/component_schemas/custom/Connector_1_1.json
@@ -35,7 +35,7 @@
       ],
       "description": "Component exists",
       "type": "boolean",
-      "default": "0"
+      "default": false
     },
     "ChargeProtocol": {
       "variable_name": "ChargeProtocol",

--- a/config/v201/component_schemas/custom/Connector_2_1.json
+++ b/config/v201/component_schemas/custom/Connector_2_1.json
@@ -35,7 +35,7 @@
       ],
       "description": "Component exists",
       "type": "boolean",
-      "default": "0"
+      "default": false
     },
     "ChargeProtocol": {
       "variable_name": "ChargeProtocol",

--- a/config/v201/component_schemas/custom/EVSE_1.json
+++ b/config/v201/component_schemas/custom/EVSE_1.json
@@ -51,7 +51,7 @@
       ],
       "description": "Component exists",
       "type": "boolean",
-      "default": "0"
+      "default": false
     },
     "EvseId": {
       "variable_name": "EvseId",

--- a/config/v201/component_schemas/custom/EVSE_2.json
+++ b/config/v201/component_schemas/custom/EVSE_2.json
@@ -51,7 +51,7 @@
       ],
       "description": "Component exists",
       "type": "boolean",
-      "default": "0"
+      "default": false
     },
     "EvseId": {
       "variable_name": "EvseId",

--- a/config/v201/component_schemas/standardized/AlignedDataCtrlr.json
+++ b/config/v201/component_schemas/standardized/AlignedDataCtrlr.json
@@ -16,7 +16,7 @@
           "mutability": "ReadWrite"
         }
       ],
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "AlignedDataCtrlrAvailable": {
@@ -32,7 +32,7 @@
         }
       ],
       "description": "If this variable reports a value of true, Clock-Aligned Data is supported.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "AlignedDataInterval": {
@@ -97,7 +97,7 @@
         }
       ],
       "description": "If set to true, the Charging Station SHALL include signed meter values in the SampledValueType in the MeterValuesRequest to the CSMS.",
-      "default": "0",
+      "default": false,
       "type": "boolean"
     },
     "AlignedDataTxEndedInterval": {

--- a/config/v201/component_schemas/standardized/AuthCacheCtrlr.json
+++ b/config/v201/component_schemas/standardized/AuthCacheCtrlr.json
@@ -17,7 +17,7 @@
         }
       ],
       "description": "Authorization caching is available, but not necessarily enabled.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "AuthCacheCtrlrEnabled": {
@@ -33,7 +33,7 @@
         }
       ],
       "description": "If set to true, Authorization caching is enabled.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "AuthCacheLifeTime": {

--- a/config/v201/component_schemas/standardized/AuthCtrlr.json
+++ b/config/v201/component_schemas/standardized/AuthCtrlr.json
@@ -16,7 +16,7 @@
           "mutability": "ReadWrite"
         }
       ],
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "AdditionalInfoItemsPerMessage": {
@@ -47,7 +47,7 @@
         }
       ],
       "description": "Whether a remote request to start a transaction in the form of RequestStartTransactionRequest message should be authorized beforehand like a local action to start a transaction.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "LocalAuthorizeOffline": {
@@ -63,7 +63,7 @@
         }
       ],
       "description": "Whether the Charging Station, when Offline, will start a transaction for locally-authorized identifiers,",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "LocalPreAuthorize": {
@@ -79,7 +79,7 @@
         }
       ],
       "description": "Whether the Charging Station, when online, will start a transaction for locally-authorized identifiers without waiting for or requesting an AuthorizeResponse from the CSMS.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "MasterPassGroupId": {
@@ -110,7 +110,7 @@
         }
       ],
       "description": "Support for unknown offline transactions.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "DisableRemoteAuthorization": {

--- a/config/v201/component_schemas/standardized/InternalCtrlr.json
+++ b/config/v201/component_schemas/standardized/InternalCtrlr.json
@@ -16,7 +16,7 @@
                   "mutability": "ReadWrite"
               }
           ],
-          "default": "1",
+          "default": true,
           "type": "boolean"
       },
       "ChargePointId": {
@@ -240,7 +240,7 @@
                   "mutability": "ReadOnly"
               }
           ],
-          "default": "1",
+          "default": true,
           "type": "boolean"
       },
       "LogMessages": {
@@ -255,7 +255,7 @@
                   "mutability": "ReadOnly"
               }
           ],
-          "default": "1",
+          "default": true,
           "type": "boolean"
       },
       "LogMessagesFormat": {
@@ -338,7 +338,7 @@
               }
           ],
           "description": "Use default verify paths for validating CSMS server certificate",
-          "default": "1",
+          "default": true,
           "type": "boolean"
       },
       "OcspRequestInterval": {
@@ -483,7 +483,7 @@
                 "mutability": "ReadOnly"
             }
         ],
-        "default": "0",
+        "default": false,
         "type": "boolean"
       },
       "MessageQueueSizeThreshold": {
@@ -551,7 +551,7 @@
               }
           ],
           "description": "If enabled the metervalues configured with the AlignedDataCtrlr will be rounded to the exact time intervals",
-          "default": "0",
+          "default": false,
           "type": "boolean"
       }
   },

--- a/config/v201/component_schemas/standardized/InternalCtrlr.json
+++ b/config/v201/component_schemas/standardized/InternalCtrlr.json
@@ -537,6 +537,21 @@
           "description": "List of criteria supported for a get custom report. Enabled,Active,Problem,Available",
           "default": "Enabled,Active,Problem,Available",
           "type": "string"
+      },
+      "RoundClockAlignedTimestamps": {
+          "variable_name": "RoundClockAlignedTimestamps",
+          "characteristics": {
+              "supportsMonitoring": false,
+              "dataType": "boolean"
+          },
+          "attributes": [
+              {
+                  "type": "Actual",
+                  "mutability": "ReadOnly"
+              }
+          ],
+          "default": "0",
+          "type": "boolean"
       }
   },
   "required": [

--- a/config/v201/component_schemas/standardized/InternalCtrlr.json
+++ b/config/v201/component_schemas/standardized/InternalCtrlr.json
@@ -550,6 +550,7 @@
                   "mutability": "ReadOnly"
               }
           ],
+          "description": "If enabled the metervalues configured with the AlignedDataCtrlr will be rounded to the exact time intervals",
           "default": "0",
           "type": "boolean"
       }

--- a/config/v201/component_schemas/standardized/LocalAuthListCtrlr.json
+++ b/config/v201/component_schemas/standardized/LocalAuthListCtrlr.json
@@ -17,7 +17,7 @@
         }
       ],
       "description": "Local Authorization List is available.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "BytesPerMessageSendLocalList": {
@@ -48,7 +48,7 @@
         }
       ],
       "description": "If this variable exists and reports a value of true, Local Authorization List is enabled.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "LocalAuthListCtrlrEntries": {

--- a/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
+++ b/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
@@ -278,7 +278,7 @@
         }
       ],
       "description": "When set to true, the Charging Station SHALL unlock the cable on the Charging Station side when the cable is unplugged at the EV. For an EVSE with only fixed cables, the mutability SHALL be ReadOnly and the actual value SHALL be false. For a charging station with fixed cables and sockets, the variable is only applicable to the sockets.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "WebSocketPingInterval": {

--- a/config/v201/component_schemas/standardized/ReservationCtrlr.json
+++ b/config/v201/component_schemas/standardized/ReservationCtrlr.json
@@ -17,7 +17,7 @@
         }
       ],
       "description": "Whether reservation is supported.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "ReservationCtrlrEnabled": {
@@ -33,7 +33,7 @@
         }
       ],
       "description": "Whether reservation is enabled.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "ReservationCtrlrNonEvseSpecific": {

--- a/config/v201/component_schemas/standardized/SampledDataCtrlr.json
+++ b/config/v201/component_schemas/standardized/SampledDataCtrlr.json
@@ -17,7 +17,7 @@
         }
       ],
       "description": "If this variable reports a value of true, Sampled Data is supported",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "SampledDataCtrlrEnabled": {
@@ -33,7 +33,7 @@
         }
       ],
       "description": "If this variable reports a value of true, Sampled Data is enabled.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "SampledDataSignReadings": {

--- a/config/v201/component_schemas/standardized/SecurityCtrlr.json
+++ b/config/v201/component_schemas/standardized/SecurityCtrlr.json
@@ -16,7 +16,7 @@
           "mutability": "ReadWrite"
         }
       ],
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "AdditionalRootCertificateCheck": {
@@ -32,7 +32,7 @@
         }
       ],
       "description": "Required for all security profiles except profile 1.",
-      "default": "0",
+      "default": false,
       "type": "boolean"
     },
     "BasicAuthPassword": {

--- a/config/v201/component_schemas/standardized/TxCtrlr.json
+++ b/config/v201/component_schemas/standardized/TxCtrlr.json
@@ -16,7 +16,7 @@
           "mutability": "ReadWrite"
         }
       ],
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "ChargingTime": {
@@ -80,7 +80,7 @@
         }
       ],
       "description": "When set to true, the Charging Station SHALL deauthorize the transaction when the cable is unplugged from the EV.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "StopTxOnInvalidId": {
@@ -96,7 +96,7 @@
         }
       ],
       "description": "Whether the Charging Station will deauthorize an ongoing transaction when it receives a non- Accepted authorization status in TransactionEventResponse for this transaction.",
-      "default": "1",
+      "default": true,
       "type": "boolean"
     },
     "TxBeforeAcceptedEnabled": {

--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -271,8 +271,13 @@
                 "attributes": {
                     "Actual": "0"
                 }
+            },
+            "RoundClockAlignedTimestamps": {
+                "variable_name": "RoundClockAlignedTimestamps",
+                "attributes": {
+                    "Actual": "0"
+                }
             }
-            
         }
     },
     {

--- a/include/ocpp/common/aligned_timer.hpp
+++ b/include/ocpp/common/aligned_timer.hpp
@@ -68,20 +68,23 @@ public:
 
     template <class Rep, class Period>
     system_time_point interval_starting_from(const std::function<void()>& callback,
-                                const std::chrono::duration<Rep, Period> interval, system_time_point start_point) {
+                                             const std::chrono::duration<Rep, Period> interval,
+                                             system_time_point start_point) {
         this->callback = callback;
         return this->interval_starting_from(interval, start_point);
     }
 
     template <class Rep, class Period>
-    system_time_point interval_starting_from(const std::chrono::duration<Rep, Period> interval, system_time_point start_point) {
+    system_time_point interval_starting_from(const std::chrono::duration<Rep, Period> interval,
+                                             system_time_point start_point) {
         this->start_point = start_point;
         this->call_interval = interval;
 
         return this->call_next();
     }
 
-    template <class Rep, class Period> system_time_point set_interval(const std::chrono::duration<Rep, Period>& interval) {
+    template <class Rep, class Period>
+    system_time_point set_interval(const std::chrono::duration<Rep, Period>& interval) {
         this->call_interval = interval;
         return this->call_next();
     }

--- a/include/ocpp/common/aligned_timer.hpp
+++ b/include/ocpp/common/aligned_timer.hpp
@@ -41,9 +41,9 @@ private:
         return next_time;
     }
 
-    void call_next() {
+    system_time_point call_next() {
         if (this->callback == nullptr) {
-            return;
+            return system_time_point{};
         }
 
         auto wrapper = [this]() {
@@ -51,7 +51,9 @@ private:
             this->at(this->get_next_timepoint());
         };
 
-        this->at(wrapper, this->get_next_timepoint());
+        auto next_timepoint = this->get_next_timepoint();
+        this->at(wrapper, next_timepoint);
+        return next_timepoint;
     }
 
 public:
@@ -65,23 +67,23 @@ public:
     }
 
     template <class Rep, class Period>
-    void interval_starting_from(const std::function<void()>& callback,
+    system_time_point interval_starting_from(const std::function<void()>& callback,
                                 const std::chrono::duration<Rep, Period> interval, system_time_point start_point) {
         this->callback = callback;
-        this->interval_starting_from(interval, start_point);
+        return this->interval_starting_from(interval, start_point);
     }
 
     template <class Rep, class Period>
-    void interval_starting_from(const std::chrono::duration<Rep, Period> interval, system_time_point start_point) {
+    system_time_point interval_starting_from(const std::chrono::duration<Rep, Period> interval, system_time_point start_point) {
         this->start_point = start_point;
         this->call_interval = interval;
 
-        this->call_next();
+        return this->call_next();
     }
 
-    template <class Rep, class Period> void set_interval(const std::chrono::duration<Rep, Period>& interval) {
+    template <class Rep, class Period> system_time_point set_interval(const std::chrono::duration<Rep, Period>& interval) {
         this->call_interval = interval;
-        this->call_next();
+        return this->call_next();
     }
 
     using Everest::Timer<std::chrono::system_clock>::stop;

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -54,6 +54,7 @@ extern const ComponentVariable& LogMessages;
 extern const RequiredComponentVariable& LogMessagesFormat;
 extern const ComponentVariable& SupportedChargingProfilePurposeTypes;
 extern const ComponentVariable& SupportedCriteria;
+extern const ComponentVariable& RoundClockAlignedTimestamps;
 extern const ComponentVariable& MaxCompositeScheduleDuration;
 extern const RequiredComponentVariable& NumberOfConnectors;
 extern const ComponentVariable& UseSslDefaultVerifyPaths;

--- a/include/ocpp/v201/transaction.hpp
+++ b/include/ocpp/v201/transaction.hpp
@@ -20,8 +20,8 @@ struct EnhancedTransaction : public Transaction {
     std::optional<float> active_energy_import_start_value;
     bool check_max_active_import_energy;
 
-    Everest::SteadyTimer sampled_tx_updated_meter_values_timer;
-    Everest::SteadyTimer sampled_tx_ended_meter_values_timer;
+    ClockAlignedTimer sampled_tx_updated_meter_values_timer;
+    ClockAlignedTimer sampled_tx_ended_meter_values_timer;
     ClockAlignedTimer aligned_tx_updated_meter_values_timer;
     ClockAlignedTimer aligned_tx_ended_meter_values_timer;
 

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -33,11 +33,9 @@ MeterValue get_meter_value_with_measurands_applied(const MeterValue& _meter_valu
 /// Sample_Clock will be filtered using \p aligned_tx_ended_measurands
 /// Any metervalue after \p max_timestamp will also be removed.
 ///\retval filtered meter values
-std::vector<MeterValue>
-get_meter_values_with_measurands_applied(const std::vector<MeterValue>& meter_values,
-                                         const std::vector<MeasurandEnum>& sampled_tx_ended_measurands,
-                                         const std::vector<MeasurandEnum>& aligned_tx_ended_measurands,
-                                         ocpp::DateTime max_timestamp);
+std::vector<MeterValue> get_meter_values_with_measurands_applied(
+    const std::vector<MeterValue>& meter_values, const std::vector<MeasurandEnum>& sampled_tx_ended_measurands,
+    const std::vector<MeasurandEnum>& aligned_tx_ended_measurands, ocpp::DateTime max_timestamp);
 
 /// \brief Converts the given \p stop_reason to a TriggerReasonEnum
 /// \param stop_reason

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -14,8 +14,8 @@ namespace utils {
 /// \brief std::vector<MeasurandEnum> of the configured AlignedDataMeasurands
 std::vector<MeasurandEnum> get_measurands_vec(const std::string& measurands_csv);
 
-///\brief This function determines if any of the \p measurands is present in the \p _meter_value at all
-///\return True if any measurand is found, false otherwise
+/// \brief This function determines if any of the \p measurands is present in the \p _meter_value at all
+/// \return True if any measurand is found, false otherwise
 bool meter_value_has_any_measurand(const MeterValue& _meter_value, const std::vector<MeasurandEnum>& measurands);
 
 /// \brief Applies the given \p measurands to the given \p _meter_value . The returned meter value will only contain
@@ -27,12 +27,12 @@ bool meter_value_has_any_measurand(const MeterValue& _meter_value, const std::ve
 MeterValue get_meter_value_with_measurands_applied(const MeterValue& _meter_value,
                                                    const std::vector<MeasurandEnum>& measurands);
 
-///\brief Applies the given measurands to \p meter_values based on their ReadingContext.
+/// \brief Applies the given measurands to \p meter_values based on their ReadingContext.
 /// Transaction_Begin, Interruption_Begin, Transaction_End, Interruption_End and Sample_Periodic will be filtered using
 /// \p sampled_tx_ended_measurands.
 /// Sample_Clock will be filtered using \p aligned_tx_ended_measurands
 /// Any metervalue after \p max_timestamp will also be removed.
-///\retval filtered meter values
+/// \retval filtered meter values
 std::vector<MeterValue> get_meter_values_with_measurands_applied(
     const std::vector<MeterValue>& meter_values, const std::vector<MeasurandEnum>& sampled_tx_ended_measurands,
     const std::vector<MeasurandEnum>& aligned_tx_ended_measurands, ocpp::DateTime max_timestamp);
@@ -47,15 +47,15 @@ TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ReasonEnum& stop_reas
 /// \return
 std::string sha256(const std::string& str);
 
-/// @brief Return a SHA256 hash generated from a combination of the \p token type and id
-/// @param token the token to generate the hash for
-/// @return A SHA256 hash string
+/// \brief Return a SHA256 hash generated from a combination of the \p token type and id
+/// \param token the token to generate the hash for
+/// \return A SHA256 hash string
 std::string generate_token_hash(const IdToken& token);
 
-/// @brief Align the clock aligned timestamps to the interval values
-/// @param timestamp the timestamp to align
-/// @param align_interval the clock aligned interval to align to since midnight 00:00
-/// @return DateTime type timestamp
+/// \brief Align the clock aligned timestamps to the interval values
+/// \param timestamp the timestamp to align
+/// \param align_interval the clock aligned interval to align to since midnight 00:00
+/// \return DateTime type timestamp
 ocpp::DateTime align_timestamp(const DateTime timestamp, std::chrono::seconds align_interval);
 
 } // namespace utils

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -31,11 +31,13 @@ MeterValue get_meter_value_with_measurands_applied(const MeterValue& _meter_valu
 /// Transaction_Begin, Interruption_Begin, Transaction_End, Interruption_End and Sample_Periodic will be filtered using
 /// \p sampled_tx_ended_measurands.
 /// Sample_Clock will be filtered using \p aligned_tx_ended_measurands
+/// Any metervalue after \p max_timestamp will also be removed.
 ///\retval filtered meter values
 std::vector<MeterValue>
 get_meter_values_with_measurands_applied(const std::vector<MeterValue>& meter_values,
                                          const std::vector<MeasurandEnum>& sampled_tx_ended_measurands,
-                                         const std::vector<MeasurandEnum>& aligned_tx_ended_measurands);
+                                         const std::vector<MeasurandEnum>& aligned_tx_ended_measurands,
+                                         ocpp::DateTime max_timestamp);
 
 /// \brief Converts the given \p stop_reason to a TriggerReasonEnum
 /// \param stop_reason
@@ -51,6 +53,12 @@ std::string sha256(const std::string& str);
 /// @param token the token to generate the hash for
 /// @return A SHA256 hash string
 std::string generate_token_hash(const IdToken& token);
+
+/// @brief Align the clock aligned timestamps to the interval values
+/// @param timestamp the timestamp to align
+/// @param align_interval the clock aligned interval to align to since midnight 00:00
+/// @return DateTime type timestamp
+ocpp::DateTime align_timestamp(const DateTime timestamp, std::chrono::seconds align_interval);
 
 } // namespace utils
 } // namespace v201

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -354,7 +354,8 @@ void ChargePoint::on_transaction_finished(const int32_t evse_id, const DateTime&
         utils::get_measurands_vec(
             this->device_model->get_value<std::string>(ControllerComponentVariables::SampledDataTxEndedMeasurands)),
         utils::get_measurands_vec(
-            this->device_model->get_value<std::string>(ControllerComponentVariables::AlignedDataTxEndedMeasurands))));
+            this->device_model->get_value<std::string>(ControllerComponentVariables::AlignedDataTxEndedMeasurands)),
+            timestamp));
 
     if (meter_values.value().empty()) {
         meter_values.reset();
@@ -1222,7 +1223,7 @@ void ChargePoint::update_aligned_data_interval() {
     }
 
     this->aligned_meter_values_timer.interval_starting_from(
-        [this]() {
+        [this, interval]() {
             // J01.FR.20 if AlignedDataSendDuringIdle is true and any transaction is active, don't send clock aligned
             // meter values
             if (this->device_model->get_optional_value<bool>(ControllerComponentVariables::AlignedDataSendDuringIdle)
@@ -1235,11 +1236,12 @@ void ChargePoint::update_aligned_data_interval() {
             }
 
             // send evseID = 0 values
-            const auto meter_value = get_latest_meter_value_filtered(
-                this->aligned_data_evse0.retrieve_processed_values(), ReadingContextEnum::Sample_Clock,
-                ControllerComponentVariables::AlignedDataMeasurands);
+            auto meter_value = get_latest_meter_value_filtered(this->aligned_data_evse0.retrieve_processed_values(),
+                                                               ReadingContextEnum::Sample_Clock,
+                                                               ControllerComponentVariables::AlignedDataMeasurands);
 
             if (!meter_value.sampledValue.empty()) {
+                meter_value.timestamp = utils::align_timestamp(DateTime{}, interval);
                 this->meter_values_req(0, std::vector<ocpp::v201::MeterValue>(1, meter_value));
             }
             this->aligned_data_evse0.clear_values();
@@ -1251,9 +1253,10 @@ void ChargePoint::update_aligned_data_interval() {
 
                 // this will apply configured measurands and possibly reduce the entries of sampledValue
                 // according to the configuration
-                const auto meter_value =
+                auto meter_value =
                     get_latest_meter_value_filtered(evse->get_idle_meter_value(), ReadingContextEnum::Sample_Clock,
                                                     ControllerComponentVariables::AlignedDataMeasurands);
+                meter_value.timestamp = utils::align_timestamp(DateTime{}, interval);
 
                 if (!meter_value.sampledValue.empty()) {
                     // J01.FR.14 this is the only case where we send a MeterValue.req

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -355,7 +355,7 @@ void ChargePoint::on_transaction_finished(const int32_t evse_id, const DateTime&
             this->device_model->get_value<std::string>(ControllerComponentVariables::SampledDataTxEndedMeasurands)),
         utils::get_measurands_vec(
             this->device_model->get_value<std::string>(ControllerComponentVariables::AlignedDataTxEndedMeasurands)),
-            timestamp));
+        timestamp));
 
     if (meter_values.value().empty()) {
         meter_values.reset();

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -158,6 +158,13 @@ const ComponentVariable& SupportedCriteria = {
         "SupportedCriteria",
     }),
 };
+const ComponentVariable& RoundClockAlignedTimestamps = {
+    ControllerComponents::InternalCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "RoundClockAlignedTimestamps",
+    }),
+};
 const ComponentVariable& SupportedChargingProfilePurposeTypes = {
     ControllerComponents::InternalCtrlr,
     std::nullopt,

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -90,21 +90,23 @@ void Evse::open_transaction(const std::string& transaction_id, const int32_t con
     this->aligned_data_tx_end.clear_values();
 
     if (sampled_data_tx_updated_interval > 0s) {
-        transaction->sampled_tx_updated_meter_values_timer.interval(
+        transaction->sampled_tx_updated_meter_values_timer.interval_starting_from(
             [this] {
                 this->transaction_meter_value_req(this->get_meter_value(), this->transaction->get_transaction(),
                                                   transaction->get_seq_no(), this->transaction->reservation_id);
             },
-            sampled_data_tx_updated_interval);
+            sampled_data_tx_updated_interval,
+            date::utc_clock::to_sys(timestamp.to_time_point()));
     }
 
     if (sampled_data_tx_ended_interval > 0s) {
-        transaction->sampled_tx_ended_meter_values_timer.interval(
+        transaction->sampled_tx_ended_meter_values_timer.interval_starting_from(
             [this] {
                 this->database_handler->transaction_metervalues_insert(this->transaction->transactionId.get(),
                                                                        this->get_meter_value());
             },
-            sampled_data_tx_ended_interval);
+            sampled_data_tx_ended_interval,
+            date::utc_clock::to_sys(timestamp.to_time_point()));
     }
 
     if (aligned_data_tx_updated_interval > 0s) {
@@ -159,7 +161,7 @@ void Evse::open_transaction(const std::string& transaction_id, const int32_t con
         // but this code is processed just after the interval.
         // For example, aligned interval = 1 min, transaction started at 11:59:59.500 and we get here on 12:00:00.100.
         // There is still the expectation for us to add a metervalue at timepoint 12:00:00.000 which we do with this.
-        if (date::utc_clock::to_sys(timestamp.to_time_point()) < (next_interval - aligned_data_tx_ended_interval)) {
+        if (date::utc_clock::to_sys(timestamp.to_time_point()) <= (next_interval - aligned_data_tx_ended_interval)) {
             store_aligned_metervalue();
         }
     }

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -126,7 +126,11 @@ void Evse::open_transaction(const std::string& transaction_id, const int32_t con
                 for (auto& item : meter_value.sampledValue) {
                     item.context = ReadingContextEnum::Sample_Clock;
                 }
-                meter_value.timestamp = utils::align_timestamp(DateTime{}, aligned_data_tx_updated_interval);
+                if (this->device_model
+                        .get_optional_value<bool>(ControllerComponentVariables::RoundClockAlignedTimestamps)
+                        .value_or(false)) {
+                    meter_value.timestamp = utils::align_timestamp(DateTime{}, aligned_data_tx_updated_interval);
+                }
                 this->transaction_meter_value_req(meter_value, this->transaction->get_transaction(),
                                                   transaction->get_seq_no(), this->transaction->reservation_id);
                 this->aligned_data_updated.clear_values();
@@ -147,7 +151,11 @@ void Evse::open_transaction(const std::string& transaction_id, const int32_t con
                 for (auto& item : meter_value.sampledValue) {
                     item.context = ReadingContextEnum::Sample_Clock;
                 }
-                meter_value.timestamp = utils::align_timestamp(DateTime{}, aligned_data_tx_ended_interval);
+                if (this->device_model
+                        .get_optional_value<bool>(ControllerComponentVariables::RoundClockAlignedTimestamps)
+                        .value_or(false)) {
+                    meter_value.timestamp = utils::align_timestamp(DateTime{}, aligned_data_tx_ended_interval);
+                }
                 this->database_handler->transaction_metervalues_insert(this->transaction->transactionId.get(),
                                                                        meter_value);
                 this->aligned_data_tx_end.clear_values();

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -54,11 +54,12 @@ MeterValue get_meter_value_with_measurands_applied(const MeterValue& _meter_valu
 std::vector<MeterValue>
 get_meter_values_with_measurands_applied(const std::vector<MeterValue>& meter_values,
                                          const std::vector<MeasurandEnum>& sampled_tx_ended_measurands,
-                                         const std::vector<MeasurandEnum>& aligned_tx_ended_measurands) {
+                                         const std::vector<MeasurandEnum>& aligned_tx_ended_measurands,
+                                         ocpp::DateTime max_timestamp) {
     std::vector<MeterValue> meter_values_result;
 
     for (const auto& meter_value : meter_values) {
-        if (meter_value.sampledValue.empty()) {
+        if (meter_value.sampledValue.empty() or meter_value.timestamp > max_timestamp) {
             continue;
         }
 
@@ -156,6 +157,27 @@ std::string sha256(const std::string& str) {
 
 std::string generate_token_hash(const IdToken& token) {
     return sha256(conversions::id_token_enum_to_string(token.type) + token.idToken.get());
+}
+
+ocpp::DateTime align_timestamp(const DateTime timestamp, std::chrono::seconds align_interval) {
+    if (align_interval.count() < 0) {
+        EVLOG_warning << "Invalid align interval value";
+        return timestamp;
+    }
+
+    auto timestamp_sys = date::utc_clock::to_sys(timestamp.to_time_point());
+    // get the current midnight
+    auto midnight = std::chrono::floor<date::days>(timestamp_sys);
+    auto seconds_since_midnight = std::chrono::duration_cast<std::chrono::seconds>(timestamp_sys - midnight);
+    auto rounded_seconds = ((seconds_since_midnight + align_interval / 2) / align_interval) * align_interval;
+    auto rounded_time = ocpp::DateTime(date::utc_clock::from_sys(midnight + rounded_seconds));
+
+    // Output the original and rounded timestamps
+    EVLOG_debug << "Original Timestamp: " << timestamp.to_rfc3339() << std::endl;
+    EVLOG_debug << "Interval: " << align_interval.count() << std::endl;
+    EVLOG_debug << "Rounded Timestamp: " << rounded_time;
+
+    return rounded_time;
 }
 
 } // namespace utils

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -51,11 +51,9 @@ MeterValue get_meter_value_with_measurands_applied(const MeterValue& _meter_valu
     return meter_value;
 }
 
-std::vector<MeterValue>
-get_meter_values_with_measurands_applied(const std::vector<MeterValue>& meter_values,
-                                         const std::vector<MeasurandEnum>& sampled_tx_ended_measurands,
-                                         const std::vector<MeasurandEnum>& aligned_tx_ended_measurands,
-                                         ocpp::DateTime max_timestamp) {
+std::vector<MeterValue> get_meter_values_with_measurands_applied(
+    const std::vector<MeterValue>& meter_values, const std::vector<MeasurandEnum>& sampled_tx_ended_measurands,
+    const std::vector<MeasurandEnum>& aligned_tx_ended_measurands, ocpp::DateTime max_timestamp) {
     std::vector<MeterValue> meter_values_result;
 
     for (const auto& meter_value : meter_values) {


### PR DESCRIPTION
* Configurable rounding of clock aligned timestamps
* Filtering of tx ended meter values after the transaction has ended
* Correctly aligning the sampled data to the start of the transaction
* Clearing of accumulated metervalues before starting a transaction to clear out the idle metervalues
* Fix edge case where transaction start time is before an interval and code is run after an interval