### PR TITLE
K01: Implement Full Validate Profile Method & Required Methods

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1157,10 +1157,10 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.16 |  |  |
 | K01.FR.17 |  |  |
 | K01.FR.19 |  |  |
-| K01.FR.20 | :white_check_mark: |  |
+| K01.FR.20 |  | This requires some feedback from the OCA, as the usage of `ACPhaseSwitchingSupported` is unclear. |
 | K01.FR.21 |  |  |
 | K01.FR.22 |  |  |
-| K01.FR.26 |  |  |
+| K01.FR.26 | :white_check_mark: |  |
 | K01.FR.27 |  |  |
 | K01.FR.28 |  |  |
 | K01.FR.29 |  |  |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1172,7 +1172,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.35 |  |  |
 | K01.FR.36 | :white_check_mark: |  |
 | K01.FR.37 |  |  |
-| K01.FR.38 |  |  |
+| K01.FR.38 | :white_check_mark: |  |
 | K01.FR.39 | :white_check_mark: |  |
 | K01.FR.40 | :white_check_mark: |  |
 | K01.FR.41 | :white_check_mark: |  |
@@ -1218,7 +1218,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | --- | --- | --- |
 | K04.FR.01 |  |  |
 | K04.FR.02 |  |  |
-| K04.FR.03 |  |  |
+| K04.FR.03 | :white_check_mark: |  |
 | K04.FR.04 |  | The same as K01.FR.21 |
 | K04.FR.05 |  | This should be handled by the user of libocpp |
 ## SmartCharging - Remote Start Transaction with Charging Profile

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1157,7 +1157,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.16 |  |  |
 | K01.FR.17 |  |  |
 | K01.FR.19 |  |  |
-| K01.FR.20 |  | This requires some feedback from the OCA, as the usage of `ACPhaseSwitchingSupported` is unclear. |
+| K01.FR.20 | :white_check_mark: | This FR hints that `ACPhaseSwitchingSupported` should be per EVSE, but this makes no sense with the rest of the spec. |
 | K01.FR.21 |  |  |
 | K01.FR.22 |  |  |
 | K01.FR.26 | :white_check_mark: |  |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1144,7 +1144,7 @@ This document contains the status of which OCPP 2.0.1 numbered requirements have
 | K01.FR.03 | :no_entry_sign: |  |
 | K01.FR.04 | :white_check_mark: |  |
 | K01.FR.05 |  |  |
-| K01.FR.06 |  |  |
+| K01.FR.06 | :white_check_mark: |  |
 | K01.FR.07 |  |  |
 | K01.FR.08 | :no_entry_sign: |  |
 | K01.FR.09 |  |  |

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <future>
+#include <memory>
 #include <set>
 
 #include <ocpp/common/charging_station_base.hpp>
@@ -393,7 +394,7 @@ private:
 
     // utility
     std::unique_ptr<MessageQueue<v201::MessageType>> message_queue;
-    std::unique_ptr<DeviceModel> device_model;
+    std::shared_ptr<DeviceModel> device_model;
     std::shared_ptr<DatabaseHandler> database_handler;
 
     std::map<int32_t, AvailabilityChange> scheduled_change_availability_requests;

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -71,7 +71,7 @@ public:
     /// according to the specification
     ///
     ProfileValidationResultEnum validate_charging_station_max_profile(const ChargingProfile& profile,
-                                                                      EvseInterface& evse) const;
+                                                                      int32_t evse_id) const;
 
     ///
     /// \brief validates the given \p profile and associated \p evse_id according to the specification

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -36,6 +36,7 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodInvalidPhaseToUse,
     ChargingSchedulePeriodUnsupportedNumberPhases,
     ChargingSchedulePeriodExtraneousPhaseValues,
+    ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported,
     ChargingStationMaxProfileCannotBeRelative,
     ChargingStationMaxProfileEvseIdGreaterThanZero,
     DuplicateTxDefaultProfileFound,

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -62,6 +62,11 @@ public:
     explicit SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses);
 
     ///
+    /// \brief validates the given \p profile according to the specification
+    ///
+    ProfileValidationResultEnum validate_profile(ChargingProfile& profile, int32_t evse_id);
+
+    ///
     /// \brief validates the existence of the given \p evse_id according to the specification
     ///
     ProfileValidationResultEnum validate_evse_exists(int32_t evse_id) const;

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -62,7 +62,9 @@ public:
     explicit SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses);
 
     ///
-    /// \brief validates the given \p profile according to the specification
+    /// \brief validates the given \p profile according to the specification.
+    /// If a profile does not have validFrom or validTo set, we conform the values
+    /// to a representation that fits the spec.
     ///
     ProfileValidationResultEnum validate_profile(ChargingProfile& profile, int32_t evse_id);
 
@@ -103,7 +105,7 @@ public:
     /// \brief Checks a given \p profile and associated \p evse_id validFrom and validTo range
     /// This method assumes that the existing profile will have dates set for validFrom and validTo
     ///
-    bool is_overlapping_validity_period(int evse_id, ChargingProfile& profile) const;
+    bool is_overlapping_validity_period(int evse_id, const ChargingProfile& profile) const;
 
 private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -8,6 +8,7 @@
 #include "ocpp/v201/enums.hpp"
 #include <limits>
 
+#include <memory>
 #include <ocpp/v201/database_handler.hpp>
 #include <ocpp/v201/evse.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
@@ -54,7 +55,7 @@ std::ostream& operator<<(std::ostream& os, const ProfileValidationResultEnum val
 class SmartChargingHandler {
 private:
     std::map<int32_t, std::unique_ptr<EvseInterface>>& evses;
-    std::unique_ptr<DeviceModel>& device_model;
+    std::shared_ptr<DeviceModel>& device_model;
 
     std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler;
     // cppcheck-suppress unusedStructMember
@@ -63,7 +64,7 @@ private:
 
 public:
     explicit SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
-                                  std::unique_ptr<DeviceModel>& device_model);
+                                  std::shared_ptr<DeviceModel>& device_model);
 
     ///
     /// \brief validates the given \p profile according to the specification.

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -73,6 +73,12 @@ public:
     ProfileValidationResultEnum validate_profile(ChargingProfile& profile, int32_t evse_id);
 
     ///
+    /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles
+    ///
+    void add_profile(int32_t evse_id, ChargingProfile& profile);
+
+protected:
+    ///
     /// \brief validates the existence of the given \p evse_id according to the specification
     ///
     ProfileValidationResultEnum validate_evse_exists(int32_t evse_id) const;
