### PR TITLE
Stop BootNotification Timer in case of RegistrationStatus::Accepted

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1240,6 +1240,10 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
         if (this->set_system_time_callback != nullptr) {
             this->set_system_time_callback(call_result.msg.currentTime.to_rfc3339());
         }
+
+        // in case the BootNotification.req was triggered by a TriggerMessage.req the timer might still run
+        this->boot_notification_timer->stop();
+
         // we are allowed to send messages to the central system
         // activate heartbeat
         this->update_heartbeat_interval();

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -2165,6 +2165,10 @@ void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationR
         if (msg.interval > 0) {
             this->heartbeat_timer.interval([this]() { this->heartbeat_req(); }, std::chrono::seconds(msg.interval));
         }
+
+        // in case the BootNotification.req was triggered by a TriggerMessage.req the timer might still run
+        this->boot_notification_timer.stop();
+
         this->init_certificate_expiration_check_timers();
         this->update_aligned_data_interval();
         this->component_state_manager->send_status_notification_all_connectors();


### PR DESCRIPTION
## Describe your changes
This change stops the bootnotification timer when `BootNotification.conf` is `Accepted`. This is required because in case the BootNotification.req was triggered by a TriggerMessage.req the timer could still run and initiate another BootNotification.req although a previous one was already accepted.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

