### PR TITLE
tests: Rename K01.FR.39 tests

### DIFF
--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -228,59 +228,6 @@ TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
 }
 
-TEST_F(ChargepointTestFixtureV201,
-       K01FR06_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
-    create_evse_with_id(evse_id);
-    std::string transaction_id = uuid();
-    open_evse_transaction(evse_id, transaction_id);
-
-    auto same_stack_level = 42;
-    auto profile_1 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
-    auto profile_2 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
-    handler.add_profile(profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
-
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
-}
-
-TEST_F(ChargepointTestFixtureV201,
-       K01FR06_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
-    create_evse_with_id(evse_id);
-    std::string transaction_id = uuid();
-    std::string different_transaction_id = uuid();
-    open_evse_transaction(evse_id, transaction_id);
-
-    auto same_stack_level = 42;
-    auto profile_1 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
-    auto profile_2 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id, same_stack_level);
-    handler.add_profile(profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
-
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
-}
-
-TEST_F(ChargepointTestFixtureV201,
-       K01FR06_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
-    create_evse_with_id(evse_id);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(evse_id, same_transaction_id);
-
-    auto stack_level_1 = 42;
-    auto stack_level_2 = 43;
-    auto profile_1 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_1);
-    auto profile_2 =
-        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_2);
-    handler.add_profile(profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
-
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
-}
-
 TEST_F(ChargepointTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 0, 1);
     auto profile = create_tx_profile(
@@ -316,6 +263,59 @@ TEST_F(ChargepointTestFixtureV201, K01FR35_IfChargingSchedulePeriodsAreNotInChon
     auto sut = handler.validate_profile_schedules(profile);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodsOutOfOrder));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR39_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
+    create_evse_with_id(evse_id);
+    std::string transaction_id = uuid();
+    open_evse_transaction(evse_id, transaction_id);
+
+    auto same_stack_level = 42;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR39_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
+    create_evse_with_id(evse_id);
+    std::string transaction_id = uuid();
+    std::string different_transaction_id = uuid();
+    open_evse_transaction(evse_id, transaction_id);
+
+    auto same_stack_level = 42;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id, same_stack_level);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR39_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
+    create_evse_with_id(evse_id);
+    std::string same_transaction_id = uuid();
+    open_evse_transaction(evse_id, same_transaction_id);
+
+    auto stack_level_1 = 42;
+    auto stack_level_2 = 43;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_1);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_2);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
 TEST_F(ChargepointTestFixtureV201,


### PR DESCRIPTION
## Describe your changes

Tests for K01.FR.39 were previously mislabeled for K01.FR.06.

This commit relabels these tests.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

