### PR TITLE
Fix ConfigurationInventory reporting in GetBaseReport

### DIFF
--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -245,13 +245,13 @@ std::vector<ReportData> DeviceModel::get_base_report_data(const ReportBaseEnum& 
 
             // iterate over possibly (Actual, Target, MinSet, MaxSet)
             for (const auto& variable_attribute : variable_attributes) {
-                // FIXME(piet): Right now this reports only FullInventory and ConfigurationInventory (ReadOnly,
-                // ReadWrite or WriteOnly) correctly
+                // FIXME(piet): Right now this reports only FullInventory (ReadOnly,
+                // ReadWrite or WriteOnly) and ConfigurationInventory (ReadWrite or WriteOnly) correctly
                 // TODO(piet): SummaryInventory
                 if (report_base == ReportBaseEnum::FullInventory or
-                    variable_attribute.mutability == MutabilityEnum::ReadOnly or
-                    variable_attribute.mutability == MutabilityEnum::ReadWrite or
-                    variable_attribute.mutability == MutabilityEnum::WriteOnly) {
+                    (report_base == ReportBaseEnum::ConfigurationInventory and
+                     (variable_attribute.mutability == MutabilityEnum::ReadWrite or
+                      variable_attribute.mutability == MutabilityEnum::WriteOnly))) {
                     report_data.variableAttribute.push_back(variable_attribute);
                     // scrub WriteOnly value from report
                     if (variable_attribute.mutability == MutabilityEnum::WriteOnly) {


### PR DESCRIPTION
In FullInventory ReadOnly, ReadyWrite and scrubbed WriteOnly variables are correctly reported However in ConfigurationInventory only ReadyWrite and scrubbed WriteOnly variables are supposed to be reported

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

