### PR TITLE
Fix Integrity Check of number of Evses and Connectors

### DIFF
--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -318,7 +318,7 @@ void DeviceModel::check_integrity(const std::map<int32_t, int32_t>& evse_connect
     try {
         this->storage->check_integrity();
 
-        int32_t nr_evse_components;
+        int32_t nr_evse_components = 0;
         std::map<int32_t, int32_t> evse_id_nr_connector_components;
 
         for (const auto& [component, variable_map] : this->device_model) {


### PR DESCRIPTION
## Describe your changes
initialize nr_of_evses with 0

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

