### PR TITLE
Made libwebsocket usage default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ else()
     find_package(nlohmann_json REQUIRED)
     find_package(nlohmann_json_schema_validator REQUIRED)
     find_package(websocketpp REQUIRED)
+    find_package(libwebsockets REQUIRED)
     
     find_package(fsm REQUIRED)
     find_package(everest-timer REQUIRED)

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ In order to use the TPM keys, it is mandatory to use the default libwebsocket im
 
 ## Support for websocket++
 
-The old old websocket++ implmentation has been deprecated. For enabling old websocket++ support use the following cmake option:
+The old websocket++ implementation has been deprecated. For enabling websocket++ support use the following cmake option:
 
 ```bash
   cmake .. -DLIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP=ON

--- a/README.md
+++ b/README.md
@@ -547,14 +547,14 @@ Local testing is still in progress.
 ## Building with FetchContent instead of EDM
 In [doc/build-with-fetchcontent](doc/build-with-fetchcontent) you can find an example how to build libocpp with FetchContent instead of EDM.
 
-## Support for libwebsockets
-
-A new websocket implementation based on libwebsockets will deprecate the old websocket++ implmentation. It supports all security profiles, along with TPM usage.
-
 ### Support for TPM keys
 
-In order to use the TPM keys, it is mandatory to use the libwebsocket implementation with the following cmake option.
+In order to use the TPM keys, it is mandatory to use the default libwebsocket implementation.
+
+## Support for websocket++
+
+The old old websocket++ implmentation has been deprecated. For enabling old websocket++ support use the following cmake option:
 
 ```bash
-  cmake .. -DLIBOCPP_ENABLE_LIBWEBSOCKETS=ON
+  cmake .. -DLIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP=ON
 ```

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,14 +27,13 @@ date:
   options: ["BUILD_TZ_LIB ON", "HAS_REMOTE_API 0", "USE_AUTOLOAD 0", "USE_SYSTEM_TZ_DB ON"]
 websocketpp:
   git: https://github.com/zaphoyd/websocketpp.git
-  git_tag: 0.8.2
+  git_tag: 0.8.2  
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
   git_tag: v0.5.0
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
-  git_tag: v4.3.3
-  cmake_condition: "LIBOCPP_ENABLE_LIBWEBSOCKETS"
+  git_tag: v4.3.3  
   options:
     - CMAKE_POLICY_DEFAULT_CMP0077 NEW
     - LWS_ROLE_RAW_FILE OFF

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,7 +27,7 @@ date:
   options: ["BUILD_TZ_LIB ON", "HAS_REMOTE_API 0", "USE_AUTOLOAD 0", "USE_SYSTEM_TZ_DB ON"]
 websocketpp:
   git: https://github.com/zaphoyd/websocketpp.git
-  git_tag: 0.8.2  
+  git_tag: 0.8.2
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
   git_tag: v0.5.0

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -56,7 +56,7 @@ add_subdirectory(ocpp/v16/messages)
 add_subdirectory(ocpp/v201/messages)
 
 option(LIBOCPP_USE_BOOST_FILESYSTEM "Usage of boost/filesystem.hpp instead of std::filesystem" OFF)
-option(LIBOCPP_ENABLE_LIBWEBSOCKETS "Usage of libwebsockets instead of websockets++" OFF)
+option(LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP "Usage of deprecated websocket++ instad of libwebsockets" OFF)
 
 target_include_directories(ocpp
     PUBLIC
@@ -110,10 +110,10 @@ endif()
  
 target_link_libraries(ocpp
     PUBLIC
-        everest::timer
-        websocketpp::websocketpp
+        everest::timer        
         nlohmann_json_schema_validator
         everest::evse_security
+        websocketpp::websocketpp
     PRIVATE
         OpenSSL::SSL
         OpenSSL::Crypto
@@ -124,15 +124,15 @@ target_link_libraries(ocpp
         date::date-tz
 )
 
-if(LIBOCPP_ENABLE_LIBWEBSOCKETS)
-    find_package(libwebsockets REQUIRED)
-    target_link_libraries(ocpp
-    PUBLIC
-        websockets_shared
-    )
+target_link_libraries(ocpp
+PUBLIC
+    websockets_shared
+)
+
+if(LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP)        
     target_compile_definitions(ocpp
         PRIVATE
-            LIBOCPP_ENABLE_LIBWEBSOCKETS
+            LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP
     )
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -56,7 +56,7 @@ add_subdirectory(ocpp/v16/messages)
 add_subdirectory(ocpp/v201/messages)
 
 option(LIBOCPP_USE_BOOST_FILESYSTEM "Usage of boost/filesystem.hpp instead of std::filesystem" OFF)
-option(LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP "Usage of deprecated websocket++ instad of libwebsockets" OFF)
+option(LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP "Usage of deprecated websocket++ instead of libwebsockets" OFF)
 
 target_include_directories(ocpp
     PUBLIC

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -129,7 +129,7 @@ PUBLIC
     websockets_shared
 )
 
-if(LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP)        
+if(LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP)
     target_compile_definitions(ocpp
         PRIVATE
             LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP

--- a/lib/ocpp/common/websocket/CMakeLists.txt
+++ b/lib/ocpp/common/websocket/CMakeLists.txt
@@ -2,15 +2,11 @@
 target_sources(ocpp
     PRIVATE
         websocket_base.cpp
-        websocket_uri.cpp
+        websocket_uri.cpp        
+        websocket.cpp
+        websocket_libwebsockets.cpp
+
+        # TODO: remove when interface refactor is done
         websocket_plain.cpp
         websocket_tls.cpp
-        websocket.cpp
 )
-
-if(LIBOCPP_ENABLE_LIBWEBSOCKETS)
-    target_sources(ocpp
-        PRIVATE
-            websocket_libwebsockets.cpp
-    )
-endif()

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -5,8 +5,10 @@
 #include <ocpp/common/websocket/websocket.hpp>
 #include <ocpp/v16/types.hpp>
 
-#ifdef LIBOCPP_ENABLE_LIBWEBSOCKETS
 #include <ocpp/common/websocket/websocket_libwebsockets.hpp>
+
+#ifdef LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP
+#include <ocpp/common
 #endif
 
 #include <boost/algorithm/string.hpp>
@@ -19,14 +21,14 @@ Websocket::Websocket(const WebsocketConnectionOptions& connection_options, std::
                      std::shared_ptr<MessageLogging> logging) :
     logging(logging) {
 
-#ifdef LIBOCPP_ENABLE_LIBWEBSOCKETS
-    this->websocket = std::make_unique<WebsocketTlsTPM>(connection_options, evse_security);
-#else
+#ifdef LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP
     if (connection_options.security_profile <= 1) {
         this->websocket = std::make_unique<WebsocketPlain>(connection_options);
     } else if (connection_options.security_profile >= 2) {
         this->websocket = std::make_unique<WebsocketTLS>(connection_options, evse_security);
     }
+#else
+    this->websocket = std::make_unique<WebsocketTlsTPM>(connection_options, evse_security);
 #endif
 }
 

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -7,10 +7,6 @@
 
 #include <ocpp/common/websocket/websocket_libwebsockets.hpp>
 
-#ifdef LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP
-#include <ocpp/common
-#endif
-
 #include <boost/algorithm/string.hpp>
 
 using json = nlohmann::json;


### PR DESCRIPTION
## Describe your changes

Websocket++ usage has been deprecated and due to future heavy interface refactoring it has been removed from the default compilation. Libwebsocket has been made the default websocket library that is used.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

