### PR TITLE
OCPP1.6: Retrieve faulted state from state machine 

### DIFF
--- a/lib/ocpp/v16/charge_point_state_machine.cpp
+++ b/lib/ocpp/v16/charge_point_state_machine.cpp
@@ -113,6 +113,9 @@ ChargePointFSM::ChargePointFSM(const StatusNotificationCallback& status_notifica
 }
 
 FSMState ChargePointFSM::get_state() const {
+    if (faulted) {
+        return FSMState::Faulted;
+    }
     return state;
 }
 


### PR DESCRIPTION
## Describe your changes
OCPP1.6 statemachine now returns faulted if previously set to faulted. The get_state() Faulted case is used for business logic in the charge point implementation

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