@@ -99,11 +105,6 @@ public:
     /// we set it to the default value (3).
     ProfileValidationResultEnum validate_profile_schedules(ChargingProfile& profile,
                                                            std::optional<EvseInterface*> evse_opt = std::nullopt) const;
-
-    ///
-    /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles
-    ///
-    void add_profile(int32_t evse_id, ChargingProfile& profile);
 
     ///
     /// \brief Checks a given \p profile and associated \p evse_id validFrom and validTo range

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -19,6 +19,7 @@ const int DEFAULT_AND_MAX_NUMBER_PHASES = 3;
 enum class ProfileValidationResultEnum {
     Valid,
     EvseDoesNotExist,
+    InvalidProfileType,
     TxProfileMissingTransactionId,
     TxProfileEvseIdNotGreaterThanZero,
     TxProfileTransactionNotOnEvse,
@@ -32,6 +33,8 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodInvalidPhaseToUse,
     ChargingSchedulePeriodUnsupportedNumberPhases,
     ChargingSchedulePeriodExtraneousPhaseValues,
+    ChargingStationMaxProfileCannotBeRelative,
+    ChargingStationMaxProfileEvseIdGreaterThanZero,
     DuplicateTxDefaultProfileFound,
     DuplicateProfileValidityPeriod
 };
@@ -62,6 +65,13 @@ public:
     /// \brief validates the existence of the given \p evse_id according to the specification
     ///
     ProfileValidationResultEnum validate_evse_exists(int32_t evse_id) const;
+
+    ///
+    /// \brief validates requirements that apply only to the ChargingStationMaxProfile \p profile
+    /// according to the specification
+    ///
+    ProfileValidationResultEnum validate_charging_station_max_profile(const ChargingProfile& profile,
+                                                                      EvseInterface& evse) const;
 
     ///
     /// \brief validates the given \p profile and associated \p evse_id according to the specification

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -81,7 +81,7 @@ public:
     ///
     /// \brief validates the given \p profile according to the specification
     ///
-    ProfileValidationResultEnum validate_tx_profile(const ChargingProfile& profile, EvseInterface& evse) const;
+    ProfileValidationResultEnum validate_tx_profile(const ChargingProfile& profile, int32_t evse_id) const;
 
     /// \brief validates that the given \p profile has valid charging schedules.
     /// If a profiles charging schedule period does not have a valid numberPhases,

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -4,6 +4,7 @@
 #ifndef OCPP_V201_SMART_CHARGING_HPP
 #define OCPP_V201_SMART_CHARGING_HPP
 
+#include "ocpp/v201/device_model.hpp"
 #include "ocpp/v201/enums.hpp"
 #include <limits>
 
@@ -52,6 +53,7 @@ std::ostream& operator<<(std::ostream& os, const ProfileValidationResultEnum val
 class SmartChargingHandler {
 private:
     std::map<int32_t, std::unique_ptr<EvseInterface>>& evses;
+    std::unique_ptr<DeviceModel>& device_model;
 
     std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler;
     // cppcheck-suppress unusedStructMember
@@ -59,7 +61,8 @@ private:
     std::vector<ChargingProfile> station_wide_charging_profiles;
 
 public:
-    explicit SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses);
+    explicit SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
+                                  std::unique_ptr<DeviceModel>& device_model);
 
     ///
     /// \brief validates the given \p profile according to the specification.
@@ -111,6 +114,7 @@ private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;
     std::vector<ChargingProfile> get_station_wide_tx_default_profiles() const;
     void conform_validity_periods(ChargingProfile& profile) const;
+    CurrentPhaseType get_current_phase_type(const std::optional<EvseInterface*> evse_opt) const;
 };
 
 } // namespace ocpp::v201

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -32,7 +32,8 @@ enum class ProfileValidationResultEnum {
     ChargingSchedulePeriodInvalidPhaseToUse,
     ChargingSchedulePeriodUnsupportedNumberPhases,
     ChargingSchedulePeriodExtraneousPhaseValues,
-    DuplicateTxDefaultProfileFound
+    DuplicateTxDefaultProfileFound,
+    DuplicateProfileValidityPeriod
 };
 
 namespace conversions {
@@ -65,7 +66,7 @@ public:
     ///
     /// \brief validates the given \p profile and associated \p evse_id according to the specification
     ///
-    ProfileValidationResultEnum validate_tx_default_profile(const ChargingProfile& profile, int32_t evse_id) const;
+    ProfileValidationResultEnum validate_tx_default_profile(ChargingProfile& profile, int32_t evse_id) const;
 
     ///
     /// \brief validates the given \p profile according to the specification
@@ -83,9 +84,16 @@ public:
     ///
     void add_profile(int32_t evse_id, ChargingProfile& profile);
 
+    ///
+    /// \brief Checks a given \p profile and associated \p evse_id validFrom and validTo range
+    /// This method assumes that the existing profile will have dates set for validFrom and validTo
+    ///
+    bool is_overlapping_validity_period(int evse_id, ChargingProfile& profile) const;
+
 private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;
     std::vector<ChargingProfile> get_station_wide_tx_default_profiles() const;
+    void conform_validity_periods(ChargingProfile& profile) const;
 };
 
 } // namespace ocpp::v201

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -30,6 +30,7 @@ enum class ProfileValidationResultEnum {
     ChargingProfileFirstStartScheduleIsNotZero,
     ChargingProfileMissingRequiredStartSchedule,
     ChargingProfileExtraneousStartSchedule,
+    ChargingScheduleChargingRateUnitUnsupported,
     ChargingSchedulePeriodsOutOfOrder,
     ChargingSchedulePeriodInvalidPhaseToUse,
     ChargingSchedulePeriodUnsupportedNumberPhases,

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -80,7 +80,7 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
         EVLOG_AND_THROW(std::invalid_argument("All non-optional callbacks must be supplied"));
     }
 
-    this->device_model = std::make_unique<DeviceModel>(std::move(device_model_storage));
+    this->device_model = std::make_shared<DeviceModel>(std::move(device_model_storage));
     this->device_model->check_integrity(evse_connector_structure);
 
     auto database_connection = std::make_unique<common::DatabaseConnection>(fs::path(core_database_path) / "cp.db");

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -57,6 +57,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingSchedulePeriodUnsupportedNumberPhases";
     case ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues:
         return "ChargingSchedulePeriodExtraneousPhaseValues";
