### PR TITLE
fix: information log causing segfault

### DIFF
--- a/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
+++ b/lib/ocpp/common/websocket/websocket_tls_tpm.cpp
@@ -390,7 +390,6 @@ void WebsocketTlsTPM::client_loop() {
             provider.set_tls_mode(OpenSSLProvider::mode_t::default_provider);
         }
 
-        EVLOG_info << "Using TLS propquery: " << provider.propquery_tls_str();
         const SSL_METHOD* method = SSLv23_client_method();
         ssl_ctx = SSL_CTX_new_ex(provider, provider.propquery_tls_str(), method);
 


### PR DESCRIPTION

## Describe your changes
debugging log triggered a seg fault when given a nullptr. removed offending log.

provider.propquery_tls_str() is allowed to return a nullptr and hence is not safe to use directly for logging.

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

