### PR TITLE
OCPP2.0.1: Allowing NotifyReportResponse by CSMS in pending

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1187,6 +1187,7 @@ void ChargePoint::message_callback(const std::string& message) {
                     enhanced_message.messageType == MessageType::SetVariables or
                     enhanced_message.messageType == MessageType::GetBaseReport or
                     enhanced_message.messageType == MessageType::GetReport or
+                    enhanced_message.messageType == MessageType::NotifyReportResponse or
                     enhanced_message.messageType == MessageType::TriggerMessage) {
                     this->handle_message(enhanced_message);
                 } else if (enhanced_message.messageType == MessageType::RequestStartTransaction) {


### PR DESCRIPTION
## Describe your changes
Allowing NotifyReportResponse by CSMS in pending.
This fixes OCTT TC_B_02_CS . 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

