### PR TITLE
Fix usage of recursive_lock in lock_guard

### DIFF
--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -3,6 +3,7 @@
 #ifndef OCPP_V16_CHARGE_POINT_CONFIGURATION_HPP
 #define OCPP_V16_CHARGE_POINT_CONFIGURATION_HPP
 
+#include <mutex>
 #include <set>
 
 #include <ocpp/common/support_older_cpp_versions.hpp>

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2074,7 +2074,7 @@ KeyValue ChargePointConfiguration::getWaitForStopTransactionsOnResetTimeoutKeyVa
 }
 
 std::optional<KeyValue> ChargePointConfiguration::getCustomKeyValue(CiString<50> key) {
-    std::lock_guard<std::recursive_mutex> lock(configuration_mutex);
+    std::lock_guard<std::recursive_mutex> lock(this->configuration_mutex);
     if (!this->config["Custom"].contains(key.get())) {
         return std::nullopt;
     }
@@ -2099,7 +2099,7 @@ ConfigurationStatus ChargePointConfiguration::setCustomKey(CiString<50> key, CiS
     if (!kv.has_value() or (kv.value().readonly and !force)) {
         return ConfigurationStatus::Rejected;
     }
-    std::lock_guard<std::recursive_mutex> lock(configuration_mutex);
+    std::lock_guard<std::recursive_mutex> lock(this->configuration_mutex);
     try {
         const auto type = this->custom_schema["properties"][key]["type"];
         if (type == "integer") {
@@ -2123,7 +2123,7 @@ ConfigurationStatus ChargePointConfiguration::setCustomKey(CiString<50> key, CiS
 }
 
 std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
-    std::lock_guard<std::mutex> lock(configuration_mutex);
+    std::lock_guard<std::recursive_mutex> lock(this->configuration_mutex);
     // Internal Profile
     if (key == "ChargePointId") {
         return this->getChargePointIdKeyValue();
@@ -2422,7 +2422,7 @@ std::vector<KeyValue> ChargePointConfiguration::get_all_key_value() {
 }
 
 ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500> value) {
-    std::lock_guard<std::mutex> lock(configuration_mutex);
+    std::lock_guard<std::recursive_mutex> lock(this->configuration_mutex);
     if (key == "AllowOfflineTxForUnknownId") {
         if (this->getAllowOfflineTxForUnknownId() == std::nullopt) {
             return ConfigurationStatus::NotSupported;


### PR DESCRIPTION
## Describe your changes
Fixed usage of recursive_mutex which was mistakenly set to mutex in two places

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation - not applicable
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

