### PR TITLE
SmartChargingHandler: Add validation for TxProfiles

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -217,7 +217,7 @@ private:
     bool skip_invalid_csms_certificate_notifications;
 
     /// \brief Component responsible for maintaining and persisting the operational status of CS, EVSEs, and connectors.
-    std::shared_ptr<ComponentStateManager> component_state_manager;
+    std::shared_ptr<ComponentStateManagerInterface> component_state_manager;
 
     // store the connector status
     struct EvseConnectorPair {

--- a/include/ocpp/v201/connector.hpp
+++ b/include/ocpp/v201/connector.hpp
@@ -42,7 +42,7 @@ private:
     int32_t connector_id;
 
     /// \brief Component responsible for maintaining and monitoring the operational status of CS, EVSEs, and connectors.
-    std::shared_ptr<ComponentStateManager> component_state_manager;
+    std::shared_ptr<ComponentStateManagerInterface> component_state_manager;
 
     /// \brief status mutex to protect the status of the connector against concurrent updates
     std::mutex status_mutex;
@@ -53,7 +53,7 @@ public:
     /// \param connector_id id of the connector
     /// \param component_state_manager A shared reference to the component state manager
     Connector(const int32_t evse_id, const int32_t connector_id,
-              std::shared_ptr<ComponentStateManager> component_state_manager);
+              std::shared_ptr<ComponentStateManagerInterface> component_state_manager);
 
     /// \brief Gets the effective Operative/Inoperative status of this connector
     OperationalStatusEnum get_effective_operational_status();

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -46,7 +46,7 @@ private:
     AverageMeterValues aligned_data_tx_end;
 
     /// \brief Component responsible for maintaining and persisting the operational status of CS, EVSEs, and connectors.
-    std::shared_ptr<ComponentStateManager> component_state_manager;
+    std::shared_ptr<ComponentStateManagerInterface> component_state_manager;
 
 public:
     /// \brief Construct a new Evse object
