### PR TITLE
Execute on changeavailability for connector 0 callback

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1340,14 +1340,14 @@ void ChargePointImpl::execute_connectors_availability_change(const std::vector<i
                 this->status->submit_event(connector, FSMEvent::BecomeAvailable, ocpp::DateTime());
             }
 
-            if (connector != 0 and this->enable_evse_callback != nullptr) {
+            if (this->enable_evse_callback != nullptr) {
                 this->enable_evse_callback(connector);
             }
         } else {
             if (connector == 0 or !evse_changed) {
                 this->status->submit_event(connector, FSMEvent::ChangeAvailabilityToUnavailable, ocpp::DateTime());
             }
-            if (connector != 0 and this->disable_evse_callback != nullptr) {
+            if (this->disable_evse_callback != nullptr) {
                 this->disable_evse_callback(connector);
             }
         }


### PR DESCRIPTION
## Describe your changes
In case of changeAvailablity.req processing, the enable/disable callback for connector 0 is also exectued.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

