### PR TITLE
Switch to libevse-security tag v0.6.0

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -30,7 +30,7 @@ websocketpp:
   git_tag: 0.8.2
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 34e89b2
+  git_tag: v0.6.0
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
   git_tag: v4.3.3  


### PR DESCRIPTION
This tag is identical to the git rev used before

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

