### PR TITLE
Enable the Power.Offered measurand

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -166,6 +166,13 @@ public:
     /// \param max_current in Amps
     void on_max_current_offered(int32_t connector, int32_t max_current);
 
+    /// \brief Stores the given \p max_power for the given \p connector offered to the EV. This function can be called
+    /// when the value for the maximum power for the connector changes. It will be used to report the Measurand
+    /// Power_Offered if it is configured
+    /// \param connector
+    /// \param max_power in Watts
+    void on_max_power_offered(int32_t connector, int32_t max_power);
+
     /// \brief Notifies chargepoint that a new session with the given \p session_id has been started at the given \p
     /// connector with the given \p reason . The logs of the session will be written into \p session_logging_path if
     /// present. This function must be called when first interaction with user or EV occurs. This can be a valid

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -466,6 +466,13 @@ public:
     /// \param max_current in Amps
     void on_max_current_offered(int32_t connector, int32_t max_current);
 
+    /// \brief Stores the given \p max_power for the given \p connector offered to the EV. This function can be called
+    /// when the value for the maximum power for the connector changes. It will be used to report the Measurand
+    /// Power_Offered if it is configured
+    /// \param connector
+    /// \param max_power in Watts
+    void on_max_power_offered(int32_t connector, int32_t max_power);
+
     /// \brief Notifies chargepoint that a new session with the given \p session_id has been started at the given \p
     /// connector with the given \p reason . The logs of the session will be written into \p session_logging_path if
     /// present. This function must be called when first interaction with user or EV occurs. This can be a valid

--- a/include/ocpp/v16/connector.hpp
+++ b/include/ocpp/v16/connector.hpp
@@ -15,6 +15,7 @@ struct Connector {
     int32_t id;
     std::optional<Measurement> measurement;
     double max_current_offered = 0;
+    double max_power_offered = 0;
     std::shared_ptr<Transaction> transaction = nullptr;
     std::map<int, ChargingProfile> stack_level_tx_default_profiles_map;
     std::map<int, ChargingProfile> stack_level_tx_profiles_map;

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -83,6 +83,10 @@ void ChargePoint::on_max_current_offered(int32_t connector, int32_t max_current)
     this->charge_point->on_max_current_offered(connector, max_current);
 }
 
+void ChargePoint::on_max_power_offered(int32_t connector, int32_t max_power) {
+    this->charge_point->on_max_power_offered(connector, max_power);
+}
+
 void ChargePoint::on_session_started(int32_t connector, const std::string& session_id,
                                      const ocpp::SessionStartedReason reason,
                                      const std::optional<std::string>& session_logging_path) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -680,6 +680,14 @@ std::optional<MeterValue> ChargePointImpl::get_latest_meter_value(int32_t connec
                 sample.value = ocpp::conversions::double_to_string(this->connectors.at(connector)->max_current_offered);
                 break;
             }
+            case Measurand::Power_Offered: {
+                // power offered to EV
+                sample.unit.emplace(UnitOfMeasure::W);
+                sample.location.emplace(Location::Outlet);
+
+                sample.value = ocpp::conversions::double_to_string(this->connectors.at(connector)->max_power_offered);
+                break;
+            }
             case Measurand::SoC: {
                 // state of charge
                 const auto soc = measurement.soc_Percent;
@@ -3141,6 +3149,13 @@ void ChargePointImpl::on_max_current_offered(int32_t connector, int32_t max_curr
     // TODO(kai): uses power meter mutex because the reading context is similar, think about storing
     // this information in a unified struct
     this->connectors.at(connector)->max_current_offered = max_current;
+}
+
+void ChargePointImpl::on_max_power_offered(int32_t connector, int32_t max_power) {
+    std::lock_guard<std::mutex> lock(measurement_mutex);
+    // TODO(kai): uses power meter mutex because the reading context is similar, think about storing
+    // this information in a unified struct
+    this->connectors.at(connector)->max_power_offered = max_power;
 }
 
 void ChargePointImpl::start_transaction(std::shared_ptr<Transaction> transaction) {


### PR DESCRIPTION
## Describe your changes
On_max_power function is added to set Power.Offered values to be available for the Measurands (MeterValues.req, StopTransaction.req)

## Issue ticket number and link
[#474](https://github.com/EVerest/libocpp/issues/474)
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

