### PR TITLE
External variable access for OCPP2.0.1 

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -292,7 +292,17 @@ private:
     bool is_valid_evse(const EVSE& evse);
     void handle_scheduled_change_availability_requests(const int32_t evse_id);
     void handle_variable_changed(const SetVariableData& set_variable_data);
+    void handle_variables_changed(const std::map<SetVariableData, SetVariableResult> set_variable_results);
     bool validate_set_variable(const SetVariableData& set_variable_data);
+
+    /// \brief Sets variables specified within \p set_variable_data_vector in the device model and returns the result.
+    /// \param set_variable_data_vector contains data of the variables to set
+    /// \param allow_read_only if true, setting VariableAttribute values with mutability ReadOnly is allowed
+    /// \return Map containing the SetVariableData as a key and the  SetVariableResult as a value for each requested
+    /// change
+    std::map<SetVariableData, SetVariableResult>
+    set_variables_internal(const std::vector<SetVariableData> set_variable_data_vector, const bool allow_read_only);
+
     MeterValue get_latest_meter_value_filtered(const MeterValue& meter_value, ReadingContextEnum context,
                                                const RequiredComponentVariable& component_variable);
 
@@ -729,6 +739,20 @@ public:
                                                 const AttributeEnum& attribute_enum) {
         return this->device_model->request_value<T>(component_id, variable_id, attribute_enum);
     }
+
+    /// \brief Gets variables specified within \p get_variable_data_vector from the device model and returns the result.
+    /// This function is used internally in order to handle GetVariables.req messages and it can be used to get
+    /// variables externally.
+    /// \param get_variable_data_vector contains data of the variables to get
+    /// \return Vector containing a result for each requested variable
+    std::vector<GetVariableResult> get_variables(const std::vector<GetVariableData> get_variable_data_vector);
+
+    /// \brief Sets variables specified within \p set_variable_data_vector in the device model and returns the result.
+    /// \param set_variable_data_vector contains data of the variables to set
+    /// \return Map containing the SetVariableData as a key and the  SetVariableResult as a value for each requested
+    /// change
+    std::map<SetVariableData, SetVariableResult>
+    set_variables(const std::vector<SetVariableData> set_variable_data_vector);
 };
 
 } // namespace v201

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -292,7 +292,7 @@ private:
     bool is_valid_evse(const EVSE& evse);
     void handle_scheduled_change_availability_requests(const int32_t evse_id);
     void handle_variable_changed(const SetVariableData& set_variable_data);
-    void handle_variables_changed(const std::map<SetVariableData, SetVariableResult> set_variable_results);
+    void handle_variables_changed(const std::map<SetVariableData, SetVariableResult>& set_variable_results);
     bool validate_set_variable(const SetVariableData& set_variable_data);
 
     /// \brief Sets variables specified within \p set_variable_data_vector in the device model and returns the result.
@@ -301,7 +301,7 @@ private:
     /// \return Map containing the SetVariableData as a key and the  SetVariableResult as a value for each requested
     /// change
     std::map<SetVariableData, SetVariableResult>
-    set_variables_internal(const std::vector<SetVariableData> set_variable_data_vector, const bool allow_read_only);
+    set_variables_internal(const std::vector<SetVariableData>& set_variable_data_vector, const bool allow_read_only);
 
     MeterValue get_latest_meter_value_filtered(const MeterValue& meter_value, ReadingContextEnum context,
                                                const RequiredComponentVariable& component_variable);
@@ -745,14 +745,14 @@ public:
     /// variables externally.
     /// \param get_variable_data_vector contains data of the variables to get
     /// \return Vector containing a result for each requested variable
-    std::vector<GetVariableResult> get_variables(const std::vector<GetVariableData> get_variable_data_vector);
+    std::vector<GetVariableResult> get_variables(const std::vector<GetVariableData>& get_variable_data_vector);
 
     /// \brief Sets variables specified within \p set_variable_data_vector in the device model and returns the result.
     /// \param set_variable_data_vector contains data of the variables to set
     /// \return Map containing the SetVariableData as a key and the  SetVariableResult as a value for each requested
     /// change
     std::map<SetVariableData, SetVariableResult>
-    set_variables(const std::vector<SetVariableData> set_variable_data_vector);
+    set_variables(const std::vector<SetVariableData>& set_variable_data_vector);
 };
 
 } // namespace v201

