### PR TITLE
Set connection_attempts to 1 from construction to prevent sometimes reporting a reconnect delay of 0ms

### DIFF
--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -13,7 +13,7 @@ WebsocketBase::WebsocketBase() :
     closed_callback(nullptr),
     message_callback(nullptr),
     reconnect_timer(nullptr),
-    connection_attempts(0),
+    connection_attempts(1),
     reconnect_backoff_ms(0),
     shutting_down(false),
     reconnecting(false) {


### PR DESCRIPTION
## Describe your changes
I notices that in somecases the `get_reconnect_interval()` function would return 0 since the `connection_attempts` was still 0 which could lead to issues in libwebsockets. The whole code assumes we start at attempt 1 so this makes sure it is set to 1 from the start.


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

