### PR TITLE
Added certificateType to SignCertificate.req

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1584,6 +1584,7 @@ void ChargePoint::sign_certificate_req(const ocpp::CertificateSigningUseEnum& ce
     std::optional<std::string> organization;
 
     if (certificate_signing_use == ocpp::CertificateSigningUseEnum::ChargingStationCertificate) {
+        req.certificateType = CertificateSigningUseEnum::ChargingStationCertificate;
         common =
             this->device_model->get_optional_value<std::string>(ControllerComponentVariables::ChargeBoxSerialNumber);
         organization =
@@ -1591,6 +1592,7 @@ void ChargePoint::sign_certificate_req(const ocpp::CertificateSigningUseEnum& ce
         country =
             this->device_model->get_optional_value<std::string>(ControllerComponentVariables::ISO15118CtrlrCountryName);
     } else {
+        req.certificateType = CertificateSigningUseEnum::V2GCertificate;
         common = this->device_model->get_optional_value<std::string>(ControllerComponentVariables::ISO15118CtrlrSeccId);
         organization = this->device_model->get_optional_value<std::string>(
             ControllerComponentVariables::ISO15118CtrlrOrganizationName);


### PR DESCRIPTION
## Describe your changes
Added certificateType to SignCertificate.req . It is an optional field that should be set in case the CSR is not intended for both the CSMS and V2G domain, which is not specifically supported for now.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