@@ -58,7 +58,7 @@ public:
     /// invalid id being exceeded
     Evse(const int32_t evse_id, const int32_t number_of_connectors, DeviceModel& device_model,
          std::shared_ptr<DatabaseHandler> database_handler,
-         std::shared_ptr<ComponentStateManager> component_state_manager,
+         std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
          const std::function<void(const MeterValue& meter_value, const Transaction& transaction, const int32_t seq_no,
                                   const std::optional<int32_t> reservation_id)>& transaction_meter_value_req,
          const std::function<void()> pause_charging_callback);

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#ifndef OCPP_V201_SMART_CHARGING_HPP
+#define OCPP_V201_SMART_CHARGING_HPP
+
+#include "ocpp/v201/enums.hpp"
+#include <limits>
+
+#include <ocpp/v201/database_handler.hpp>
+#include <ocpp/v201/evse.hpp>
+#include <ocpp/v201/ocpp_types.hpp>
+#include <ocpp/v201/transaction.hpp>
+
+namespace ocpp::v201 {
+
+enum class ProfileValidationResultEnum {
+    Valid,
+    TxProfileMissingTransactionId,
+    TxProfileEvseIdNotGreaterThanZero,
+    TxProfileTransactionNotOnEvse,
+    TxProfileEvseHasNoActiveTransaction,
+    TxProfileConflictingStackLevel
+};
+
+/// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
+/// to calculate the composite schedules
+class SmartChargingHandler {
+private:
+    std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler;
+    // cppcheck-suppress unusedStructMember
+    std::vector<ChargingProfile> charging_profiles;
+
+public:
+    explicit SmartChargingHandler();
+
+    ///
+    /// \brief validates the given \p profile according to the specification
+    ///
+    ProfileValidationResultEnum validate_tx_profile(const ChargingProfile& profile, Evse& evse) const;
+
+    /// \brief Adds a given \p profile to our stored list of profiles
+    void add_profile(const ChargingProfile& profile);
+};
+
+} // namespace ocpp::v201
+
+#endif // OCPP_V201_SMART_CHARGING_HPP

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(ocpp
         ocpp/v16/types.cpp
         ocpp/v201/average_meter_values.cpp
         ocpp/v201/charge_point.cpp
+        ocpp/v201/smart_charging.cpp
         ocpp/v201/connector.cpp
         ocpp/v201/ctrlr_component_variables.cpp
         ocpp/v201/database_handler.cpp

--- a/lib/ocpp/v201/component_state_manager.cpp
+++ b/lib/ocpp/v201/component_state_manager.cpp
@@ -6,6 +6,9 @@
 
 namespace ocpp::v201 {
 
+ComponentStateManagerInterface::~ComponentStateManagerInterface() {
+}
+
 void ComponentStateManager::read_all_states_from_database_or_set_defaults(
     const std::map<int32_t, int32_t>& evse_connector_structure) {
 

--- a/lib/ocpp/v201/connector.cpp
+++ b/lib/ocpp/v201/connector.cpp
@@ -33,7 +33,7 @@ std::string connector_event_to_string(ConnectorEvent e) {
 } // namespace conversions
 
 Connector::Connector(const int32_t evse_id, const int32_t connector_id,
-                     std::shared_ptr<ComponentStateManager> component_state_manager) :
+                     std::shared_ptr<ComponentStateManagerInterface> component_state_manager) :
     evse_id(evse_id), connector_id(connector_id), component_state_manager(component_state_manager) {
 }
 

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -348,8 +348,12 @@ int32_t DatabaseHandler::get_local_authorization_list_number_of_entries() {
 }
 
 bool DatabaseHandler::transaction_metervalues_insert(const std::string& transaction_id, const MeterValue& meter_value) {
+    if (meter_value.sampledValue.empty()) {
+        return false;
+    }
+
     auto sampled_value_context = meter_value.sampledValue.at(0).context;
-    if (meter_value.sampledValue.empty() or !sampled_value_context.has_value()) {
+    if (!sampled_value_context.has_value()) {
         return false;
     }
 

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -40,7 +40,7 @@ static float get_normalized_energy_value(SampledValue sampled_value) {
 
 Evse::Evse(const int32_t evse_id, const int32_t number_of_connectors, DeviceModel& device_model,
            std::shared_ptr<DatabaseHandler> database_handler,
-           std::shared_ptr<ComponentStateManager> component_state_manager,
+           std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
            const std::function<void(const MeterValue& meter_value, const Transaction& transaction, const int32_t seq_no,
                                     const std::optional<int32_t> reservation_id)>& transaction_meter_value_req,
            const std::function<void()> pause_charging_callback) :

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include "ocpp/common/types.hpp"
+#include "ocpp/v201/enums.hpp"
+#include "ocpp/v201/ocpp_types.hpp"
+#include "ocpp/v201/transaction.hpp"
+#include <memory>
+#include <ocpp/v201/smart_charging.hpp>
+
+using namespace std::chrono;
+
+namespace ocpp::v201 {
+
+SmartChargingHandler::SmartChargingHandler() {
+}
+
+ProfileValidationResultEnum SmartChargingHandler::validate_tx_profile(const ChargingProfile& profile,
+                                                                      Evse& evse) const {
+    if (!profile.transactionId.has_value()) {
+        return ProfileValidationResultEnum::TxProfileMissingTransactionId;
+    }
+
+    int32_t evseId = evse.get_evse_info().id;
+    if (evseId <= 0) {
+        return ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero;
+    }
+
+    if (!evse.has_active_transaction()) {
+        return ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction;
+    }
+
+    auto& transaction = evse.get_transaction();
+    if (transaction->transactionId != profile.transactionId.value()) {
+        return ProfileValidationResultEnum::TxProfileTransactionNotOnEvse;
+    }
+
+    auto conflicts_with = [&profile](const ChargingProfile& candidate) {
+        return candidate.transactionId == profile.transactionId && candidate.stackLevel == profile.stackLevel;
+    };
+    if (std::any_of(charging_profiles.begin(), charging_profiles.end(), conflicts_with)) {
+        return ProfileValidationResultEnum::TxProfileConflictingStackLevel;
+    }
+
+    return ProfileValidationResultEnum::Valid;
+}
+
+void SmartChargingHandler::add_profile(const ChargingProfile& profile) {
+    charging_profiles.push_back(profile);
+}
+
+} // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/CMakeLists.txt
+++ b/tests/lib/ocpp/v201/CMakeLists.txt
@@ -1,7 +1,9 @@
+target_include_directories(libocpp_unit_tests PUBLIC mocks)
 
 target_sources(libocpp_unit_tests PRIVATE
         test_device_model_storage_sqlite.cpp
         test_notify_report_requests_splitter.cpp
         test_ocsp_updater.cpp
         test_component_state_manager.cpp
-        test_device_model.cpp)
+        test_device_model.cpp
+        test_smart_charging_handler.cpp)

--- a/tests/lib/ocpp/v201/mocks/component_state_manager_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/component_state_manager_mock.hpp
@@ -1,0 +1,44 @@
+#include <gmock/gmock.h>
+
+#include "ocpp/v201/component_state_manager.hpp"
+
+namespace ocpp::v201 {
+class ComponentStateManagerMock : public ComponentStateManagerInterface {
+    MOCK_METHOD(void, set_cs_effective_availability_changed_callback,
+                (const std::function<void(const OperationalStatusEnum new_status)>& callback));
+
+    MOCK_METHOD(void, set_evse_effective_availability_changed_callback,
+                (const std::function<void(const int32_t evse_id, const OperationalStatusEnum new_status)>& callback));
+
+    MOCK_METHOD(void, set_connector_effective_availability_changed_callback,
+                (const std::function<void(const int32_t evse_id, const int32_t connector_id,
+                                          const OperationalStatusEnum new_status)>& callback));
+
+    MOCK_METHOD(OperationalStatusEnum, get_cs_individual_operational_status, ());
+    MOCK_METHOD(OperationalStatusEnum, get_evse_individual_operational_status, (int32_t evse_id));
+    MOCK_METHOD(OperationalStatusEnum, get_connector_individual_operational_status,
+                (int32_t evse_id, int32_t connector_id));
+    MOCK_METHOD(OperationalStatusEnum, get_cs_persisted_operational_status, ());
+    MOCK_METHOD(OperationalStatusEnum, get_evse_persisted_operational_status, (int32_t evse_id));
+    MOCK_METHOD(OperationalStatusEnum, get_connector_persisted_operational_status,
+                (int32_t evse_id, int32_t connector_id));
+    MOCK_METHOD(void, set_cs_individual_operational_status, (OperationalStatusEnum new_status, bool persist));
+    MOCK_METHOD(void, set_evse_individual_operational_status,
+                (int32_t evse_id, OperationalStatusEnum new_status, bool persist));
+    MOCK_METHOD(void, set_connector_individual_operational_status,
+                (int32_t evse_id, int32_t connector_id, OperationalStatusEnum new_status, bool persist));
+    MOCK_METHOD(OperationalStatusEnum, get_evse_effective_operational_status, (int32_t evse_id));
+    MOCK_METHOD(OperationalStatusEnum, get_connector_effective_operational_status,
+                (int32_t evse_id, int32_t connector_id));
+    MOCK_METHOD(ConnectorStatusEnum, get_connector_effective_status, (int32_t evse_id, int32_t connector_id));
+    MOCK_METHOD(void, set_connector_occupied, (int32_t evse_id, int32_t connector_id, bool is_occupied));
+    MOCK_METHOD(void, set_connector_reserved, (int32_t evse_id, int32_t connector_id, bool is_reserved));
+    MOCK_METHOD(void, set_connector_faulted, (int32_t evse_id, int32_t connector_id, bool is_faulted));
+    MOCK_METHOD(void, set_connector_unavailable, (int32_t evse_id, int32_t connector_id, bool is_unavailable));
+    MOCK_METHOD(void, trigger_all_effective_availability_changed_callbacks, ());
+    MOCK_METHOD(void, send_status_notification_all_connectors, ());
+    MOCK_METHOD(void, send_status_notification_changed_connectors, ());
+    MOCK_METHOD(void, send_status_notification_single_connector, (int32_t evse_id, int32_t connector_id));
+};
+
+} // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/mocks/device_model_storage_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/device_model_storage_mock.hpp
@@ -1,0 +1,17 @@
+#include <gmock/gmock.h>
+
+#include "ocpp/v201/device_model_storage.hpp"
+
+namespace ocpp::v201 {
+class DeviceModelStorageMock : public DeviceModelStorage {
+public:
+    MOCK_METHOD(DeviceModelMap, get_device_model, ());
+    MOCK_METHOD(std::optional<VariableAttribute>, get_variable_attribute,
+                (const Component&, const Variable&, const AttributeEnum&));
+    MOCK_METHOD(std::vector<VariableAttribute>, get_variable_attributes,
+                (const Component&, const Variable&, const std::optional<AttributeEnum>&));
+    MOCK_METHOD(bool, set_variable_attribute_value,
+                (const Component&, const Variable&, const AttributeEnum&, const std::string&));
+    MOCK_METHOD(void, check_integrity, ());
+};
+} // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1,0 +1,233 @@
+#include "date/tz.h"
+#include "ocpp/v201/ctrlr_component_variables.hpp"
+#include "ocpp/v201/device_model_storage_sqlite.hpp"
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <filesystem>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+
+#include <component_state_manager_mock.hpp>
+#include <device_model_storage_mock.hpp>
+#include <evse_security_mock.hpp>
+#include <ocpp/common/call_types.hpp>
+#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/evse.hpp>
+#include <ocpp/v201/smart_charging.hpp>
+#include <optional>
+
+#include <sstream>
+
+namespace ocpp::v201 {
+
+class ChargepointTestFixtureV201 : public testing::Test {
+protected:
+    void SetUp() override {
+    }
+
+    ChargingSchedule create_charge_schedule(ChargingRateUnitEnum charging_rate_unit) {
+        int32_t id;
+        std::vector<ChargingSchedulePeriod> charging_schedule_period;
+        std::optional<CustomData> custom_data;
+        std::optional<ocpp::DateTime> start_schedule;
+        std::optional<int32_t> duration;
+        std::optional<float> min_charging_rate;
+        std::optional<SalesTariff> sales_tariff;
+
+        return ChargingSchedule{
+            id,
+            charging_rate_unit,
+            charging_schedule_period,
+            custom_data,
+            start_schedule,
+            duration,
+            min_charging_rate,
+            sales_tariff,
+        };
+    }
+
+    ChargingProfile create_tx_profile(ChargingSchedule charging_schedule, std::string transaction_id,
+                                      int stack_level = 1) {
+        auto charging_profile_id = 1;
+        auto charging_profile_purpose = ChargingProfilePurposeEnum::TxProfile;
+        auto charging_profile_kind = ChargingProfileKindEnum::Absolute;
+        auto recurrency_kind = RecurrencyKindEnum::Daily;
+        std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
+        return ChargingProfile{.id = charging_profile_id,
+                               .stackLevel = stack_level,
+                               .chargingProfilePurpose = charging_profile_purpose,
+                               .chargingProfileKind = charging_profile_kind,
+                               .chargingSchedule = charging_schedules,
+                               .customData = {},
+                               .recurrencyKind = recurrency_kind,
+                               .validFrom = {},
+                               .validTo = {},
+                               .transactionId = transaction_id};
+    }
+
+    ChargingProfile create_tx_profile_with_missing_transaction_id(ChargingSchedule charging_schedule) {
+        auto charging_profile_id = 1;
+        auto stack_level = 1;
+        auto charging_profile_purpose = ChargingProfilePurposeEnum::TxProfile;
+        auto charging_profile_kind = ChargingProfileKindEnum::Absolute;
+        auto recurrency_kind = RecurrencyKindEnum::Daily;
+        std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
+        return ChargingProfile{
+            charging_profile_id,
+            stack_level,
+            charging_profile_purpose,
+            charging_profile_kind,
+            charging_schedules,
+            {}, // transactionId
+            recurrency_kind,
+            {}, // validFrom
+            {}  // validTo
+        };
+    }
+
+    DeviceModel create_device_model() {
+        std::unique_ptr<DeviceModelStorageMock> storage_mock =
+            std::make_unique<testing::NiceMock<DeviceModelStorageMock>>();
+        ON_CALL(*storage_mock, get_device_model).WillByDefault(testing::Return(DeviceModelMap()));
+        return DeviceModel(std::move(storage_mock));
+    }
+
+    void create_evse_with_id(int id) {
+        testing::MockFunction<void(const MeterValue& meter_value, const Transaction& transaction, const int32_t seq_no,
+                                   const std::optional<int32_t> reservation_id)>
+            transaction_meter_value_req_mock;
+        testing::MockFunction<void()> pause_charging_callback_mock;
+        auto e1 = std::make_unique<Evse>(
+            id, 1, device_model, database_handler, std::make_shared<ComponentStateManagerMock>(),
+            transaction_meter_value_req_mock.AsStdFunction(), pause_charging_callback_mock.AsStdFunction());
+        evses[id] = std::move(e1);
+    }
+
+    SmartChargingHandler create_smart_charging_handler() {
+        return SmartChargingHandler();
+    }
+
+    std::string uuid() {
+        std::stringstream s;
+        s << uuid_generator();
+        return s.str();
+    }
+
+    void open_evse_transaction(int evse_id, std::string transaction_id) {
+        auto connector_id = 1;
+        auto meter_start = MeterValue();
+        auto id_token = IdToken();
+        auto date_time = ocpp::DateTime("2024-01-17T17:00:00");
+        evses[evse_id]->open_transaction(
+            transaction_id, connector_id, date_time, meter_start, id_token, {}, {},
+            std::chrono::seconds(static_cast<int64_t>(1)), std::chrono::seconds(static_cast<int64_t>(1)),
+            std::chrono::seconds(static_cast<int64_t>(1)), std::chrono::seconds(static_cast<int64_t>(1)));
+    }
+
+    // Default values used within the tests
+    std::map<int32_t, std::unique_ptr<Evse>> evses;
+    std::shared_ptr<DatabaseHandler> database_handler;
+
+    const int evse_id = 1;
+    bool ignore_no_transaction = true;
+    const int profile_max_stack_level = 1;
+    const int max_charging_profiles_installed = 1;
+    const int charging_schedule_max_periods = 1;
+    DeviceModel device_model = create_device_model();
+    SmartChargingHandler handler = create_smart_charging_handler();
+    boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
+};
+
+TEST_F(ChargepointTestFixtureV201, K01FR03_IfTxProfileIsMissingTransactionId_ThenProfileIsInvalid) {
+    create_evse_with_id(evse_id);
+    auto profile = create_tx_profile_with_missing_transaction_id(create_charge_schedule(ChargingRateUnitEnum::A));
+    auto sut = handler.validate_tx_profile(profile, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR16_IfTxProfileHasEvseIdNotGreaterThanZero_ThenProfileIsInvalid) {
+    auto wrong_evse_id = 0;
+    create_evse_with_id(0);
+    auto profile = create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+    auto sut = handler.validate_tx_profile(profile, *evses[wrong_evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR33_IfTxProfileTransactionIsNotOnEvse_ThenProfileIsInvalid) {
+    create_evse_with_id(evse_id);
+    open_evse_transaction(evse_id, "wrong transaction id");
+    auto profile = create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+    auto sut = handler.validate_tx_profile(profile, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileTransactionNotOnEvse));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction_ThenProfileIsInvalid) {
+    auto connector_id = 1;
+    auto meter_start = MeterValue();
+    auto id_token = IdToken();
+    auto date_time = ocpp::DateTime("2024-01-17T17:00:00");
+    create_evse_with_id(evse_id);
+    auto profile = create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+    auto sut = handler.validate_tx_profile(profile, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR06_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
+    create_evse_with_id(evse_id);
+    std::string transaction_id = uuid();
+    open_evse_transaction(evse_id, transaction_id);
+
+    auto same_stack_level = 42;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR06_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
+    create_evse_with_id(evse_id);
+    std::string transaction_id = uuid();
+    std::string different_transaction_id = uuid();
+    open_evse_transaction(evse_id, transaction_id);
+
+    auto same_stack_level = 42;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id, same_stack_level);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR06_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
+    create_evse_with_id(evse_id);
+    std::string same_transaction_id = uuid();
+    open_evse_transaction(evse_id, same_transaction_id);
+
+    auto stack_level_1 = 42;
+    auto stack_level_2 = 43;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_1);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_2);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+} // namespace ocpp::v201


### PR DESCRIPTION
Creates a skeleton for SmartChargingHandler and adds a method
to validate TxProfiles and TxProfiles only. This method
ensures that a given profile (assumed to be TxProfile) fits all of
the functional requirements specific to TxProfiles per K01.

The function, `validate_tx_profile ()`, takes a profile and an
EVSE, and returns a variant of `ProfileValidationResultEnum`.
This enum allows us to have detailed responses for the different types
of invalid profiles, and eventually will let us log *why* a profile
is invalid if the general validation fails.

Part of the prerequisites for https://github.com/EVerest/libocpp/issues/361

Related to https://github.com/EVerest/libocpp/issues/467 and https://github.com/EVerest/libocpp/issues/468