### PR TITLE
[REF] Documentation changed for the wrong name of parameter (issue 422)

### DIFF
--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -53,7 +53,7 @@ public:
     /// \param evse_id id of the evse
     /// \param number_of_connectors of the evse
     /// \param device_model reference to the device model
-    /// \param status_notification_callback that is called when the status of a connector changes
+    /// \param component_state_manager that is called when the status of a connector changes
     /// \param pause_charging_callback that is called when the charging should be paused due to max energy on
     /// invalid id being exceeded
     Evse(const int32_t evse_id, const int32_t number_of_connectors, DeviceModel& device_model,


### PR DESCRIPTION
status_notifcation_callback was replaced by component_state_manager to have a correct documentation. Simply the name in the documentation modified! Let me know if there is something missing or misunderstood otherwise kindly provide assistance for successful merge.

## Just a name was changed in /brief section

## https://github.com/EVerest/libocpp/issues/422

## Checklist before requesting a review
- [*] I have performed a self-review of my code
- [*] I have made corresponding changes to the documentation
- [*] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements