### PR TITLE
Use correct libevse-security hash

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -31,7 +31,7 @@ websocketpp:
   cmake_condition: "LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP"
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 6e702ef5df568c2f9929a3c3b97a09c0cb4c5b21
+  git_tag: 34ced9f4452c2ffe3145f4ff200c42dc83278c47
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
   git_tag: v4.3.3  


### PR DESCRIPTION
When #604 was merged it did not point to a git hash on the main branch but on a now deleted feature branch

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

