### PR TITLE
Moved security event notification to charge_point start function

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+#include "ocpp/common/types.hpp"
 #include <thread>
 
 #include <everest/logging.hpp>
@@ -822,15 +823,29 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->load_charging_profiles();
     this->call_set_connection_timeout();
 
-    if (this->bootreason == BootReasonEnum::RemoteReset) {
+    switch (bootreason) {
+    case BootReasonEnum::RemoteReset:
         this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
                                         "Charging Station rebooted due to requested remote reset!", true);
-    } else if (this->bootreason == BootReasonEnum::ScheduledReset) {
+        break;
+    case BootReasonEnum::ScheduledReset:
         this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
                                         "Charging Station rebooted due to a scheduled reset!", true);
-    } else if (this->bootreason == BootReasonEnum::PowerUp) {
+        break;
+    case BootReasonEnum::FirmwareUpdate:
+        this->securityEventNotification(CiString<50>(ocpp::security_events::FIRMWARE_UPDATED),
+                                        "Charging Station rebooted due to firmware update!", true);
+        break;
+    case BootReasonEnum::ApplicationReset:
+    case BootReasonEnum::LocalReset:
+    case BootReasonEnum::PowerUp:
+    case BootReasonEnum::Triggered:
+    case BootReasonEnum::Unknown:
+    case BootReasonEnum::Watchdog:
+    default:
         this->securityEventNotification(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
                                         "The Charge Point has booted", true);
+        break;
     }
 
     this->stopped = false;

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -822,6 +822,17 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->load_charging_profiles();
     this->call_set_connection_timeout();
 
+    if (this->bootreason == BootReasonEnum::RemoteReset) {
+        this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+                                        "Charging Station rebooted due to requested remote reset!", true);
+    } else if (this->bootreason == BootReasonEnum::ScheduledReset) {
+        this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+                                        "Charging Station rebooted due to a scheduled reset!", true);
+    } else if (this->bootreason == BootReasonEnum::PowerUp) {
+        this->securityEventNotification(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
+                                        "The Charge Point has booted", true);
+    }
+
     this->stopped = false;
     return true;
 }
@@ -1238,17 +1249,6 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
 
         if (this->is_pnc_enabled()) {
             this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
-        }
-
-        if (this->bootreason == BootReasonEnum::RemoteReset) {
-            this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
-                                            "Charging Station rebooted due to requested remote reset!", true);
-        } else if (this->bootreason == BootReasonEnum::ScheduledReset) {
-            this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
-                                            "Charging Station rebooted due to a scheduled reset!", true);
-        } else if (this->bootreason == BootReasonEnum::PowerUp) {
-            this->securityEventNotification(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
-                                            "The Charge Point has booted", true);
         }
 
         this->stop_pending_transactions();

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -182,6 +182,22 @@ void ChargePoint::start(BootReasonEnum bootreason) {
     this->boot_notification_req(bootreason);
     this->start_websocket();
     // FIXME(piet): Run state machine with correct initial state
+
+    if (this->bootreason == BootReasonEnum::RemoteReset) {
+        this->security_event_notification_req(
+            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+            std::optional<CiString<255>>("Charging Station rebooted due to requested remote reset!"), true, true);
+    } else if (this->bootreason == BootReasonEnum::ScheduledReset) {
+        this->security_event_notification_req(
+            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+            std::optional<CiString<255>>("Charging Station rebooted due to a scheduled reset!"), true, true);
+    } else {
+        std::string startup_message = "Charging Station powered up! Firmware version: ";
+        startup_message.append(
+            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+        this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
+                                              std::optional<CiString<255>>(startup_message), true, true);
+    }
 }
 
 void ChargePoint::start_websocket() {


### PR DESCRIPTION
## Describe your changes
Moved security event notification from BootNotification.conf handler to charge_point start function. This allows logging and queuing of the SecurityEvent when it actually occurs

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

