### PR TITLE
Add TxDefaultProfile to either EVSE or entire station.

### DIFF
--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -81,7 +81,12 @@ public:
     ///
     /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles
     ///
-    void add_profile(int32_t evse_id, ChargingProfile& profile);
+    ProfileValidationResultEnum add_profile(int32_t evse_id, ChargingProfile& profile);
+
+    ///
+    /// \brief Retrieves existing profiles on system.
+    ///
+    ChargingProfile get_profiles();
 
 private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -192,12 +192,14 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
     return ProfileValidationResultEnum::Valid;
 }
 
-void SmartChargingHandler::add_profile(int32_t evse_id, ChargingProfile& profile) {
+ProfileValidationResultEnum SmartChargingHandler::add_profile(int32_t evse_id, ChargingProfile& profile) {
     if (STATION_WIDE_ID == evse_id) {
         station_wide_charging_profiles.push_back(profile);
     } else {
         charging_profiles[evse_id].push_back(profile);
     }
+
+    return ProfileValidationResultEnum::Valid;
 }
 
 std::vector<ChargingProfile> SmartChargingHandler::get_evse_specific_tx_default_profiles() const {

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -545,4 +545,32 @@ TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACEVSE_ThenSe
     EXPECT_THAT(numberPhases, testing::Eq(3));
 }
 
+TEST_F(ChargepointTestFixtureV201,
+       K01FR14_IfTxDefaultProfileWithSameStackLevelDoesNotExist_ThenApplyStationWideTxDefaultProfileToAllEvses) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                           ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+
+    auto sut = handler.add_profile(STATION_WIDE_ID, profile);
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+
+    EXPECT_THAT(handler.get_profiles(), testing::Contains(profile));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR15_IfTxDefaultProfileWithSameStackLevelDoesNotExist_ThenApplyTxDefaultProfileToEvse) {
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                           ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
+
+    auto sut = handler.add_profile(DEFAULT_EVSE_ID, profile);
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+
+    EXPECT_THAT(handler.get_profiles(), testing::Contains(profile));
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

I added some tests for adding a TxDefaultProfile either to the entire station or to a specific EVSE.

Validation is presumed, and eventually validation will be included in add_profile(), but not for this user story.

## Issue ticket number and link

https://github.com/US-JOET/base-camp/issues/98

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

