### PR TITLE
Remove redundant conversions for CustomData

### DIFF
--- a/include/ocpp/v201/ocpp_types.hpp
+++ b/include/ocpp/v201/ocpp_types.hpp
@@ -15,15 +15,6 @@ namespace ocpp {
 namespace v201 {
 
 using CustomData = nlohmann::json;
-/// \brief Conversion from a given CustomData \p k to a given json object \p j
-void to_json(json& j, const CustomData& k);
-
-/// \brief Conversion from a given json object \p j to a given CustomData \p k
-void from_json(const json& j, CustomData& k);
-
-// \brief Writes the string representation of the given CustomData \p k to the given output stream \p os
-/// \returns an output stream with the CustomData written to
-std::ostream& operator<<(std::ostream& os, const CustomData& k);
 
 struct AdditionalInfo {
     CiString<36> additionalIdToken;

--- a/lib/ocpp/v201/ocpp_types.cpp
+++ b/lib/ocpp/v201/ocpp_types.cpp
@@ -13,27 +13,6 @@
 namespace ocpp {
 namespace v201 {
 
-/// \brief Conversion from a given CustomData \p k to a given json object \p j
-void to_json(json& j, const CustomData& k) {
-    // custom data, make sure that vendorId exists
-    j["vendorId"] = k.at("vendorId");
-    j = k;
-}
-
-/// \brief Conversion from a given json object \p j to a given CustomData \p k
-void from_json(const json& j, CustomData& k) {
-    // custom data, make sure that vendorId exists
-    k["vendorId"] = j.at("vendorId");
-    k = j;
-}
-
-// \brief Writes the string representation of the given CustomData \p k to the given output stream \p os
-/// \returns an output stream with the CustomData written to
-std::ostream& operator<<(std::ostream& os, const CustomData& k) {
-    os << json(k).dump(4);
-    return os;
-}
-
 /// \brief Conversion from a given AdditionalInfo \p k to a given json object \p j
 void to_json(json& j, const AdditionalInfo& k) {
     // the required parts of the message

--- a/src/code_generator/common/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.cpp.jinja
@@ -16,15 +16,10 @@ namespace {{namespace}} {
 {% endif %}
 {%- if parsed_types|length %}
 {%- for type in parsed_types %}
-{% if not type.name.endswith('Request') and not type.name.endswith('Response') %}
+{% if not type.name.endswith('Request') and not type.name.endswith('Response') and not (type.name == "CustomData" and namespace == "v201") %}
 
     /// \brief Conversion from a given {{ type.name }} \p k to a given json object \p j
     void to_json(json& j, const {{ type.name }}& k) {
-{% if type.name == "CustomData" and namespace == "v201" %}
-        // custom data, make sure that vendorId exists
-        j["vendorId"] = k.at("vendorId");
-        j = k;
-{% else %}
         // the required parts of the message
 {% if type.properties|selectattr('required')|list|length %}
         j = json{
@@ -82,16 +77,10 @@ j["{{property.name}}"] = k.{{property.name}}.value();
         }
 {% endif %}
 {% endfor %}
-{% endif %}
     }
 
     /// \brief Conversion from a given json object \p j to a given {{ type.name }} \p k
     void from_json(const json& j, {{ type.name }}& k) {
-{% if type.name == "CustomData" and namespace == "v201" %}
-        // custom data, make sure that vendorId exists
-        k["vendorId"] = j.at("vendorId");
-        k = j;
-{% else %}
         // the required parts of the message
 {% for property in type.properties %}
 {% if property.required %}
@@ -139,7 +128,6 @@ j["{{property.name}}"] = k.{{property.name}}.value();
         }
 {% endif %}
 {% endfor %}
-{% endif %}
     }
 
     // \brief Writes the string representation of the given {{ type.name }} \p k to the given output stream \p os

--- a/src/code_generator/common/templates/ocpp_types.hpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.hpp.jinja
@@ -34,6 +34,7 @@ struct {{type.name}} {
 {% endfor %}
 };
 {% endif %}
+{% if not (type.name == "CustomData" and namespace == "v201") %}
     /// \brief Conversion from a given {{ type.name }} \p k to a given json object \p j
     void to_json(json& j, const {{ type.name }}& k);
 
@@ -44,6 +45,7 @@ struct {{type.name}} {
     /// \returns an output stream with the {{ type.name }} written to
     std::ostream& operator<<(std::ostream& os, const {{ type.name }}& k);
 
+{% endif %}
 {% endif %}
 {% endfor %}
 {%- endif %}


### PR DESCRIPTION
This is already a nlohmann json object, so no dedicated conversions are required and might even be harmful for some compilers

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

