### PR TITLE
Move handling of changed variable

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1666,9 +1666,6 @@ ChargePoint::set_variables_internal(const std::vector<SetVariableData>& set_vari
         response[set_variable_data] = set_variable_result;
     }
 
-    // post handling of changed variables after the SetVariables.conf has been queued
-    this->handle_variables_changed(response);
-
     return response;
 }
 
@@ -3329,7 +3326,9 @@ ChargePoint::get_variables(const std::vector<GetVariableData>& get_variable_data
 std::map<SetVariableData, SetVariableResult>
 ChargePoint::set_variables(const std::vector<SetVariableData>& set_variable_data_vector) {
     // set variables and allow setting of ReadOnly variables
-    return this->set_variables_internal(set_variable_data_vector, true);
+    const auto response = this->set_variables_internal(set_variable_data_vector, true);
+    this->handle_variables_changed(response);
+    return response;
 }
 
 } // namespace v201


### PR DESCRIPTION
## Describe your changes
Moved handling of changed variable after responding with SetVariables.conf.

Without this change, handling of variable changes on a SetVariable.req was started before responding with a SetVariables.conf . This is problematic e.g. for a BasicAuthPassword change

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

