### PR TITLE
Removed logging used in debug

### DIFF
--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -416,6 +416,7 @@ void WebsocketTlsTPM::client_loop() {
 
     // lws_set_log_level(LLL_ERR | LLL_WARN | LLL_NOTICE | LLL_INFO | LLL_DEBUG | LLL_PARSER | LLL_HEADER | LLL_EXT |
     //                          LLL_CLIENT | LLL_LATENCY | LLL_THREAD | LLL_USER, nullptr);
+    lws_set_log_level(LLL_ERR, nullptr);
 
     lws_context_creation_info info;
     memset(&info, 0, sizeof(lws_context_creation_info));
@@ -791,7 +792,7 @@ void WebsocketTlsTPM::on_message(std::string&& message) {
         return;
     }
 
-    EVLOG_info << "Received message over TLS websocket polling for process: " << message;
+    EVLOG_debug << "Received message over TLS websocket polling for process: " << message;
 
     {
         std::lock_guard<std::mutex> lock(this->recv_mutex);
@@ -982,7 +983,7 @@ void WebsocketTlsTPM::poll_message(const std::shared_ptr<WebsocketMessage>& msg)
         }
     }
 
-    EVLOG_info << "Queueing message over TLS websocket: " << msg->payload;
+    EVLOG_debug << "Queueing message over TLS websocket: " << msg->payload;
 
     {
         std::lock_guard<std::mutex> lock(this->queue_mutex);
@@ -995,7 +996,7 @@ void WebsocketTlsTPM::poll_message(const std::shared_ptr<WebsocketMessage>& msg)
     {
         std::unique_lock lock(this->msg_send_cv_mutex);
         if (msg_send_cv.wait_for(lock, std::chrono::seconds(20), [&] { return (true == msg->message_sent); })) {
-            EVLOG_info << "Successfully sent last message over TLS websocket!";
+            EVLOG_debug << "Successfully sent last message over TLS websocket!";
         } else {
             EVLOG_warning << "Could not send last message over TLS websocket!";
         }


### PR DESCRIPTION
## Describe your changes

Logging mode for libwebsockets has been set to 'error' only. Messages send/received will only generate a 'DEBUG' message, and not a INFO message.

## Issue ticket number and link

https://github.com/EVerest/libocpp/issues/598

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

