### PR TITLE
OCPP1.6: Call set_connection_timeout in start function

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -820,6 +820,7 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->websocket->connect();
     this->boot_notification();
     this->load_charging_profiles();
+    this->call_set_connection_timeout();
 
     this->stopped = false;
     return true;


### PR DESCRIPTION
calling set_connection_timeout on start up to apply the value that is set

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

