### PR TITLE
Executing disconnected callback when websocket connection is closed

### DIFF
--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -718,7 +718,10 @@ void WebsocketTlsTPM::close(websocketpp::close::status::value code, const std::s
     // Clear any irrelevant data after a DC
     recv_buffered_message.clear();
 
-    std::thread closing([this]() { this->closed_callback(websocketpp::close::status::normal); });
+    std::thread closing([this]() {
+        this->closed_callback(websocketpp::close::status::normal);
+        this->disconnected_callback();
+    });
     closing.detach();
 }
 
@@ -750,7 +753,10 @@ void WebsocketTlsTPM::on_conn_close() {
     // Clear any irrelevant data after a DC
     recv_buffered_message.clear();
 
-    std::thread closing([this]() { this->closed_callback(websocketpp::close::status::normal); });
+    std::thread closing([this]() {
+        this->closed_callback(websocketpp::close::status::normal);
+        this->disconnected_callback();
+    });
     closing.detach();
 }
 


### PR DESCRIPTION
## Describe your changes
Executing disconnected callback when websocket connection is closed in libwebsockets. This allows the charge point to use the properly use the OfflineThreshold

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