+    case ProfileValidationResultEnum::ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported:
+        return "ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported";
     case ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative:
         return "ChargingStationMaxProfileCannotBeRelative";
     case ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero:
@@ -228,7 +230,6 @@ ProfileValidationResultEnum SmartChargingHandler::validate_tx_profile(const Char
 }
 
 /* TODO: Implement the following functional requirements:
- * - K01.FR.20
  * - K01.FR.34
  * - K01.FR.43
  * - K01.FR.48
@@ -257,6 +258,13 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
             // K01.FR.19
             if (charging_schedule_period.numberPhases != 1 && charging_schedule_period.phaseToUse.has_value()) {
                 return ProfileValidationResultEnum::ChargingSchedulePeriodInvalidPhaseToUse;
+            }
+
+            // K01.FR.20
+            if (charging_schedule_period.phaseToUse.has_value() &&
+                !device_model->get_optional_value<bool>(ControllerComponentVariables::ACPhaseSwitchingSupported)
+                     .value_or(false)) {
+                return ProfileValidationResultEnum::ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported;
             }
 
             // K01.FR.31

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -24,6 +24,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "Valid";
     case ProfileValidationResultEnum::EvseDoesNotExist:
         return "EvseDoesNotExist";
+    case ProfileValidationResultEnum::InvalidProfileType:
+        return "InvalidProfileType";
     case ProfileValidationResultEnum::TxProfileMissingTransactionId:
         return "TxProfileMissingTransactionId";
     case ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero:
@@ -50,6 +52,10 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingSchedulePeriodUnsupportedNumberPhases";
     case ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues:
         return "ChargingSchedulePeriodExtraneousPhaseValues";
+    case ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative:
+        return "ChargingStationMaxProfileCannotBeRelative";
+    case ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero:
+        return "ChargingStationMaxProfileEvseIdGreaterThanZero";
     case ProfileValidationResultEnum::DuplicateTxDefaultProfileFound:
         return "DuplicateTxDefaultProfileFound";
     }

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -74,13 +74,12 @@ ProfileValidationResultEnum SmartChargingHandler::validate_evse_exists(int32_t e
 }
 
 ProfileValidationResultEnum SmartChargingHandler::validate_charging_station_max_profile(const ChargingProfile& profile,
-                                                                                        EvseInterface& evse) const {
+                                                                                        int32_t evse_id) const {
     if (profile.chargingProfilePurpose != ChargingProfilePurposeEnum::ChargingStationMaxProfile) {
         return ProfileValidationResultEnum::InvalidProfileType;
     }
 
-    int32_t evseId = evse.get_evse_info().id;
-    if (evseId > 0) {
+    if (evse_id > 0) {
         return ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero;
     }
 

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -73,6 +73,24 @@ ProfileValidationResultEnum SmartChargingHandler::validate_evse_exists(int32_t e
                                               : ProfileValidationResultEnum::Valid;
 }
 
+ProfileValidationResultEnum SmartChargingHandler::validate_charging_station_max_profile(const ChargingProfile& profile,
+                                                                                        EvseInterface& evse) const {
+    if (profile.chargingProfilePurpose != ChargingProfilePurposeEnum::ChargingStationMaxProfile) {
+        return ProfileValidationResultEnum::InvalidProfileType;
+    }
+
+    int32_t evseId = evse.get_evse_info().id;
+    if (evseId > 0) {
+        return ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero;
+    }
+
+    if (profile.chargingProfileKind == ChargingProfileKindEnum::Relative) {
+        return ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative;
+    }
+
+    return ProfileValidationResultEnum::Valid;
+}
+
 ProfileValidationResultEnum SmartChargingHandler::validate_tx_default_profile(ChargingProfile& profile,
                                                                               int32_t evse_id) const {
     auto profiles = evse_id == 0 ? get_evse_specific_tx_default_profiles() : get_station_wide_tx_default_profiles();

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -95,7 +95,7 @@ CurrentPhaseType SmartChargingHandler::get_current_phase_type(const std::optiona
 }
 
 SmartChargingHandler::SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
-                                           std::unique_ptr<DeviceModel>& device_model) :
+                                           std::shared_ptr<DeviceModel>& device_model) :
     evses(evses), device_model(device_model) {
 }
 

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -370,10 +370,8 @@ bool SmartChargingHandler::is_overlapping_validity_period(int candidate_evse_id,
 }
 
 void SmartChargingHandler::conform_validity_periods(ChargingProfile& profile) const {
-    profile.validFrom =
-        profile.validFrom.has_value() ? profile.validFrom.value() : ocpp::DateTime(date::utc_clock::now());
-    profile.validTo =
-        profile.validTo.has_value() ? profile.validTo.value() : ocpp::DateTime(date::utc_clock::time_point::max());
+    profile.validFrom = profile.validFrom.value_or(ocpp::DateTime());
+    profile.validTo = profile.validTo.value_or(ocpp::DateTime(date::utc_clock::time_point::max()));
 }
 
 } // namespace ocpp::v201

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -58,6 +58,8 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "ChargingStationMaxProfileEvseIdGreaterThanZero";
     case ProfileValidationResultEnum::DuplicateTxDefaultProfileFound:
         return "DuplicateTxDefaultProfileFound";
+    case ProfileValidationResultEnum::DuplicateProfileValidityPeriod:
+        return "DuplicateProfileValidityPeriod";
     }
 
     throw std::out_of_range("No known string conversion for provided enum of type ProfileValidationResultEnum");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(MIGRATION_FILES_LOCATION_V16 "${CMAKE_CURRENT_BINARY_DIR}/resources/v16/migration_files")
 set(MIGRATION_FILES_LOCATION_V201 "${CMAKE_CURRENT_BINARY_DIR}/resources/v201/migration_files")
+set(DEVICE_MODEL_DB_LOCATION_V201 "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/everest/modules/OCPP201/device_model_storage.db")
 
 add_executable(database_tests database_tests.cpp)
 
@@ -31,6 +32,7 @@ target_compile_definitions(libocpp_unit_tests
     MIGRATION_FILES_LOCATION_V201="${MIGRATION_FILES_LOCATION_V201}"
     MIGRATION_FILE_VERSION_V16=${MIGRATION_FILE_VERSION_V16}
     MIGRATION_FILE_VERSION_V201=${MIGRATION_FILE_VERSION_V201}
+    DEVICE_MODEL_DB_LOCATION_V201="${DEVICE_MODEL_DB_LOCATION_V201}"
 )
 
 add_custom_command(TARGET libocpp_unit_tests POST_BUILD

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -622,12 +622,14 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileLastForever_RejectInc
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime(date::utc_clock::time_point::min()),
                             ocpp::DateTime(date::utc_clock::time_point::max()));
 
+    auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A), uuid(), ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL,
-        ocpp::DateTime("2024-01-02T13:00:00"), ocpp::DateTime("2024-03-01T13:00:00"));
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-02T13:00:00"),
+        ocpp::DateTime("2024-03-01T13:00:00"));
 
-    auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -636,12 +638,13 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidFromIncomingV
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime("2024-01-01T13:00:00"),
                             ocpp::DateTime(date::utc_clock::time_point::max()));
 
-    auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
-                                           ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {},
-                                           ocpp::DateTime("2024-01-01T13:00:00"));
+    auto periods = create_charging_schedule_periods(0);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {}, ocpp::DateTime("2024-01-01T13:00:00"));
 
-    auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -650,12 +653,13 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidToIncomingVal
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime("2024-02-01T13:00:00"),
                             ocpp::DateTime(date::utc_clock::time_point::max()));
 
-    auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
-                                           ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL,
-                                           ocpp::DateTime("2024-01-31T13:00:00"), {});
+    auto periods = create_charging_schedule_periods(0);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-31T13:00:00"), {});
 
-    auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -665,11 +669,13 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomin
                             ocpp::DateTime(date::utc_clock::now() - std::chrono::hours(5 * 24)),
                             ocpp::DateTime(date::utc_clock::now() + std::chrono::hours(5 * 24)));
 
-    auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
-                                           ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {}, {});
+    auto periods = create_charging_schedule_periods(0);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {}, {});
 
-    auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -678,12 +684,14 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomin
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime("2024-01-01T13:00:00"),
                             ocpp::DateTime("2024-02-01T13:00:00"));
 
+    auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, {}, {}), uuid(), ChargingProfileKindEnum::Absolute,
-        DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-15T13:00:00"), ocpp::DateTime("2024-02-01T13:00:00"));
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-15T13:00:00"),
+        ocpp::DateTime("2024-02-01T13:00:00"));
 
-    auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -301,7 +301,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChar
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid());
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::InvalidProfileType));
 }
@@ -316,7 +316,7 @@ TEST_F(ChargepointTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_Evs
         create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                 create_charge_schedule(ChargingRateUnitEnum::A, periods), same_transaction_id);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[EVSE_ID_1]);
+    auto sut = handler.validate_charging_station_max_profile(profile, EVSE_ID_1);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero));
 }
@@ -328,7 +328,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -341,7 +341,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
                                            create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
                                            ChargingProfileKindEnum::Recurring);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -354,7 +354,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
                                            create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
                                            ChargingProfileKindEnum::Relative);
 
-    auto sut = handler.validate_charging_station_max_profile(profile, *evses[STATION_WIDE_ID]);
+    auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative));
 }

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -44,7 +44,7 @@ public:
     using SmartChargingHandler::validate_tx_profile;
 
     TestSmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
-                             std::unique_ptr<DeviceModel>& device_model) :
+                             std::shared_ptr<DeviceModel>& device_model) :
         SmartChargingHandler(evses, device_model) {
     }
 };
@@ -184,11 +184,11 @@ protected:
         sqlite3_close(source_handle);
     }
 
-    std::unique_ptr<DeviceModel> create_device_model() {
+    std::shared_ptr<DeviceModel> create_device_model() {
         create_device_model_db();
         auto device_model_storage =
             std::make_unique<DeviceModelStorageSqlite>("file:device_model?mode=memory&cache=shared");
-        auto device_model = std::make_unique<DeviceModel>(std::move(device_model_storage));
+        auto device_model = std::make_shared<DeviceModel>(std::move(device_model_storage));
 
         // Defaults
         const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;
@@ -249,7 +249,7 @@ protected:
     sqlite3* db_handle;
 
     bool ignore_no_transaction = true;
-    std::unique_ptr<DeviceModel> device_model = create_device_model();
+    std::shared_ptr<DeviceModel> device_model = create_device_model();
     TestSmartChargingHandler handler = create_smart_charging_handler();
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
 };

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -249,67 +249,6 @@ TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
 }
 
-TEST_F(ChargepointTestFixtureV201,
-       K01FR06_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
-    create_evse_with_id(DEFAULT_EVSE_ID);
-    std::string transaction_id = uuid();
-    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
-
-    auto same_stack_level = 42;
-    auto profile_1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), transaction_id,
-                                             ChargingProfileKindEnum::Absolute, same_stack_level);
-    auto profile_2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), transaction_id,
-                                             ChargingProfileKindEnum::Absolute, same_stack_level);
-    handler.add_profile(DEFAULT_EVSE_ID, profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
-
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
-}
-
-TEST_F(ChargepointTestFixtureV201,
-       K01FR06_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
-    create_evse_with_id(DEFAULT_EVSE_ID);
-    std::string transaction_id = uuid();
-    std::string different_transaction_id = uuid();
-    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
-
-    auto same_stack_level = 42;
-    auto profile_1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), transaction_id,
-                                             ChargingProfileKindEnum::Absolute, same_stack_level);
-    auto profile_2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id,
-                                             ChargingProfileKindEnum::Absolute, same_stack_level);
-    handler.add_profile(DEFAULT_EVSE_ID, profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
-
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
-}
-
-TEST_F(ChargepointTestFixtureV201,
-       K01FR06_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
-    create_evse_with_id(DEFAULT_EVSE_ID);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(DEFAULT_EVSE_ID, same_transaction_id);
-
-    auto stack_level_1 = 42;
-    auto stack_level_2 = 43;
-
-    auto profile_1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
-                                             ChargingProfileKindEnum::Absolute, stack_level_1);
-    auto profile_2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
-                                             ChargingProfileKindEnum::Absolute, stack_level_2);
-
-    handler.add_profile(DEFAULT_EVSE_ID, profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
-
-    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
-}
-
 TEST_F(ChargepointTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 0, 1);
     auto profile = create_charging_profile(
@@ -349,6 +288,59 @@ TEST_F(ChargepointTestFixtureV201, K01FR35_IfChargingSchedulePeriodsAreNotInChon
     auto sut = handler.validate_profile_schedules(profile);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodsOutOfOrder));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR39_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
+    create_evse_with_id(evse_id);
+    std::string transaction_id = uuid();
+    open_evse_transaction(evse_id, transaction_id);
+
+    auto same_stack_level = 42;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR39_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
+    create_evse_with_id(evse_id);
+    std::string transaction_id = uuid();
+    std::string different_transaction_id = uuid();
+    open_evse_transaction(evse_id, transaction_id);
+
+    auto same_stack_level = 42;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), transaction_id, same_stack_level);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id, same_stack_level);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201,
+       K01FR39_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
+    create_evse_with_id(evse_id);
+    std::string same_transaction_id = uuid();
+    open_evse_transaction(evse_id, same_transaction_id);
+
+    auto stack_level_1 = 42;
+    auto stack_level_2 = 43;
+    auto profile_1 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_1);
+    auto profile_2 =
+        create_tx_profile(create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id, stack_level_2);
+    handler.add_profile(profile_2);
+    auto sut = handler.validate_tx_profile(profile_1, *evses[evse_id]);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
 TEST_F(ChargepointTestFixtureV201,

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -4,6 +4,7 @@
 #include "date/tz.h"
 #include "ocpp/common/types.hpp"
 #include "ocpp/v201/ctrlr_component_variables.hpp"
+#include "ocpp/v201/device_model.hpp"
 #include "ocpp/v201/device_model_storage_sqlite.hpp"
 #include "ocpp/v201/ocpp_types.hpp"
 #include <boost/uuid/uuid_generators.hpp>
@@ -33,6 +34,20 @@ static const int STATION_WIDE_ID = 0;
 static const int DEFAULT_EVSE_ID = 1;
 static const int DEFAULT_PROFILE_ID = 1;
 static const int DEFAULT_STACK_LEVEL = 1;
+
+class TestSmartChargingHandler : public SmartChargingHandler {
+public:
+    using SmartChargingHandler::validate_charging_station_max_profile;
+    using SmartChargingHandler::validate_evse_exists;
+    using SmartChargingHandler::validate_profile_schedules;
+    using SmartChargingHandler::validate_tx_default_profile;
+    using SmartChargingHandler::validate_tx_profile;
+
+    TestSmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
+                             std::unique_ptr<DeviceModel>& device_model) :
+        SmartChargingHandler(evses, device_model) {
+    }
+};
 
 class ChargepointTestFixtureV201 : public testing::Test {
 protected:
@@ -194,8 +209,8 @@ protected:
         evses[id] = std::move(e1);
     }
 
-    SmartChargingHandler create_smart_charging_handler() {
-        return SmartChargingHandler(evses, device_model);
+    TestSmartChargingHandler create_smart_charging_handler() {
+        return TestSmartChargingHandler(evses, device_model);
     }
 
     std::string uuid() {
@@ -235,7 +250,7 @@ protected:
 
     bool ignore_no_transaction = true;
     std::unique_ptr<DeviceModel> device_model = create_device_model();
-    SmartChargingHandler handler = create_smart_charging_handler();
+    TestSmartChargingHandler handler = create_smart_charging_handler();
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
 };
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -328,6 +328,18 @@ TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSup
                 testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported));
 }
 
+TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedTrue_ThenProfileIsNotInvalid) {
+    auto periods = create_charging_schedule_periods_with_phases(0, 1, 1);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
+        ChargingProfileKindEnum::Absolute, 1);
+
+    auto sut = handler.validate_profile_schedules(profile);
+
+    EXPECT_THAT(sut, testing::Not(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
+}
+
 TEST_F(ChargepointTestFixtureV201,
        K01FR26_IfChargingRateUnitIsNotInChargingScheduleChargingRateUnits_ThenProfileIsInvalid) {
     const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -880,4 +880,44 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsInvalid_Then
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
 }
 
+TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsValid_ThenProfileIsValid) {
+    auto transaction_id = uuid();
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    create_evse_with_id(DEFAULT_EVSE_ID);
+    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")),
+        transaction_id);
+    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxDefaultProfileIsValid_ThenProfileIsValid) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    create_evse_with_id(DEFAULT_EVSE_ID);
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfileIsValid_ThenProfileIsValid) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+
+    auto sut = handler.validate_profile(profile, STATION_WIDE_ID);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -495,6 +495,65 @@ TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToDiffe
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
+TEST_F(ChargepointTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCEVSE_ThenProfileIsInvalid) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::DC));
+
+    auto periods = create_charging_schedule_periods(0, 1);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+
+    auto sut = handler.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCEVSE_ThenProfileIsInvalid) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::DC));
+
+    auto periods = create_charging_schedule_periods(0, 1, 1);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+
+    auto sut = handler.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR45_IfNumberPhasesGreaterThanMaxNumberPhasesForACEVSE_ThenProfileIsInvalid) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::AC));
+
+    auto periods = create_charging_schedule_periods(0, 4);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+
+    auto sut = handler.validate_profile_schedules(profile, &mock_evse);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedNumberPhases));
+}
+
+TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACEVSE_ThenSetNumberPhasesToThree) {
+    auto mock_evse = testing::NiceMock<EvseMock>();
+    ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::AC));
+
+    auto periods = create_charging_schedule_periods(0);
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+
+    auto sut = handler.validate_profile_schedules(profile, &mock_evse);
+
+    auto numberPhases = profile.chargingSchedule[0].chargingSchedulePeriod[0].numberPhases;
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+    EXPECT_THAT(numberPhases, testing::Eq(3));
+}
+
 TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileLastForever_RejectIncoming) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime(date::utc_clock::time_point::min()),
                             ocpp::DateTime(date::utc_clock::time_point::max()));

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -34,6 +34,7 @@ static const int STATION_WIDE_ID = 0;
 static const int DEFAULT_EVSE_ID = 1;
 static const int DEFAULT_PROFILE_ID = 1;
 static const int DEFAULT_STACK_LEVEL = 1;
+static const std::string DEFAULT_TX_ID = "10c75ff7-74f5-44f5-9d01-f649f3ac7b78";
 
 class TestSmartChargingHandler : public SmartChargingHandler {
 public:
@@ -134,7 +135,7 @@ protected:
 
     ChargingProfile
     create_charging_profile(int32_t charging_profile_id, ChargingProfilePurposeEnum charging_profile_purpose,
-                            ChargingSchedule charging_schedule, std::string transaction_id,
+                            ChargingSchedule charging_schedule, std::optional<std::string> transaction_id = {},
                             ChargingProfileKindEnum charging_profile_kind = ChargingProfileKindEnum::Absolute,
                             int stack_level = DEFAULT_STACK_LEVEL, std::optional<ocpp::DateTime> validFrom = {},
                             std::optional<ocpp::DateTime> validTo = {}) {
@@ -150,26 +151,6 @@ protected:
                                .validFrom = validFrom,
                                .validTo = validTo,
                                .transactionId = transaction_id};
-    }
-
-    ChargingProfile create_tx_profile_with_missing_transaction_id(ChargingSchedule charging_schedule) {
-        auto charging_profile_id = DEFAULT_PROFILE_ID;
-        auto stack_level = DEFAULT_STACK_LEVEL;
-        auto charging_profile_purpose = ChargingProfilePurposeEnum::TxProfile;
-        auto charging_profile_kind = ChargingProfileKindEnum::Absolute;
-        auto recurrency_kind = RecurrencyKindEnum::Daily;
-        std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
-        return ChargingProfile{
-            charging_profile_id,
-            stack_level,
-            charging_profile_purpose,
-            charging_profile_kind,
-            charging_schedules,
-            {}, // transactionId
-            recurrency_kind,
-            {}, // validFrom
-            {}  // validTo
-        };
     }
 
     void create_device_model_db(const std::string& path) {
@@ -243,7 +224,7 @@ protected:
         }
         auto existing_profile = create_charging_profile(
             profile_id, ChargingProfilePurposeEnum::TxDefaultProfile, create_charge_schedule(ChargingRateUnitEnum::A),
-            uuid(), ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, validFrom, validTo);
+            {}, ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, validFrom, validTo);
         handler.add_profile(evse_id, existing_profile);
     }
 
@@ -261,7 +242,8 @@ protected:
 
 TEST_F(ChargepointTestFixtureV201, K01FR03_IfTxProfileIsMissingTransactionId_ThenProfileIsInvalid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
-    auto profile = create_tx_profile_with_missing_transaction_id(create_charge_schedule(ChargingRateUnitEnum::A));
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {});
     auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
@@ -271,7 +253,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR16_IfTxProfileHasEvseIdNotGreaterThanZer
     auto wrong_evse_id = STATION_WIDE_ID;
     create_evse_with_id(wrong_evse_id);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
     auto sut = handler.validate_tx_profile(profile, wrong_evse_id);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero));
@@ -281,7 +263,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR33_IfTxProfileTransactionIsNotOnEvse_The
     create_evse_with_id(DEFAULT_EVSE_ID);
     open_evse_transaction(DEFAULT_EVSE_ID, "wrong transaction id");
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
     auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileTransactionNotOnEvse));
@@ -294,7 +276,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction
     auto date_time = ocpp::DateTime("2024-01-17T17:00:00");
     create_evse_with_id(DEFAULT_EVSE_ID);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
     auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
@@ -304,7 +286,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPhaseToUseSe
     auto periods = create_charging_schedule_periods_with_phases(0, 0, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
         ChargingProfileKindEnum::Absolute, 1);
 
     auto sut = handler.validate_profile_schedules(profile);
@@ -320,7 +302,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSup
     auto periods = create_charging_schedule_periods_with_phases(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
         ChargingProfileKindEnum::Absolute, 1);
 
     auto sut = handler.validate_profile_schedules(profile);
@@ -337,7 +319,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSup
     auto periods = create_charging_schedule_periods_with_phases(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
         ChargingProfileKindEnum::Absolute, 1);
 
     auto sut = handler.validate_profile_schedules(profile);
@@ -355,7 +337,7 @@ TEST_F(ChargepointTestFixtureV201,
     auto periods = create_charging_schedule_periods(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
         ChargingProfileKindEnum::Absolute, 1);
 
     auto sut = handler.validate_profile_schedules(profile);
@@ -365,7 +347,7 @@ TEST_F(ChargepointTestFixtureV201,
 
 TEST_F(ChargepointTestFixtureV201, K01_IfChargingSchedulePeriodsAreMissing_ThenProfileIsInvalid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile);
 
@@ -375,7 +357,7 @@ TEST_F(ChargepointTestFixtureV201, K01_IfChargingSchedulePeriodsAreMissing_ThenP
 TEST_F(ChargepointTestFixtureV201, K01FR31_IfStartPeriodOfFirstChargingSchedulePeriodIsNotZero_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(1);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile);
 
@@ -385,7 +367,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR31_IfStartPeriodOfFirstChargingScheduleP
 TEST_F(ChargepointTestFixtureV201, K01FR35_IfChargingSchedulePeriodsAreNotInChonologicalOrder_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods({0, 2, 1});
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile);
 
@@ -396,7 +378,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChar
     create_evse_with_id(STATION_WIDE_ID);
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A));
 
     auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
@@ -405,13 +387,9 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChar
 
 TEST_F(ChargepointTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_EvseIDgt0_Invalid) {
     const int EVSE_ID_1 = DEFAULT_EVSE_ID;
-    create_evse_with_id(EVSE_ID_1);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(EVSE_ID_1, same_transaction_id);
     auto periods = create_charging_schedule_periods({0, 1, 2});
-    auto profile =
-        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
-                                create_charge_schedule(ChargingRateUnitEnum::A, periods), same_transaction_id);
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A, periods));
 
     auto sut = handler.validate_charging_station_max_profile(profile, EVSE_ID_1);
 
@@ -419,11 +397,8 @@ TEST_F(ChargepointTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_Evs
 }
 
 TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsAbsolute_Valid) {
-    create_evse_with_id(STATION_WIDE_ID);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(STATION_WIDE_ID, same_transaction_id);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id);
+                                           create_charge_schedule(ChargingRateUnitEnum::A));
 
     auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
@@ -431,11 +406,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
 }
 
 TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRecurring_Valid) {
-    create_evse_with_id(STATION_WIDE_ID);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(STATION_WIDE_ID, same_transaction_id);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {},
                                            ChargingProfileKindEnum::Recurring);
 
     auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
@@ -444,12 +416,9 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
 }
 
 TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRelative_Invalid) {
-    create_evse_with_id(STATION_WIDE_ID);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(STATION_WIDE_ID, same_transaction_id);
-    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
-                                           ChargingProfileKindEnum::Relative);
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A), {}, ChargingProfileKindEnum::Relative);
 
     auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
 
@@ -459,15 +428,14 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
 TEST_F(ChargepointTestFixtureV201,
        K01FR39_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
-    std::string transaction_id = uuid();
-    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
+    open_evse_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
 
     auto same_stack_level = 42;
     auto profile_1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), transaction_id,
+                                             create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID,
                                              ChargingProfileKindEnum::Absolute, same_stack_level);
     auto profile_2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), transaction_id,
+                                             create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID,
                                              ChargingProfileKindEnum::Absolute, same_stack_level);
     handler.add_profile(DEFAULT_EVSE_ID, profile_2);
     auto sut = handler.validate_tx_profile(profile_1, DEFAULT_EVSE_ID);
@@ -478,13 +446,12 @@ TEST_F(ChargepointTestFixtureV201,
 TEST_F(ChargepointTestFixtureV201,
        K01FR39_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
-    std::string transaction_id = uuid();
     std::string different_transaction_id = uuid();
-    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
+    open_evse_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
 
     auto same_stack_level = 42;
     auto profile_1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), transaction_id,
+                                             create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID,
                                              ChargingProfileKindEnum::Absolute, same_stack_level);
     auto profile_2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
                                              create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id,
@@ -498,17 +465,16 @@ TEST_F(ChargepointTestFixtureV201,
 TEST_F(ChargepointTestFixtureV201,
        K01FR39_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(DEFAULT_EVSE_ID, same_transaction_id);
+    open_evse_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
 
     auto stack_level_1 = 42;
     auto stack_level_2 = 43;
 
     auto profile_1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
+                                             create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID,
                                              ChargingProfileKindEnum::Absolute, stack_level_1);
     auto profile_2 = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
-                                             create_charge_schedule(ChargingRateUnitEnum::A), same_transaction_id,
+                                             create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID,
                                              ChargingProfileKindEnum::Absolute, stack_level_2);
 
     handler.add_profile(DEFAULT_EVSE_ID, profile_2);
@@ -521,7 +487,7 @@ TEST_F(ChargepointTestFixtureV201,
        K01FR40_IfChargingProfileKindIsAbsoluteAndStartScheduleDoesNotExist_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), DEFAULT_TX_ID,
                                            ChargingProfileKindEnum::Absolute, 1);
 
     auto sut = handler.validate_profile_schedules(profile);
@@ -533,7 +499,7 @@ TEST_F(ChargepointTestFixtureV201,
        K01FR40_IfChargingProfileKindIsRecurringAndStartScheduleDoesNotExist_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), DEFAULT_TX_ID,
                                            ChargingProfileKindEnum::Recurring, 1);
 
     auto sut = handler.validate_profile_schedules(profile);
@@ -546,7 +512,7 @@ TEST_F(ChargepointTestFixtureV201,
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
         ChargingProfileKindEnum::Relative, 1);
 
     auto sut = handler.validate_profile_schedules(profile);
@@ -589,7 +555,7 @@ TEST_P(ChargepointTestFixtureV201_FR52, K01FR52_TxDefaultProfileValidationV201Te
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
     auto profile = create_charging_profile(added_profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {},
                                            ChargingProfileKindEnum::Absolute, added_stack_level);
     auto sut = handler.validate_tx_default_profile(profile, STATION_WIDE_ID);
 
@@ -614,7 +580,7 @@ TEST_P(ChargepointTestFixtureV201_FR53, K01FR53_TxDefaultProfileValidationV201Te
     create_evse_with_id(DEFAULT_EVSE_ID);
 
     auto profile = create_charging_profile(added_profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {},
                                            ChargingProfileKindEnum::Absolute, added_stack_level);
     auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
 
@@ -625,7 +591,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR52_TxDefaultProfileValidIfAppliedToWhole
     install_profile_on_evse(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {},
                                            ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
     auto sut = handler.validate_tx_default_profile(profile, STATION_WIDE_ID);
 
@@ -635,10 +601,10 @@ TEST_F(ChargepointTestFixtureV201, K01FR52_TxDefaultProfileValidIfAppliedToWhole
 TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToExistingEvseAgain) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
-    auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
-                                           ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL,
-                                           ocpp::DateTime("2024-02-02T17:00:00"));
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A), {}, ChargingProfileKindEnum::Absolute,
+                                DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-02-02T17:00:00"));
     auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
@@ -649,7 +615,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToDiffe
     create_evse_with_id(DEFAULT_EVSE_ID + 1);
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {},
                                            ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
     auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID + 1);
 
@@ -663,7 +629,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCEVSE_ThenP
     auto periods = create_charging_schedule_periods(0, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, &mock_evse);
 
@@ -677,7 +643,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCEVSE_ThenPro
     auto periods = create_charging_schedule_periods(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, &mock_evse);
 
@@ -692,7 +658,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCChargingSt
     auto periods = create_charging_schedule_periods(0, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, std::nullopt);
 
@@ -707,7 +673,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCChargingStat
     auto periods = create_charging_schedule_periods(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, std::nullopt);
 
@@ -721,7 +687,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR45_IfNumberPhasesGreaterThanMaxNumberPha
     auto periods = create_charging_schedule_periods(0, 4);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, &mock_evse);
 
@@ -737,7 +703,7 @@ TEST_F(ChargepointTestFixtureV201,
     auto periods = create_charging_schedule_periods(0, 4);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, std::nullopt);
 
@@ -751,7 +717,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACEVSE_ThenSe
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, &mock_evse);
 
@@ -769,7 +735,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACChargingSta
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile_schedules(profile, std::nullopt);
 
@@ -786,7 +752,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileLastForever_RejectInc
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-02T13:00:00"),
         ocpp::DateTime("2024-03-01T13:00:00"));
 
@@ -802,7 +768,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidFromIncomingV
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {}, ocpp::DateTime("2024-01-01T13:00:00"));
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
@@ -817,7 +783,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidToIncomingVal
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-31T13:00:00"), {});
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
@@ -833,7 +799,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomin
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {}, {});
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
@@ -848,7 +814,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomin
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-15T13:00:00"),
         ocpp::DateTime("2024-02-01T13:00:00"));
 
@@ -859,7 +825,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomin
 
 TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfEvseDoesNotExist_ThenProfileIsInvalid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A), uuid());
+                                           create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID + 1);
 
@@ -871,7 +837,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfScheduleIsInvalid_ThenP
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid(),
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
         ChargingProfileKindEnum::Relative, 1);
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
@@ -881,12 +847,10 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfScheduleIsInvalid_ThenP
 
 TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfileIsInvalid_ThenProfileIsInvalid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
-    std::string same_transaction_id = uuid();
-    open_evse_transaction(DEFAULT_EVSE_ID, same_transaction_id);
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
@@ -900,7 +864,7 @@ TEST_F(ChargepointTestFixtureV201,
     auto periods = create_charging_schedule_periods(0);
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), {},
                                            ChargingProfileKindEnum::Relative, DEFAULT_STACK_LEVEL);
 
     auto sut = handler.validate_profile(profile, STATION_WIDE_ID);
@@ -916,7 +880,7 @@ TEST_F(ChargepointTestFixtureV201,
     auto periods = create_charging_schedule_periods(0);
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), uuid(),
+                                           create_charge_schedule(ChargingRateUnitEnum::A, periods), {},
                                            ChargingProfileKindEnum::Relative, DEFAULT_STACK_LEVEL);
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
@@ -927,7 +891,8 @@ TEST_F(ChargepointTestFixtureV201,
 TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsInvalid_ThenProfileIsInvalid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
     auto periods = create_charging_schedule_periods(0);
-    auto profile = create_tx_profile_with_missing_transaction_id(
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
@@ -935,16 +900,14 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsInvalid_Then
 }
 
 TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsValid_ThenProfileIsValid) {
-    auto transaction_id = uuid();
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     create_evse_with_id(DEFAULT_EVSE_ID);
-    open_evse_transaction(DEFAULT_EVSE_ID, transaction_id);
+    open_evse_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
 
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")),
-        transaction_id);
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
@@ -957,7 +920,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxDefaultProfileIsValid
 
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
@@ -967,7 +930,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfile
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), uuid());
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
     auto sut = handler.validate_profile(profile, STATION_WIDE_ID);
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -833,11 +833,13 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfEvseDoesNotExist_ThenPr
 
 TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfScheduleIsInvalid_ThenProfileIsInvalid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
+
+    auto extraneous_start_schedule = ocpp::DateTime("2024-01-17T17:00:00");
     auto periods = create_charging_schedule_periods(0);
-    auto profile = create_charging_profile(
-        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID,
-        ChargingProfileKindEnum::Relative, 1);
+    auto profile =
+        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                create_charge_schedule(ChargingRateUnitEnum::A, periods, extraneous_start_schedule),
+                                DEFAULT_TX_ID, ChargingProfileKindEnum::Relative, 1);
 
     auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -744,7 +744,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACChargingSta
     EXPECT_THAT(numberPhases, testing::Eq(3));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileLastForever_RejectIncoming) {
+TEST_F(ChargepointTestFixtureV201, K01FR06_ExistingProfileLastsForever_RejectIncoming) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime(date::utc_clock::time_point::min()),
                             ocpp::DateTime(date::utc_clock::time_point::max()));
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -601,10 +601,9 @@ TEST_F(ChargepointTestFixtureV201, K01FR52_TxDefaultProfileValidIfAppliedToWhole
 TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToExistingEvseAgain) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
-    auto profile =
-        create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
-                                create_charge_schedule(ChargingRateUnitEnum::A), {}, ChargingProfileKindEnum::Absolute,
-                                DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-02-02T17:00:00"));
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {},
+                                           ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
     auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -216,7 +216,7 @@ protected:
 TEST_F(ChargepointTestFixtureV201, K01FR03_IfTxProfileIsMissingTransactionId_ThenProfileIsInvalid) {
     create_evse_with_id(DEFAULT_EVSE_ID);
     auto profile = create_tx_profile_with_missing_transaction_id(create_charge_schedule(ChargingRateUnitEnum::A));
-    auto sut = handler.validate_tx_profile(profile, *evses[DEFAULT_EVSE_ID]);
+    auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
 }
@@ -226,7 +226,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR16_IfTxProfileHasEvseIdNotGreaterThanZer
     create_evse_with_id(wrong_evse_id);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid());
-    auto sut = handler.validate_tx_profile(profile, *evses[wrong_evse_id]);
+    auto sut = handler.validate_tx_profile(profile, wrong_evse_id);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero));
 }
@@ -236,7 +236,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR33_IfTxProfileTransactionIsNotOnEvse_The
     open_evse_transaction(DEFAULT_EVSE_ID, "wrong transaction id");
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid());
-    auto sut = handler.validate_tx_profile(profile, *evses[DEFAULT_EVSE_ID]);
+    auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileTransactionNotOnEvse));
 }
@@ -249,7 +249,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction
     create_evse_with_id(DEFAULT_EVSE_ID);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), uuid());
-    auto sut = handler.validate_tx_profile(profile, *evses[DEFAULT_EVSE_ID]);
+    auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
 }
@@ -373,7 +373,7 @@ TEST_F(ChargepointTestFixtureV201,
                                              create_charge_schedule(ChargingRateUnitEnum::A), transaction_id,
                                              ChargingProfileKindEnum::Absolute, same_stack_level);
     handler.add_profile(DEFAULT_EVSE_ID, profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
+    auto sut = handler.validate_tx_profile(profile_1, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
 }
@@ -393,7 +393,7 @@ TEST_F(ChargepointTestFixtureV201,
                                              create_charge_schedule(ChargingRateUnitEnum::A), different_transaction_id,
                                              ChargingProfileKindEnum::Absolute, same_stack_level);
     handler.add_profile(DEFAULT_EVSE_ID, profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
+    auto sut = handler.validate_tx_profile(profile_1, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -415,7 +415,7 @@ TEST_F(ChargepointTestFixtureV201,
                                              ChargingProfileKindEnum::Absolute, stack_level_2);
 
     handler.add_profile(DEFAULT_EVSE_ID, profile_2);
-    auto sut = handler.validate_tx_profile(profile_1, *evses[DEFAULT_EVSE_ID]);
+    auto sut = handler.validate_tx_profile(profile_1, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -389,7 +389,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR35_IfChargingSchedulePeriodsAreNotInChon
 TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChargingStationMaxProfile_Invalid) {
     create_evse_with_id(STATION_WIDE_ID);
     auto periods = create_charging_schedule_periods({0, 1, 2});
-    auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A));
 
     auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);


### PR DESCRIPTION
## Describe your changes

This PR finishes fleshing out the profile validation work in `SmartChargingHandler`. It finalizes the implementation for a few functional requirements:

* K01.FR.06
* K01.FR.38
* K01.FR.03

With this PR, we can now call `validate_profile()` and, based on the type of the given profile, run the specific validation methods that are applicable. We also simplify the function signatures of some of the previously added methods to take the EVSE ID.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

