### PR TITLE
Supported Measurands for OCPP1.6

### DIFF
--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -245,6 +245,12 @@
             "type": "integer",
             "readOnly": true,
             "minimum": 1
+        },
+        "SupportedMeasurands": {
+            "$comment": "Comma seperated list of supported measurands of the powermeter",
+            "type": "string",
+            "readOnly": true,
+            "default": "Energy.Active.Import.Register,Energy.Active.Export.Register,Power.Active.Import,Voltage,Current.Import,Frequency,Current.Offered,Power.Offered"
         }
     },
     "additionalProperties": false

--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -247,7 +247,7 @@
             "minimum": 1
         },
         "SupportedMeasurands": {
-            "$comment": "Comma seperated list of supported measurands of the powermeter",
+            "$comment": "Comma separated list of supported measurands of the powermeter",
             "type": "string",
             "readOnly": true,
             "default": "Energy.Active.Import.Register,Energy.Active.Export.Register,Power.Active.Import,Voltage,Current.Import,Frequency,Current.Offered,Power.Offered"

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -33,6 +33,7 @@ private:
     bool measurands_supported(std::string csv);
     json get_user_config();
     void setInUserConfig(std::string profile, std::string key, json value);
+    void init_supported_measurands();
 
     bool isConnectorPhaseRotationValid(std::string str);
 
@@ -84,6 +85,8 @@ public:
     bool getVerifyCsmsCommonName();
     KeyValue getVerifyCsmsCommonNameKeyValue();
     bool getUseTPM();
+    std::string getSupportedMeasurands();
+    KeyValue getSupportedMeasurandsKeyValue();
 
     int32_t getRetryBackoffRandomRange();
     void setRetryBackoffRandomRange(int32_t retry_backoff_random_range);


### PR DESCRIPTION
## Describe your changes
* Added internal configuration key: SupportedMeasurands
* Initializing supported measurands on startup (was an open TODO)
* Measurands that are configured that are not part of the configured supported measurands are rejected or application crashes on startup if misconfigured

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/485

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

