### PR TITLE
Fix compatibility with python 3.7

### DIFF
--- a/config/v201/init_device_model_db.py
+++ b/config/v201/init_device_model_db.py
@@ -264,7 +264,10 @@ class DeviceModelDatabaseInitializer:
         """
 
         if delete_db_if_exists:
-            self._database_file.unlink(missing_ok=True)
+            try:
+                self._database_file.unlink()
+            except FileNotFoundError:
+                print(f"Could not remove database file {self._database_file}, file not found.")
 
         with self._connect() as cur:
             with self.INIT_DEVICE_MODEL_SQL.open("r") as sql_file:
@@ -348,8 +351,9 @@ if __name__ == '__main__':
     database_initializer = DeviceModelDatabaseInitializer(database_file)
 
     if "init" in commands:
-        if database_file.is_relative_to(Path("/tmp/ocpp201")):  # nosec
-            Path("/tmp/ocpp201").mkdir(parents=True, exist_ok=True)
+        tmp_path = Path("/tmp/ocpp201")
+        if tmp_path == database_file or tmp_path in database_file.parents: # nosec
+            tmp_path.mkdir(parents=True, exist_ok=True)
         database_initializer.initialize_database(schemas_path)
 
     if "insert" in commands:

--- a/config/v201/init_device_model_db.py
+++ b/config/v201/init_device_model_db.py
@@ -351,8 +351,8 @@ if __name__ == '__main__':
     database_initializer = DeviceModelDatabaseInitializer(database_file)
 
     if "init" in commands:
-        tmp_path = Path("/tmp/ocpp201")
-        if tmp_path == database_file or tmp_path in database_file.parents: # nosec
+        tmp_path = Path("/tmp/ocpp201") # nosec
+        if tmp_path == database_file or tmp_path in database_file.parents:
             tmp_path.mkdir(parents=True, exist_ok=True)
         database_initializer.initialize_database(schemas_path)
 


### PR DESCRIPTION
## Describe your changes
The missing_ok paramter of unlink as well as the is_relative_to function of path were introduced in python 3.8.
This PR fixes compatibility with python 3.7

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

