### PR TITLE
Libwebsockets: Fix message loss on reconnect

### DIFF
--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -47,7 +47,7 @@ enum class ConnectionFailedReason {
 ///
 class WebsocketBase {
 protected:
-    bool m_is_connected;
+    std::atomic_bool m_is_connected;
     WebsocketConnectionOptions connection_options;
     std::function<void(const int security_profile)> connected_callback;
     std::function<void()> disconnected_callback;
@@ -59,11 +59,11 @@ protected:
     websocketpp::connection_hdl handle;
     std::mutex reconnect_mutex;
     std::mutex connection_mutex;
-    long reconnect_backoff_ms;
+    std::atomic_int reconnect_backoff_ms;
     websocketpp::transport::timer_handler reconnect_callback;
-    int connection_attempts;
-    bool shutting_down;
-    bool reconnecting;
+    std::atomic_int connection_attempts;
+    std::atomic_bool shutting_down;
+    std::atomic_bool reconnecting;
 
     /// \brief Indicates if the required callbacks are registered
     /// \returns true if the websocket is properly initialized

--- a/include/ocpp/common/websocket/websocket_tls_tpm.hpp
+++ b/include/ocpp/common/websocket/websocket_tls_tpm.hpp
@@ -67,7 +67,7 @@ private:
 
     void request_write();
 
-    void poll_message(const std::shared_ptr<WebsocketMessage>& msg, bool wait_sendaf);
+    void poll_message(const std::shared_ptr<WebsocketMessage>& msg);
 
 private:
     std::shared_ptr<EvseSecurity> evse_security;
@@ -79,8 +79,10 @@ private:
     std::condition_variable conn_cv;
 
     std::mutex queue_mutex;
+
     std::queue<std::shared_ptr<WebsocketMessage>> message_queue;
     std::condition_variable msg_send_cv;
+    std::mutex msg_send_cv_mutex;
 
     std::unique_ptr<std::thread> recv_message_thread;
     std::mutex recv_mutex;

--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -610,7 +610,8 @@ void WebsocketTlsTPM::close(websocketpp::close::status::value code, const std::s
     }
 
     this->m_is_connected = false;
-    this->closed_callback(websocketpp::close::status::normal);
+    std::thread closing([this]() { this->closed_callback(websocketpp::close::status::normal); });
+    closing.detach();
 }
 
 void WebsocketTlsTPM::on_conn_connected() {
@@ -641,7 +642,8 @@ void WebsocketTlsTPM::on_conn_fail() {
 
     std::lock_guard<std::mutex> lk(this->connection_mutex);
     if (this->m_is_connected) {
-        this->disconnected_callback();
+        std::thread disconnect([this]() { this->disconnected_callback(); });
+        disconnect.detach();
     }
 
     this->m_is_connected = false;

--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -511,11 +511,28 @@ bool WebsocketTlsTPM::connect() {
 
     // Wait old thread for a clean state
     if (this->websocket_thread) {
+        // Awake libwebsockets thread to quickly exit
+        request_write();
         this->websocket_thread->join();
     }
 
     if (this->recv_message_thread) {
+        // Awake the receiving message thread to finish
+        recv_message_cv.notify_one();
         this->recv_message_thread->join();
+    }
+
+    // Clear any pending messages on a new connection
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex);
+        std::queue<std::shared_ptr<WebsocketMessage>> empty;
+        empty.swap(message_queue);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(recv_mutex);
+        std::queue<std::string> empty;
+        empty.swap(recv_message_queue);
     }
 
     // Bind reconnect callback

--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -632,7 +632,8 @@ void WebsocketTlsTPM::on_conn_close() {
     this->disconnected_callback();
     this->cancel_reconnect_timer();
 
-    this->closed_callback(websocketpp::close::status::normal);
+    std::thread closing([this]() { this->closed_callback(websocketpp::close::status::normal); });
+    closing.detach();
 }
 
 void WebsocketTlsTPM::on_conn_fail() {

--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -522,6 +522,12 @@ bool WebsocketTlsTPM::connect() {
         this->recv_message_thread->join();
     }
 
+    // Stop any pending reconnect timer
+    {
+        std::lock_guard<std::mutex> lk(this->reconnect_mutex);
+        this->reconnect_timer_tpm.stop();
+    }
+
     // Clear any pending messages on a new connection
     {
         std::lock_guard<std::mutex> lock(queue_mutex);

--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -741,7 +741,6 @@ void WebsocketTlsTPM::on_writable() {
         return;
     }
 
-    
     // Execute while we have messages that were polled
     while (true) {
         WebsocketMessage* message = nullptr;


### PR DESCRIPTION
When using libwebsockets, the first message after a reconnect could not be sent as the connect handler to the libocpp was called from the wrong thread.