### PR TITLE
OCPP1.6: Fix handling of SetChargingProfile(TxProfile)

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1957,7 +1957,7 @@ void ChargePointImpl::handleSetChargingProfileRequest(ocpp::Call<SetChargingProf
                       << call.msg.csChargingProfiles.chargingProfilePurpose;
         response.status = ChargingProfileStatus::Rejected;
     } else if (this->smart_charging_handler->validate_profile(
-                   profile, connector_id, true, this->configuration->getChargeProfileMaxStackLevel(),
+                   profile, connector_id, false, this->configuration->getChargeProfileMaxStackLevel(),
                    this->configuration->getMaxChargingProfilesInstalled(),
                    this->configuration->getChargingScheduleMaxPeriods(),
                    this->configuration->getChargingScheduleAllowedChargingRateUnitVector())) {


### PR DESCRIPTION
## Describe your changes
* Fixes issue that SetChargingProfile handler allowed TxProfile when there was no active transaction
* Fixed bug that Recurring profiles were accepted without validating profile purpose
* Added further test cases

TxProfiles without a `transactionId` are still accepted in case:
A transaction is active for this connector
OR
TxProfile is part of `RemoteStartTransaction.req` (`ignore_no_transaction` is set to true)

## Issue ticket number and link
Related discussion: https://github.com/EVerest/libocpp/pull/299

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

