### PR TITLE
Schedule Validation Follow-Ups

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1178,7 +1178,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.41 | :white_check_mark: |  |
 | K01.FR.42 |  |  |
 | K01.FR.43 |  |  |
-| K01.FR.44 |  |  |
+| K01.FR.44 | :white_check_mark: | We reject invalid profiles instead of modifying and accepting them. |
 | K01.FR.45 |  |  |
 | K01.FR.46 |  |  |
 | K01.FR.47 |  |  |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1179,7 +1179,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.42 |  |  |
 | K01.FR.43 |  |  |
 | K01.FR.44 | :white_check_mark: | We reject invalid profiles instead of modifying and accepting them. |
-| K01.FR.45 |  |  |
+| K01.FR.45 | :white_check_mark: | We reject invalid profiles instead of modifying and accepting them. |
 | K01.FR.46 |  |  |
 | K01.FR.47 |  |  |
 | K01.FR.48 |  |  |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1183,7 +1183,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.46 |  |  |
 | K01.FR.47 |  |  |
 | K01.FR.48 |  |  |
-| K01.FR.49 |  |  |
+| K01.FR.49 | :white_check_mark: |  |
 | K01.FR.50 |  |  |
 | K01.FR.51 |  |  |
 | K01.FR.52 | :white_check_mark: |  |

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -18,6 +18,12 @@
 namespace ocpp {
 namespace v201 {
 
+enum class CurrentPhaseType {
+    AC,
+    DC,
+    Unknown,
+};
+
 class EvseInterface {
 public:
     virtual ~EvseInterface();
@@ -118,6 +124,9 @@ public:
     /// \brief Restores the operative status of a connector within this EVSE to the persisted status and recomputes its
     /// effective status \param connector_id The ID of the connector
     virtual void restore_connector_operative_status(int32_t connector_id) = 0;
+
+    /// \brief Returns the phase type for the EVSE based on its SupplyPhases. It can be AC, DC, or Unknown.
+    virtual CurrentPhaseType get_current_phase_type() = 0;
 };
 
 /// \brief Represents an EVSE. An EVSE can contain multiple Connector objects, but can only supply energy to one of
@@ -199,6 +208,8 @@ public:
     void set_evse_operative_status(OperationalStatusEnum new_status, bool persist);
     void set_connector_operative_status(int32_t connector_id, OperationalStatusEnum new_status, bool persist);
     void restore_connector_operative_status(int32_t connector_id);
+
+    CurrentPhaseType get_current_phase_type();
 };
 
 } // namespace v201

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -72,8 +72,10 @@ public:
     ///
     ProfileValidationResultEnum validate_tx_profile(const ChargingProfile& profile, EvseInterface& evse) const;
 
