### PR TITLE
Fixed link to OCPP protocols in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # C++ implementation of OCPP
 ![Github Actions](https://github.com/EVerest/libocpp/actions/workflows/build_and_test.yaml/badge.svg)
 
-This is a C++ library implementation of OCPP for version 1.6 (https://www.openchargealliance.org/protocols/ocpp-16/) and 2.0.1 (https://www.openchargealliance.org/protocols/ocpp-201/). It enables charging stations to communicate with cloud backends for remote control, monitoring and billing of charging processes.
+This is a C++ library implementation of OCPP for version 1.6 and 2.0.1
+(see https://openchargealliance.org/protocols/open-charge-point-protocol/).
+
+It enables charging stations to communicate with cloud backends for remote
+control, monitoring and billing of charging processes.
 
 Libocpp can be used for the communication of one charging station and multiple EVSE using a single websocket connection.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Github Actions](https://github.com/EVerest/libocpp/actions/workflows/build_and_test.yaml/badge.svg)
 
 This is a C++ library implementation of OCPP for version 1.6 and 2.0.1
-(see https://openchargealliance.org/protocols/open-charge-point-protocol/).
+(see [OCPP protocols at OCA website](https://openchargealliance.org/protocols/open-charge-point-protocol/)).
 
 It enables charging stations to communicate with cloud backends for remote
 control, monitoring and billing of charging processes.


### PR DESCRIPTION
Quick fix: Pages for OCPP did change at OCA website.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