--- a/include/ocpp/v201/comparators.hpp
+++ b/include/ocpp/v201/comparators.hpp
@@ -67,6 +67,5 @@ inline bool operator<(const SetVariableData& lhs, const SetVariableData& rhs) {
     return lhs.component < rhs.component;
 }
 
-
 } // namespace v201
 } // namespace ocpp

--- a/include/ocpp/v201/comparators.hpp
+++ b/include/ocpp/v201/comparators.hpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <ocpp/v201/ocpp_types.hpp>
+
+namespace ocpp {
+namespace v201 {
+
+inline bool operator==(const EVSE& lhs, const EVSE& rhs) {
+    return lhs.id == rhs.id and lhs.connectorId == rhs.connectorId;
+};
+
+inline bool operator<(const EVSE& lhs, const EVSE& rhs) {
+    if (lhs.id != rhs.id) {
+        return lhs.id < rhs.id;
+    }
+    return lhs.connectorId < rhs.connectorId;
+}
+
+inline bool operator==(const Component& lhs, const Component& rhs) {
+    return lhs.name.get() == rhs.name.get() and lhs.instance == rhs.instance and lhs.evse == rhs.evse;
+};
+
+inline bool operator<(const Component& lhs, const Component& rhs) {
+    if (lhs.name != rhs.name) {
+        return lhs.name < rhs.name;
+    }
+    if (lhs.instance != rhs.instance) {
+        return lhs.instance < rhs.instance;
+    }
+    return lhs.evse < rhs.evse;
+};
+
+inline bool operator==(const Variable& lhs, const Variable& rhs) {
+    return lhs.name.get() == rhs.name.get() and lhs.instance == rhs.instance;
+};
+
+inline bool operator<(const Variable& lhs, const Variable& rhs) {
+    if (lhs.name != rhs.name) {
+        return lhs.name < rhs.name;
+    }
+    return lhs.instance < rhs.instance;
+};
+
+inline bool operator==(const ComponentVariable& lhs, const ComponentVariable& rhs) {
+    return lhs.component == rhs.component and lhs.variable == rhs.variable;
+}
+
+inline bool operator<(const ComponentVariable& lhs, const ComponentVariable& rhs) {
+    if (lhs.component == rhs.component) {
+        return lhs.variable < rhs.variable;
+    }
+    return lhs.component < rhs.component;
+}
+
+inline bool operator==(const SetVariableData& lhs, const SetVariableData& rhs) {
+    return lhs.component == rhs.component and lhs.variable == rhs.variable and
+           lhs.attributeValue.get() == rhs.attributeValue.get() and lhs.attributeType == rhs.attributeType;
+}
+
+inline bool operator<(const SetVariableData& lhs, const SetVariableData& rhs) {
+    if (lhs.component == rhs.component) {
+        return lhs.variable < rhs.variable;
+    }
+    return lhs.component < rhs.component;
+}
+
+
+} // namespace v201
+} // namespace ocpp

--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -85,15 +85,6 @@ private:
                                    const ocpp::v201::Component& component_,
                                    const struct ocpp::v201::Variable& variable_);
 
-    /// \brief Sets the variable_id attribute \p value specified by \p component_id , \p variable_id and \p
-    /// attribute_enum \param component_id \param variable_id \param attribute_enum \param value
-    /// \param force_read_only If this is true, only read-only variables can be changed,
-    ///                        otherwise only non read-only variables can be changed
-    /// \return Result of the requested operation
-    SetVariableStatusEnum set_value_internal(const Component& component_id, const Variable& variable_id,
-                                             const AttributeEnum& attribute_enum, const std::string& value,
-                                             bool force_read_only);
-
 public:
     /// \brief Constructor for the device model
     /// \param device_model_storage pointer to a device model storage class
@@ -174,10 +165,12 @@ public:
     /// \param variable_id
     /// \param attribute_enum
     /// \param value
+    /// \param allow_read_only If this is true, read-only variables can be changed,
+    ///                        otherwise only non read-only variables can be changed. Defaults to false
     /// \return Result of the requested operation
     SetVariableStatusEnum set_value(const Component& component_id, const Variable& variable_id,
-                                    const AttributeEnum& attribute_enum, const std::string& value);
-
+                                    const AttributeEnum& attribute_enum, const std::string& value,
+                                    const bool allow_read_only = false);
     /// \brief Sets the variable_id attribute \p value specified by \p component_id , \p variable_id and \p
     /// attribute_enum for read only variables only. Only works on certain allowed components.
     /// \param component_id