-    /// \brief validates that the given \p profile has valid charging schedules
-    ProfileValidationResultEnum validate_profile_schedules(const ChargingProfile& profile,
+    /// \brief validates that the given \p profile has valid charging schedules.
+    /// If a profiles charging schedule period does not have a valid numberPhases,
+    /// we set it to the default value (3).
+    ProfileValidationResultEnum validate_profile_schedules(ChargingProfile& profile,
                                                            std::optional<EvseInterface*> evse_opt = std::nullopt) const;
 
     ///

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -28,6 +28,7 @@ enum class ProfileValidationResultEnum {
     ChargingProfileExtraneousStartSchedule,
     ChargingSchedulePeriodsOutOfOrder,
     ChargingSchedulePeriodInvalidPhaseToUse,
+    ChargingSchedulePeriodExtraneousPhaseValues,
     DuplicateTxDefaultProfileFound
 };
 
@@ -69,7 +70,8 @@ public:
     ProfileValidationResultEnum validate_tx_profile(const ChargingProfile& profile, EvseInterface& evse) const;
 
     /// \brief validates that the given \p profile has valid charging schedules
-    ProfileValidationResultEnum validate_profile_schedules(const ChargingProfile& profile) const;
+    ProfileValidationResultEnum validate_profile_schedules(const ChargingProfile& profile,
+                                                           std::optional<EvseInterface*> evse_opt = std::nullopt) const;
 
     ///
     /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -31,6 +31,14 @@ enum class ProfileValidationResultEnum {
     DuplicateTxDefaultProfileFound
 };
 
+namespace conversions {
+/// \brief Converts the given ProfileValidationResultEnum \p e to human readable string
+/// \returns a string representation of the ProfileValidationResultEnum
+std::string profile_validation_result_to_string(ProfileValidationResultEnum e);
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ProfileValidationResultEnum validation_result);
+
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
 /// to calculate the composite schedules
 class SmartChargingHandler {

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -14,6 +14,8 @@
 
 namespace ocpp::v201 {
 
+const int DEFAULT_AND_MAX_NUMBER_PHASES = 3;
+
 enum class ProfileValidationResultEnum {
     Valid,
     EvseDoesNotExist,
@@ -28,6 +30,7 @@ enum class ProfileValidationResultEnum {
     ChargingProfileExtraneousStartSchedule,
     ChargingSchedulePeriodsOutOfOrder,
     ChargingSchedulePeriodInvalidPhaseToUse,
+    ChargingSchedulePeriodUnsupportedNumberPhases,
     ChargingSchedulePeriodExtraneousPhaseValues,
     DuplicateTxDefaultProfileFound
 };

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -309,5 +309,21 @@ Connector* Evse::get_connector(int32_t connector_id) {
     return this->id_connector_map.at(connector_id).get();
 }
 
+CurrentPhaseType Evse::get_current_phase_type() {
+    ComponentVariable evse_variable =
+        EvseComponentVariables::get_component_variable(this->evse_id, EvseComponentVariables::SupplyPhases);
+    auto supply_phases = this->device_model.get_optional_value<int32_t>(evse_variable);
+    if (supply_phases == std::nullopt) {
+        return CurrentPhaseType::Unknown;
+    } else if (*supply_phases == 1 || *supply_phases == 3) {
+        return CurrentPhaseType::AC;
+    } else if (*supply_phases == 0) {
+        return CurrentPhaseType::DC;
+    }
+
+    // NOTE: SupplyPhases should never be a value that isn't NULL, 1, 3, or 0.
+    return CurrentPhaseType::Unknown;
+}
+
 } // namespace v201
 } // namespace ocpp

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
+#include <optional>
 #include <utility>
 
 #include <everest/logging.hpp>

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -144,8 +144,10 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
             // K01.FR.31
             if (i == 0 && charging_schedule_period.startPeriod != 0) {
                 return ProfileValidationResultEnum::ChargingProfileFirstStartScheduleIsNotZero;
-                // K01.FR.35
-            } else if (i != 0 && i + 1 < schedule.chargingSchedulePeriod.size()) {
+            }
+
+            // K01.FR.35
+            if (i + 1 < schedule.chargingSchedulePeriod.size()) {
                 auto next_charging_schedule_period = schedule.chargingSchedulePeriod[i + 1];
                 if (next_charging_schedule_period.startPeriod <= charging_schedule_period.startPeriod) {
                     return ProfileValidationResultEnum::ChargingSchedulePeriodsOutOfOrder;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -15,6 +15,48 @@ using namespace std::chrono;
 
 namespace ocpp::v201 {
 
+namespace conversions {
+std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
+    switch (e) {
+    case ProfileValidationResultEnum::Valid:
+        return "Valid";
+    case ProfileValidationResultEnum::EvseDoesNotExist:
+        return "EvseDoesNotExist";
+    case ProfileValidationResultEnum::TxProfileMissingTransactionId:
+        return "TxProfileMissingTransactionId";
+    case ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero:
+        return "TxProfileEvseIdNotGreaterThanZero";
+    case ProfileValidationResultEnum::TxProfileTransactionNotOnEvse:
+        return "TxProfileTransactionNotOnEvse";
+    case ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction:
+        return "TxProfileEvseHasNoActiveTransaction";
+    case ProfileValidationResultEnum::TxProfileConflictingStackLevel:
+        return "TxProfileConflictingStackLevel";
+    case ProfileValidationResultEnum::ChargingProfileNoChargingSchedulePeriods:
+        return "ChargingProfileNoChargingSchedulePeriods";
+    case ProfileValidationResultEnum::ChargingProfileFirstStartScheduleIsNotZero:
+        return "ChargingProfileFirstStartScheduleIsNotZero";
+    case ProfileValidationResultEnum::ChargingProfileMissingRequiredStartSchedule:
+        return "ChargingProfileMissingRequiredStartSchedule";
+    case ProfileValidationResultEnum::ChargingProfileExtraneousStartSchedule:
+        return "ChargingProfileExtraneousStartSchedule";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodsOutOfOrder:
+        return "ChargingSchedulePeriodsOutOfOrder";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodInvalidPhaseToUse:
+        return "ChargingSchedulePeriodInvalidPhaseToUse";
+    case ProfileValidationResultEnum::DuplicateTxDefaultProfileFound:
+        return "DuplicateTxDefaultProfileFound";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type ProfileValidationResultEnum");
+}
+} // namespace conversions
+
+std::ostream& operator<<(std::ostream& os, const ProfileValidationResultEnum validation_result) {
+    os << conversions::profile_validation_result_to_string(validation_result);
+    return os;
+}
+
 const int32_t STATION_WIDE_ID = 0;
 
 SmartChargingHandler::SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses) : evses(evses) {

--- a/tests/lib/ocpp/v201/mocks/evse_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_mock.hpp
@@ -33,5 +33,6 @@ public:
     MOCK_METHOD(void, set_connector_operative_status,
                 (int32_t connector_id, OperationalStatusEnum new_status, bool persist));
     MOCK_METHOD(void, restore_connector_operative_status, (int32_t connector_id));
+    MOCK_METHOD(CurrentPhaseType, get_current_phase_type, ());
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/mocks/evse_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_mock.hpp
@@ -9,8 +9,8 @@ public:
     MOCK_METHOD(uint32_t, get_number_of_connectors, ());
     MOCK_METHOD(void, open_transaction,
                 (const std::string& transaction_id, const int32_t connector_id, const DateTime& timestamp,
-                 const MeterValue& meter_start, const IdToken& id_token, const std::optional<IdToken>& group_id_token,
-                 const std::optional<int32_t> reservation_id,
+                 const MeterValue& meter_start, const std::optional<IdToken>& id_token,
+                 const std::optional<IdToken>& group_id_token, const std::optional<int32_t> reservation_id,
                  const std::chrono::seconds sampled_data_tx_updated_interval,
                  const std::chrono::seconds sampled_data_tx_ended_interval,
                  const std::chrono::seconds aligned_data_tx_updated_interval,

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -519,4 +519,18 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCEVSE_ThenPro
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
 }
 
+TEST_F(ChargepointTestFixtureV201, K01FR45_IfNumberPhasesGreaterThanMaxNumberPhasesForACEVSE_ThenProfileIsInvalid) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::AC));
+
+    auto periods = create_charging_schedule_periods(0, 4);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+
+    auto sut = handler.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedNumberPhases));
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

Depends on #534

Handles FRs 44, 45, and 49 for EVSEs.

A question: Should we also be checking the ChargingStation's `SupplyPhases` for these FRs for profiles set to EVSE \#0? (In the code, this would be the case when a value for `evse` is not provided to `validate_profile_schedules()`)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

