### PR TITLE
OCPP1.6: Pending transactions at startup

### DIFF
--- a/include/ocpp/v16/utils.hpp
+++ b/include/ocpp/v16/utils.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v16/types.hpp>
+
+namespace ocpp {
+namespace v16 {
+namespace utils {
+bool is_transaction_message_type(const MessageType& message_type) {
+    return message_type == MessageType::StartTransaction or message_type == MessageType::StopTransaction or
+           message_type == MessageType::MeterValues or message_type == MessageType::SecurityEventNotification;
+}
+} // namespace utils
+} // namespace v16
+} // namespace ocpp

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -821,6 +821,9 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->init_websocket();
     this->websocket->connect();
     this->boot_notification();
+    // push transaction messages including SecurityEventNotification.req onto the message queue
+    this->message_queue->get_transaction_messages_from_db(this->configuration->getDisableSecurityEventNotifications());
+    this->stop_pending_transactions();
     this->load_charging_profiles();
     this->call_set_connection_timeout();
 
@@ -1249,10 +1252,6 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
                                       ocpp::DateTime());
         }
 
-        // push transaction messages including SecurityEventNotification.req onto the message queue
-        this->message_queue->get_transaction_messages_from_db(
-            this->configuration->getDisableSecurityEventNotifications());
-
         if (this->is_pnc_enabled()) {
             this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
             this->v2g_certificate_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
@@ -1266,8 +1265,6 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
         if (this->is_pnc_enabled()) {
             this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
         }
-
-        this->stop_pending_transactions();
 
         break;
     }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -7,6 +7,7 @@
 #include <ocpp/v16/charge_point.hpp>
 #include <ocpp/v16/charge_point_configuration.hpp>
 #include <ocpp/v16/charge_point_impl.hpp>
+#include <ocpp/v16/utils.hpp>
 #include <ocpp/v201/utils.hpp>
 
 #include <optional>
@@ -2598,8 +2599,8 @@ bool ChargePointImpl::allowed_to_send_message(json::array_t message, bool initia
     }
 
     if (!this->initialized) {
-        // BootNotification and StopTransaction messages can be queued before receiving a BootNotification.conf
-        if (message_type == MessageType::BootNotification || message_type == MessageType::StopTransaction) {
+        // BootNotification and transaction related messages can be queued before receiving a BootNotification.conf
+        if (message_type == MessageType::BootNotification or utils::is_transaction_message_type(message_type)) {
             return true;
         }
         return false;


### PR DESCRIPTION
## Describe your changes
1. The `stop_pending_transactions()` is currently executed as part of the BootNotififcation.conf handler. This change moves the `stop_pending_transactions()` function to the public `start()` function of the start point. This change is required because in case transactions are started before a BootNotification.conf is received (e.g. if being offline) these transactions would have been stopped when the BootNotification.conf(Accepted) is received without this change.

2. Transaction-related messages are now allowed to be queued before a BootNotification.conf(Accepted) has been received.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

