### PR TITLE
Change trigger reason for stopped by EV according to errata

### DIFF
--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -137,7 +137,7 @@ TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ReasonEnum& stop_reas
     case ReasonEnum::SOCLimitReached:
         return TriggerReasonEnum::EnergyLimitReached;
     case ReasonEnum::StoppedByEV:
-        return TriggerReasonEnum::ChargingStateChanged;
+        return TriggerReasonEnum::StopAuthorized;
     case ReasonEnum::TimeLimitReached:
         return TriggerReasonEnum::TimeLimitReached;
     case ReasonEnum::Timeout:


### PR DESCRIPTION
## Describe your changes
When charging session is stopped on EV request (ISO15118), errata specifies `stopReason=StoppedByEV` and `triggerReason=StopAuthorized`

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/550

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md). Note that the errata will change requirement E15.FR.04 and add a new E15.FR.05
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

