### PR TITLE
Response TriggerMessage Rejected for MeterValues if the measurand does not exist

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -2603,8 +2603,8 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
                 response.status = TriggerMessageStatusEnum::Accepted;
             }
         } else {
-            const auto measurands = utils::get_measurands_vec(this->device_model->get_value<std::string>(
-                ControllerComponentVariables::AlignedDataMeasurands));
+            const auto measurands = utils::get_measurands_vec(
+                this->device_model->get_value<std::string>(ControllerComponentVariables::AlignedDataMeasurands));
             for (auto const& [evse_id, evse] : this->evses) {
                 if (utils::meter_value_has_any_measurand(evse->get_meter_value(), measurands)) {
                     response.status = TriggerMessageStatusEnum::Accepted;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -2603,8 +2603,8 @@ void ChargePoint::handle_trigger_message(Call<TriggerMessageRequest> call) {
                 response.status = TriggerMessageStatusEnum::Accepted;
             }
         } else {
-            auto measurands = utils::get_measurands_vec(this->device_model->get_value<std::string>(
-                ControllerComponentVariables::SampledDataTxUpdatedMeasurands));
+            const auto measurands = utils::get_measurands_vec(this->device_model->get_value<std::string>(
+                ControllerComponentVariables::AlignedDataMeasurands));
             for (auto const& [evse_id, evse] : this->evses) {
                 if (utils::meter_value_has_any_measurand(evse->get_meter_value(), measurands)) {
                     response.status = TriggerMessageStatusEnum::Accepted;


### PR DESCRIPTION
## Describe your changes
TriggerMessage response is rejected for MeterValues if the measurand doesn't exist
## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/563
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

