### PR TITLE
Verify that EVSE exists.

### DIFF
--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -16,6 +16,7 @@ namespace ocpp::v201 {
 
 enum class ProfileValidationResultEnum {
     Valid,
+    EVseDoesNotExist,
     TxProfileMissingTransactionId,
     TxProfileEvseIdNotGreaterThanZero,
     TxProfileTransactionNotOnEvse,
@@ -27,12 +28,19 @@ enum class ProfileValidationResultEnum {
 /// to calculate the composite schedules
 class SmartChargingHandler {
 private:
+    std::map<int32_t, std::unique_ptr<Evse>>& evses;
+
     std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler;
     // cppcheck-suppress unusedStructMember
     std::vector<ChargingProfile> charging_profiles;
 
 public:
-    explicit SmartChargingHandler();
+    explicit SmartChargingHandler(std::map<int32_t, std::unique_ptr<Evse>>& evses);
+
+    ///
+    /// \brief validates the existence of the given \p evse_id according to the specification
+    ///
+    ProfileValidationResultEnum validate_evse_exists(int32_t evse_id) const;
 
     ///
     /// \brief validates the given \p profile according to the specification

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -12,7 +12,12 @@ using namespace std::chrono;
 
 namespace ocpp::v201 {
 
-SmartChargingHandler::SmartChargingHandler() {
+SmartChargingHandler::SmartChargingHandler(std::map<int32_t, std::unique_ptr<Evse>>& evses) : evses(evses) {
+}
+
+ProfileValidationResultEnum SmartChargingHandler::validate_evse_exists(int32_t evse_id) const {
+    return evses.find(evse_id) == evses.end() ? ProfileValidationResultEnum::EVseDoesNotExist
+                                              : ProfileValidationResultEnum::Valid;
 }
 
 ProfileValidationResultEnum SmartChargingHandler::validate_tx_profile(const ChargingProfile& profile,

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -21,6 +21,8 @@
 
 namespace ocpp::v201 {
 
+static const int DEFAULT_EVSE_ID = 1;
+
 class ChargepointTestFixtureV201 : public testing::Test {
 protected:
     void SetUp() override {
@@ -105,7 +107,7 @@ protected:
     }
 
     SmartChargingHandler create_smart_charging_handler() {
-        return SmartChargingHandler();
+        return SmartChargingHandler(evses);
     }
 
     std::string uuid() {
@@ -227,6 +229,17 @@ TEST_F(ChargepointTestFixtureV201,
     handler.add_profile(profile_2);
     auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
 
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR28_WhenEvseDoesNotExistThenReject) {
+    auto sut = handler.validate_evse_exists(DEFAULT_EVSE_ID);
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::EVseDoesNotExist));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR28_WhenEvseDoesExistThenAccept) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+    auto sut = handler.validate_evse_exists(DEFAULT_EVSE_ID);
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 


### PR DESCRIPTION
These changes apply to K01.FR.28.

If the specified EVSE does not exist, then validation should reject it.
