### PR TITLE
Guard 2.0.1 database transactions with a mutex

### DIFF
--- a/include/ocpp/common/database/database_connection.hpp
+++ b/include/ocpp/common/database/database_connection.hpp
@@ -17,7 +17,7 @@ namespace ocpp::common {
 class DatabaseTransactionInterface {
 public:
     /// \brief Destructor of transaction: Will by default rollback unless commit() is called
-    virtual ~DatabaseTransactionInterface();
+    virtual ~DatabaseTransactionInterface() = default;
 
     /// \brief Commits the transaction and release the lock on the database interface
     virtual void commit() = 0;

--- a/include/ocpp/common/database/database_connection.hpp
+++ b/include/ocpp/common/database/database_connection.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <sqlite3.h>
 
 #include <ocpp/common/support_older_cpp_versions.hpp>
@@ -10,6 +11,20 @@
 #include "sqlite_statement.hpp"
 
 namespace ocpp::common {
+
+/// \brief Helper class for transactions. Will lock the database interface from new transaction until commit() or
+/// rollback() is caller or the object destroyed
+class DatabaseTransactionInterface {
+public:
+    /// \brief Destructor of transaction: Will by default rollback unless commit() is called
+    virtual ~DatabaseTransactionInterface();
+
+    /// \brief Commits the transaction and release the lock on the database interface
+    virtual void commit() = 0;
+
+    /// \brief Aborts the transaction and release the lock on the database interface
+    virtual void rollback() = 0;
+};
 
 class DatabaseConnectionInterface {
 public:
@@ -21,14 +36,9 @@ public:
     /// \brief Closes the database connection. Returns true if succeeded.
     virtual bool close_connection() = 0;
 
-    /// \brief Start a transaction on the database. Returns true if succeeded.
-    virtual bool begin_transaction() = 0;
-
-    /// \brief Commits the transaction on the database. Returns true if succeeded.
-    virtual bool commit_transaction() = 0;
-
-    /// \brief Rolls back the transaction on the database. Returns true if succeeded.
-    virtual bool rollback_transaction() = 0;
+    /// \brief Start a transaction on the database. Returns an object holding the transaction.
+    /// \note This function can block until the previous transaction is finished.
+    [[nodiscard]] virtual std::unique_ptr<DatabaseTransactionInterface> begin_transaction() = 0;
 
     /// \brief Immediately executes \p statement. Returns true if succeeded.
     virtual bool execute_statement(const std::string& statement) = 0;
@@ -52,6 +62,7 @@ private:
     sqlite3* db;
     const fs::path database_file_path;
     std::atomic_uint32_t open_count;
+    std::timed_mutex transaction_mutex;
 
     bool close_connection_internal(bool force_close);
 
@@ -63,9 +74,7 @@ public:
     bool open_connection() override;
     bool close_connection() override;
 
-    bool begin_transaction() override;
-    bool commit_transaction() override;
-    bool rollback_transaction() override;
+    [[nodiscard]] std::unique_ptr<DatabaseTransactionInterface> begin_transaction() override;
 
     bool execute_statement(const std::string& statement) override;
     std::unique_ptr<SQLiteStatementInterface> new_statement(const std::string& sql) override;

--- a/include/ocpp/common/database/database_connection.hpp
+++ b/include/ocpp/common/database/database_connection.hpp
@@ -13,7 +13,7 @@
 namespace ocpp::common {
 
 /// \brief Helper class for transactions. Will lock the database interface from new transaction until commit() or
-/// rollback() is caller or the object destroyed
+/// rollback() is called or the object destroyed
 class DatabaseTransactionInterface {
 public:
     /// \brief Destructor of transaction: Will by default rollback unless commit() is called

--- a/include/ocpp/v201/database_handler.hpp
+++ b/include/ocpp/v201/database_handler.hpp
@@ -7,7 +7,6 @@
 #include <deque>
 #include <fstream>
 #include <memory>
-#include <mutex>
 #include <ocpp/common/support_older_cpp_versions.hpp>
 
 #include <ocpp/common/database/database_connection.hpp>
@@ -34,8 +33,6 @@ private:
     void insert_availability(int32_t evse_id, int32_t connector_id, OperationalStatusEnum operational_status,
                              bool replace);
     OperationalStatusEnum get_availability(int32_t evse_id, int32_t connector_id);
-
-    std::mutex database_transaction_mutex;
 
 public:
     DatabaseHandler(std::unique_ptr<common::DatabaseConnectionInterface> database,

--- a/include/ocpp/v201/database_handler.hpp
+++ b/include/ocpp/v201/database_handler.hpp
@@ -7,6 +7,7 @@
 #include <deque>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <ocpp/common/support_older_cpp_versions.hpp>
 
 #include <ocpp/common/database/database_connection.hpp>
@@ -33,6 +34,8 @@ private:
     void insert_availability(int32_t evse_id, int32_t connector_id, OperationalStatusEnum operational_status,
                              bool replace);
     OperationalStatusEnum get_availability(int32_t evse_id, int32_t connector_id);
+
+    std::mutex database_transaction_mutex;
 
 public:
     DatabaseHandler(std::unique_ptr<common::DatabaseConnectionInterface> database,

--- a/lib/ocpp/common/database/database_schema_updater.cpp
+++ b/lib/ocpp/common/database/database_schema_updater.cpp
@@ -12,7 +12,8 @@ namespace ocpp::common {
 
 // Helper functions
 
-enum class Direction {
+enum class Direction
+{
     Up,
     Down
 };
@@ -200,8 +201,9 @@ bool DatabaseSchemaUpdater::apply_migration_files(const fs::path& migration_file
         return false;
     }
 
+    bool retval = true;
     try {
-        this->database->begin_transaction();
+        auto transaction = this->database->begin_transaction();
 
         for (const auto& item : list.value()) {
             std::ifstream stream{item.path};
@@ -216,16 +218,14 @@ bool DatabaseSchemaUpdater::apply_migration_files(const fs::path& migration_file
         }
 
         this->set_user_version(target_schema_version);
-        this->database->commit_transaction();
+        transaction->commit();
     } catch (std::exception& e) {
-        this->database->rollback_transaction();
-        this->database->close_connection();
         EVLOG_error << "Failure during migration file apply: " << e.what();
-        return false;
+        retval = false;
     }
 
     this->database->close_connection();
-    return true;
+    return retval;
 }
 
 } // namespace ocpp::common

--- a/lib/ocpp/common/database/database_schema_updater.cpp
+++ b/lib/ocpp/common/database/database_schema_updater.cpp
@@ -12,8 +12,7 @@ namespace ocpp::common {
 
 // Helper functions
 
-enum class Direction
-{
+enum class Direction {
     Up,
     Down
 };

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -52,9 +52,7 @@ void DatabaseHandler::init_enum_table_inner(const std::string& table_name, const
     }
 
     std::scoped_lock lock(this->database_transaction_mutex);
-    if (!this->database->begin_transaction()) {
-        throw std::runtime_error("Could not begin transaction");
-    }
+    auto transaction = this->database->begin_transaction();
 
     std::string sql = "INSERT INTO " + table_name + " VALUES (@id, @value);";
     auto insert_stmt = this->database->new_statement(sql);
@@ -72,9 +70,7 @@ void DatabaseHandler::init_enum_table_inner(const std::string& table_name, const
         insert_stmt->reset();
     }
 
-    if (!this->database->commit_transaction()) {
-        throw std::runtime_error("Could not commit transaction");
-    }
+    transaction->commit();
 }
 
 template <typename T>
@@ -342,11 +338,7 @@ bool DatabaseHandler::transaction_metervalues_insert(const std::string& transact
                        "@phase, @location, @custom_data, @unit_custom_data, @unit_text, @unit_multiplier, "
                        "@signed_meter_data, @signing_method, @encoding_method, @public_key);";
 
-    std::scoped_lock lock(this->database_transaction_mutex);
-    if (!this->database->begin_transaction()) {
-        throw std::runtime_error("Could not begin transaction");
-    }
-
+    auto transaction = this->database->begin_transaction();
     auto insert_stmt = this->database->new_statement(sql2);
 
     for (const auto& item : meter_value.sampledValue) {
@@ -413,9 +405,7 @@ bool DatabaseHandler::transaction_metervalues_insert(const std::string& transact
         insert_stmt->reset();
     }
 
-    if (!this->database->commit_transaction()) {
-        throw std::runtime_error("Could not commit transaction");
-    }
+    transaction->commit();
 
     return true;
 }

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -51,6 +51,7 @@ void DatabaseHandler::init_enum_table_inner(const std::string& table_name, const
         throw std::runtime_error("Table does not exist.");
     }
 
+    std::scoped_lock lock(this->database_transaction_mutex);
     if (!this->database->begin_transaction()) {
         throw std::runtime_error("Could not begin transaction");
     }
@@ -341,6 +342,7 @@ bool DatabaseHandler::transaction_metervalues_insert(const std::string& transact
                        "@phase, @location, @custom_data, @unit_custom_data, @unit_text, @unit_multiplier, "
                        "@signed_meter_data, @signing_method, @encoding_method, @public_key);";
 
+    std::scoped_lock lock(this->database_transaction_mutex);
     if (!this->database->begin_transaction()) {
         throw std::runtime_error("Could not begin transaction");
     }

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -51,7 +51,6 @@ void DatabaseHandler::init_enum_table_inner(const std::string& table_name, const
         throw std::runtime_error("Table does not exist.");
     }
 
-    std::scoped_lock lock(this->database_transaction_mutex);
     auto transaction = this->database->begin_transaction();
 
     std::string sql = "INSERT INTO " + table_name + " VALUES (@id, @value);";


### PR DESCRIPTION
Otherwise it might happen that we try to insert metervalues into the database while another transaction event is happening. In certain circumstances (for example with multiple EVSEs present) this can lead to a "Could not begin transaction" exception

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

