### PR TITLE
Mz security event boot reason

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1954,6 +1954,9 @@ void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationR
             this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
                                                   std::optional<CiString<255>>(startup_message), true, true);
         } else {
+            std::string startup_message = "Charging station reset or reboot. Firmware version: ";
+            startup_message.append(
+                    this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
             this->security_event_notification_req(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
                                                   std::optional<CiString<255>>(startup_message), true, true);
         }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1947,11 +1947,14 @@ void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationR
             this->security_event_notification_req(
                 CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
                 std::optional<CiString<255>>("Charging Station rebooted due to a scheduled reset!"), true, true);
-        } else {
+        } else if (this->bootreason == BootReasonEnum::PowerUp) {
             std::string startup_message = "Charging Station powered up! Firmware version: ";
             startup_message.append(
                 this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
             this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
+                                                  std::optional<CiString<255>>(startup_message), true, true);
+        } else {
+            this->security_event_notification_req(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
                                                   std::optional<CiString<255>>(startup_message), true, true);
         }
     } else {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1956,7 +1956,7 @@ void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationR
         } else {
             std::string startup_message = "Charging station reset or reboot. Firmware version: ";
             startup_message.append(
-                    this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+                this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
             this->security_event_notification_req(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
                                                   std::optional<CiString<255>>(startup_message), true, true);
         }


### PR DESCRIPTION
## Describe your changes
By default, a 'Reset or reboot' security event is now sent. This includes another default message. 

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ ? ] I have made corresponding changes to the documentation
- [ x ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

