### PR TITLE
Reliability improvements for OpenSSL tpm2 provider on an embedded system

### DIFF
--- a/include/ocpp/common/websocket/websocket_tls_tpm.hpp
+++ b/include/ocpp/common/websocket/websocket_tls_tpm.hpp
@@ -6,8 +6,10 @@
 #include <ocpp/common/evse_security.hpp>
 #include <ocpp/common/websocket/websocket_base.hpp>
 
+#include <condition_variable>
 #include <optional>
 #include <queue>
+#include <string>
 
 struct ssl_ctx_st;
 
@@ -50,7 +52,7 @@ public:
     int process_callback(void* wsi_ptr, int callback_reason, void* user, void* in, size_t len);
 
 private:
-    void tls_init(struct ssl_ctx_st* ctx, const char* path_chain, const char* path_key, bool tpm_key,
+    void tls_init(struct ssl_ctx_st* ctx, const std::string& path_chain, const std::string& path_key, bool tpm_key,
                   std::optional<std::string>& password);
     void client_loop();
     void recv_loop();

--- a/include/ocpp/common/websocket/websocket_tls_tpm.hpp
+++ b/include/ocpp/common/websocket/websocket_tls_tpm.hpp
@@ -6,7 +6,11 @@
 #include <ocpp/common/evse_security.hpp>
 #include <ocpp/common/websocket/websocket_base.hpp>
 
+#include <optional>
 #include <queue>
+
+struct ssl_ctx_st;
+
 namespace ocpp {
 
 struct ConnectionData;
@@ -46,7 +50,8 @@ public:
     int process_callback(void* wsi_ptr, int callback_reason, void* user, void* in, size_t len);
 
 private:
-    void tls_init();
+    void tls_init(struct ssl_ctx_st* ctx, const char* path_chain, const char* path_key, bool tpm_key,
+                  std::optional<std::string>& password);
     void client_loop();
     void recv_loop();
 

--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -349,8 +349,6 @@ void WebsocketTlsTPM::client_loop() {
 
     info.fd_limit_per_thread = 1 + 1 + 1;
 
-    const bool use_tpm = connection_options.use_tpm_tls;
-
     // Setup context - need to know the key type first
 
     std::string path_key;

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2178,6 +2178,7 @@ void ChargePointImpl::handleExtendedTriggerMessageRequest(ocpp::Call<ExtendedTri
 void ChargePointImpl::sign_certificate(const ocpp::CertificateSigningUseEnum& certificate_signing_use,
                                        bool initiated_by_trigger_message) {
 
+    EVLOG_info << "Create CSR (TPM=" << this->configuration->getUseTPM() << ")";
     SignCertificateRequest req;
 
     const auto csr = this->evse_security->generate_certificate_signing_request(


### PR DESCRIPTION
related to [libevse-security PR42](https://github.com/EVerest/libevse-security/pull/42)

# Background

The existing implementation was occasionally failing especially when there was a migration from using non-TPM keys to supporting TPM protected keys (TSS2). Issues were observed during the loading and unloading of providers. There was also some concern that another call could impact which providers were loaded and their property strings.

There were significant improvements once the the tpm2-abrmd daemon was included and running. Generating keys, CSRs etc. didn't appear to need tpm2-abrmd however once TLS was being used tpm2-abrmd became essential.

It also became clear that the provider configuration depends on the key type. Hence the first line of the PEM key file is read so that the provider can be configured before actually loading the key.
Updates

Note: the tpm2-abrmd daemon needs to be running for tpm2 where TLS is being used.

# Functionality change

The meaning of UseTPM has been clarified to support interworking and upgrades from non-TPM keys to TPM protected keys.
For TLS the provider chosen is based on the PEM file and not the UseTPM OCPP configuration variable.
UseTPM is used to determine how a new key is to be generated and not how an existing key is used.

# Changes

The code has been updated to use the new OpenSSL provider implementation in libevse-security. It provides a suitable implementation for:
- OpenSSL v3
  - TPM protected keys
  - non-TPM protected keys
- OpenSSL v1 
  - non-TPM protected keys