--- a/include/ocpp/v201/device_model_storage.hpp
+++ b/include/ocpp/v201/device_model_storage.hpp
@@ -7,6 +7,7 @@
 #include <map>
 #include <memory>
 #include <ocpp/common/support_older_cpp_versions.hpp>
+#include <ocpp/v201/comparators.hpp>
 #include <optional>
 
 #include <ocpp/v201/ocpp_types.hpp>
@@ -19,53 +20,6 @@ struct VariableMetaData {
     VariableCharacteristics characteristics;
     std::vector<VariableMonitoring> monitors;
 };
-
-inline bool operator==(const EVSE& lhs, const EVSE& rhs) {
-    return lhs.id == rhs.id and lhs.connectorId == rhs.connectorId;
-};
-
-inline bool operator<(const EVSE& lhs, const EVSE& rhs) {
-    if (lhs.id != rhs.id) {
-        return lhs.id < rhs.id;
-    }
-    return lhs.connectorId < rhs.connectorId;
-}
-
-inline bool operator==(const Component& lhs, const Component& rhs) {
-    return lhs.name.get() == rhs.name.get() and lhs.instance == rhs.instance and lhs.evse == rhs.evse;
-};
-
-inline bool operator<(const Component& lhs, const Component& rhs) {
-    if (lhs.name != rhs.name) {
-        return lhs.name < rhs.name;
-    }
-    if (lhs.instance != rhs.instance) {
-        return lhs.instance < rhs.instance;
-    }
-    return lhs.evse < rhs.evse;
-};
-
-inline bool operator==(const Variable& lhs, const Variable& rhs) {
-    return lhs.name.get() == rhs.name.get() and lhs.instance == rhs.instance;
-};
-
-inline bool operator<(const Variable& lhs, const Variable& rhs) {
-    if (lhs.name != rhs.name) {
-        return lhs.name < rhs.name;
-    }
-    return lhs.instance < rhs.instance;
-};
-
-inline bool operator==(const ComponentVariable& lhs, const ComponentVariable& rhs) {
-    return lhs.component == rhs.component and lhs.variable == rhs.variable;
-}
-
-inline bool operator<(const ComponentVariable& lhs, const ComponentVariable& rhs) {
-    if (lhs.component == rhs.component) {
-        return lhs.variable < rhs.variable;
-    }
-    return lhs.component < rhs.component;
-}
 
 using VariableMap = std::map<Variable, VariableMetaData>;
 using DeviceModelMap = std::map<Component, VariableMap>;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1449,6 +1449,22 @@ void ChargePoint::handle_variable_changed(const SetVariableData& set_variable_da
     // TODO(piet): other special handling of changed variables can be added here...
 }
 
