### PR TITLE
drop use of deprecated OpenSSL functions

### DIFF
--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -3,8 +3,6 @@
 #ifndef V201_UTILS_HPP
 #define V201_UTILS_HPP
 
-#include <openssl/sha.h>
-
 #include <ocpp/v201/ocpp_types.hpp>
 namespace ocpp {
 namespace v201 {

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -4,6 +4,8 @@
 #include <everest/logging.hpp>
 
 #include <algorithm>
+#include <openssl/evp.h>
+#include <openssl/sha.h>
 
 #include <ocpp/common/utils.hpp>
 #include <ocpp/v201/utils.hpp>
@@ -147,10 +149,7 @@ TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ReasonEnum& stop_reas
 
 std::string sha256(const std::string& str) {
     unsigned char hash[SHA256_DIGEST_LENGTH];
-    SHA256_CTX sha256;
-    SHA256_Init(&sha256);
-    SHA256_Update(&sha256, str.c_str(), str.size());
-    SHA256_Final(hash, &sha256);
+    EVP_Digest(str.c_str(), str.size(), hash, NULL, EVP_sha256(), NULL);
     std::stringstream ss;
     ss << std::hex << std::setfill('0');
     for (const auto& byte : hash) {

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -152,8 +152,9 @@ std::string sha256(const std::string& str) {
     SHA256_Update(&sha256, str.c_str(), str.size());
     SHA256_Final(hash, &sha256);
     std::stringstream ss;
-    for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-        ss << std::hex << std::setw(2) << std::setfill('0') << (int)hash[i];
+    ss << std::hex << std::setfill('0');
+    for (const auto& byte : hash) {
+        ss << std::setw(2) << (int)byte;
     }
     return ss.str();
 }


### PR DESCRIPTION
## Describe your changes
Replace deprecated OpenSSL functions by supported ones.

The set of SHA256_* types and functions are deprecated since OpenSSL 3.
Compilation warns:
```
.../libocpp/lib/ocpp/v201/utils.cpp:151:16: warning: ‘int SHA256_Init(SHA256_CTX*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
```
and may even fail if OpenSSL is built without support for deprecated functions.

Switch to the recommended set of EVP_* functions. These have been available since about OpenSSL 0.9.7, I tested (compiled, linked, and functionally compared) using OpenSSL 0.9.8g.

This sha256 utility function, used for ID token database entries, may be useful in other places (PnC comes to mind), and could be moved to libevse-security. On the other hand, while libocpp already depends on libevse-security, it feels peculiar using it for database (or does it?).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

