### PR TITLE
Protect from concurrent connector status updates

### DIFF
--- a/include/ocpp/v201/connector.hpp
+++ b/include/ocpp/v201/connector.hpp
@@ -44,6 +44,8 @@ private:
     /// \brief Component responsible for maintaining and monitoring the operational status of CS, EVSEs, and connectors.
     std::shared_ptr<ComponentStateManager> component_state_manager;
 
+    /// \brief status mutex to protect the status of the connector against concurrent updates
+    std::mutex status_mutex;
 public:
     /// \brief Construct a new Connector object
     /// \param evse_id id of the EVSE the connector is ap art of

--- a/include/ocpp/v201/connector.hpp
+++ b/include/ocpp/v201/connector.hpp
@@ -46,6 +46,7 @@ private:
 
     /// \brief status mutex to protect the status of the connector against concurrent updates
     std::mutex status_mutex;
+
 public:
     /// \brief Construct a new Connector object
     /// \param evse_id id of the EVSE the connector is ap art of

--- a/lib/ocpp/v201/connector.cpp
+++ b/lib/ocpp/v201/connector.cpp
@@ -38,6 +38,7 @@ Connector::Connector(const int32_t evse_id, const int32_t connector_id,
 }
 
 void Connector::submit_event(ConnectorEvent event) {
+    std::lock_guard lk(this->status_mutex);
     switch (event) {
     case ConnectorEvent::PlugIn:
         this->component_state_manager->set_connector_occupied(this->evse_id, this->connector_id, true);


### PR DESCRIPTION
Added lock guard to submit_event of connector to protect connector status from concurrent updates