+void ChargePoint::handle_variables_changed(const std::map<SetVariableData, SetVariableResult> set_variable_results) {
+    // iterate over set_variable_results
+    for (const auto& [set_variable_data, set_variable_result] : set_variable_results) {
+        if (set_variable_result.attributeStatus == SetVariableStatusEnum::Accepted) {
+            EVLOG_info << set_variable_data.component.name << ":" << set_variable_data.variable.name << " changed to "
+                       << set_variable_data.attributeValue.get();
+            // handles required behavior specified within OCPP2.0.1 (e.g. reconnect when BasicAuthPassword has changed)
+            this->handle_variable_changed(set_variable_data);
+            // notifies libocpp user application that a variable has changed
+            if (this->callbacks.variable_changed_callback.has_value()) {
+                this->callbacks.variable_changed_callback.value()(set_variable_data);
+            }
+        }
+    }
+}
+
 bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data) {
     ComponentVariable cv = {set_variable_data.component, std::nullopt, set_variable_data.variable};
     if (cv == ControllerComponentVariables::NetworkConfigurationPriority) {
@@ -1490,6 +1506,37 @@ bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data
     }
     return true;
     // TODO(piet): other special validating of variables requested to change can be added here...
+}
+
+std::map<SetVariableData, SetVariableResult>
+ChargePoint::set_variables_internal(const std::vector<SetVariableData> set_variable_data_vector,
+                                    const bool allow_read_only) {
+    std::map<SetVariableData, SetVariableResult> response;
+
+    // iterate over the set_variable_data_vector
+    for (const auto& set_variable_data : set_variable_data_vector) {
+        SetVariableResult set_variable_result;
+        set_variable_result.component = set_variable_data.component;
+        set_variable_result.variable = set_variable_data.variable;
+        set_variable_result.attributeType = set_variable_data.attributeType.value_or(AttributeEnum::Actual);
+
+        // validates variable against business logic of the spec
+        if (this->validate_set_variable(set_variable_data)) {
+            // attempt to set the value includes device model validation
+            set_variable_result.attributeStatus =
+                this->device_model->set_value(set_variable_data.component, set_variable_data.variable,
+                                              set_variable_data.attributeType.value_or(AttributeEnum::Actual),
+                                              set_variable_data.attributeValue.get(), allow_read_only);
+        } else {
+            set_variable_result.attributeStatus = SetVariableStatusEnum::Rejected;
+        }
+        response[set_variable_data] = set_variable_result;
+    }
+
+    // post handling of changed variables after the SetVariables.conf has been queued
+    this->handle_variables_changed(response);
+
+    return response;
 }
 
 std::optional<int32_t> ChargePoint::get_transaction_evseid(const CiString<36>& transaction_id) {
@@ -2001,46 +2048,17 @@ void ChargePoint::handle_set_variables_req(Call<SetVariablesRequest> call) {
 
     SetVariablesResponse response;
 
-    // collection used to collect SetVariableData that has been accepted
-    std::vector<SetVariableData> accepted_set_variable_data;
-
-    // iterate over the request
-    for (const auto& set_variable_data : msg.setVariableData) {
-        SetVariableResult set_variable_result;
-        set_variable_result.component = set_variable_data.component;
-        set_variable_result.variable = set_variable_data.variable;
-        set_variable_result.attributeType = set_variable_data.attributeType.value_or(AttributeEnum::Actual);
-
-        if (this->validate_set_variable(set_variable_data)) {
-            set_variable_result.attributeStatus =
-                this->device_model->set_value(set_variable_data.component, set_variable_data.variable,
-                                              set_variable_data.attributeType.value_or(AttributeEnum::Actual),
-                                              set_variable_data.attributeValue.get());
-        } else {
-            set_variable_result.attributeStatus = SetVariableStatusEnum::Rejected;
-        }
-        response.setVariableResult.push_back(set_variable_result);
-
-        // collect SetVariableData that has been accepted
-        if (set_variable_result.attributeStatus == SetVariableStatusEnum::Accepted) {
-            accepted_set_variable_data.push_back(set_variable_data);
-        }
+    // set variables but do not allow setting ReadOnly variables
+    const auto set_variables_response = this->set_variables_internal(msg.setVariableData, false);
+    for (const auto& [single_set_variable_data, single_set_variable_result] : set_variables_response) {
+        response.setVariableResult.push_back(single_set_variable_result);
     }
 
     ocpp::CallResult<SetVariablesResponse> call_result(response, call.uniqueId);
     this->send<SetVariablesResponse>(call_result);
 
-    // iterate over changed_component_variables_values_map
-    for (const auto& set_variable_data : accepted_set_variable_data) {
-        EVLOG_info << set_variable_data.component.name << ":" << set_variable_data.variable.name << " changed to "
-                   << set_variable_data.attributeValue.get();
-        // handles required behavior specified within OCPP2.0.1 (e.g. reconnect when BasicAuthPassword has changed)
-        this->handle_variable_changed(set_variable_data);
-        // notifies application that a variable has changed
-        if (this->callbacks.variable_changed_callback.has_value()) {
-            this->callbacks.variable_changed_callback.value()(set_variable_data);
-        }
-    }
+    // post handling of changed variables after the SetVariables.conf has been queued
+    this->handle_variables_changed(set_variables_response);
 }
 
 void ChargePoint::handle_get_variables_req(const EnhancedMessage<v201::MessageType>& message) {
@@ -2069,22 +2087,7 @@ void ChargePoint::handle_get_variables_req(const EnhancedMessage<v201::MessageTy
     }
 
     GetVariablesResponse response;
-
-    for (const auto& get_variable_data : msg.getVariableData) {
-        GetVariableResult get_variable_result;
-        get_variable_result.component = get_variable_data.component;
-        get_variable_result.variable = get_variable_data.variable;
-        get_variable_result.attributeType = get_variable_data.attributeType.value_or(AttributeEnum::Actual);
-        const auto request_value_response = this->device_model->request_value<std::string>(
-            get_variable_data.component, get_variable_data.variable,
-            get_variable_data.attributeType.value_or(AttributeEnum::Actual));
-        if (request_value_response.status == GetVariableStatusEnum::Accepted and
-            request_value_response.value.has_value()) {
-            get_variable_result.attributeValue = request_value_response.value.value();
-        }
-        get_variable_result.attributeStatus = request_value_response.status;
-        response.getVariableResult.push_back(get_variable_result);
-    }
+    response.getVariableResult = this->get_variables(msg.getVariableData);
 
     ocpp::CallResult<GetVariablesResponse> call_result(response, call.uniqueId);
     this->send<GetVariablesResponse>(call_result);
@@ -3116,6 +3119,32 @@ void ChargePoint::execute_change_availability_request(ChangeAvailabilityRequest 
     } else {
         this->set_cs_operative_status(request.operationalStatus, persist);
     }
+}
+
+std::vector<GetVariableResult> ChargePoint::get_variables(const std::vector<GetVariableData> get_variable_data_vector) {
+    std::vector<GetVariableResult> response;
+    for (const auto& get_variable_data : get_variable_data_vector) {
+        GetVariableResult get_variable_result;
+        get_variable_result.component = get_variable_data.component;
+        get_variable_result.variable = get_variable_data.variable;
+        get_variable_result.attributeType = get_variable_data.attributeType.value_or(AttributeEnum::Actual);
+        const auto request_value_response = this->device_model->request_value<std::string>(
+            get_variable_data.component, get_variable_data.variable,
+            get_variable_data.attributeType.value_or(AttributeEnum::Actual));
+        if (request_value_response.status == GetVariableStatusEnum::Accepted and
+            request_value_response.value.has_value()) {
+            get_variable_result.attributeValue = request_value_response.value.value();
+        }
+        get_variable_result.attributeStatus = request_value_response.status;
+        response.push_back(get_variable_result);
+    }
+    return response;
+}
+
+std::map<SetVariableData, SetVariableResult>
+ChargePoint::set_variables(const std::vector<SetVariableData> set_variable_data_vector) {
+    // set variables and allow setting of ReadOnly variables
+    return this->set_variables_internal(set_variable_data_vector, true);
 }
 
 } // namespace v201

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1449,7 +1449,7 @@ void ChargePoint::handle_variable_changed(const SetVariableData& set_variable_da
     // TODO(piet): other special handling of changed variables can be added here...
 }
 
-void ChargePoint::handle_variables_changed(const std::map<SetVariableData, SetVariableResult> set_variable_results) {
+void ChargePoint::handle_variables_changed(const std::map<SetVariableData, SetVariableResult>& set_variable_results) {
     // iterate over set_variable_results
     for (const auto& [set_variable_data, set_variable_result] : set_variable_results) {
         if (set_variable_result.attributeStatus == SetVariableStatusEnum::Accepted) {
@@ -1509,7 +1509,7 @@ bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data
 }
 
 std::map<SetVariableData, SetVariableResult>
-ChargePoint::set_variables_internal(const std::vector<SetVariableData> set_variable_data_vector,
+ChargePoint::set_variables_internal(const std::vector<SetVariableData>& set_variable_data_vector,
                                     const bool allow_read_only) {
     std::map<SetVariableData, SetVariableResult> response;
 
@@ -3121,7 +3121,8 @@ void ChargePoint::execute_change_availability_request(ChangeAvailabilityRequest 
     }
 }
 
-std::vector<GetVariableResult> ChargePoint::get_variables(const std::vector<GetVariableData> get_variable_data_vector) {
+std::vector<GetVariableResult>
+ChargePoint::get_variables(const std::vector<GetVariableData>& get_variable_data_vector) {
     std::vector<GetVariableResult> response;
     for (const auto& get_variable_data : get_variable_data_vector) {
         GetVariableResult get_variable_result;
@@ -3142,7 +3143,7 @@ std::vector<GetVariableResult> ChargePoint::get_variables(const std::vector<GetV
 }
 
 std::map<SetVariableData, SetVariableResult>
-ChargePoint::set_variables(const std::vector<SetVariableData> set_variable_data_vector) {
+ChargePoint::set_variables(const std::vector<SetVariableData>& set_variable_data_vector) {
     // set variables and allow setting of ReadOnly variables
     return this->set_variables_internal(set_variable_data_vector, true);
 }


### PR DESCRIPTION
## Describe your changes
* added get_variables and set_variables functions to v201/charge_point
* changed argument for set_value from force_read_only to allow_read_only to be able to reuse this function within SetVariables.req handler and external set_variable calls of charge_point

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/525

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

