### PR TITLE
separate unavailable from inoperative

### DIFF
--- a/doc/state_chart_1_6.drawio
+++ b/doc/state_chart_1_6.drawio
@@ -1,348 +1,388 @@
-<mxfile host="65bd71144e">
-    <diagram id="enTwcsW3kJKdFbbsoOIB" name="Page-1">
-        <mxGraphModel dx="2808" dy="1103" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
-            <root>
-                <mxCell id="0"/>
-                <mxCell id="1" parent="0"/>
-                <mxCell id="120" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" target="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="1260" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="760" y="1260"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="121" value="FaultDetected" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="120">
-                    <mxGeometry x="0.5379" relative="1" as="geometry">
-                        <mxPoint x="-54" y="-10" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="187" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="100">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="380" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="380"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="188" value="UsageInitiated" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="187">
-                    <mxGeometry x="-0.669" y="2" relative="1" as="geometry">
-                        <mxPoint x="14" y="-8" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="200" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="7" target="199">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="300"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="7" value="Available" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
-                    <mxGeometry x="120" y="280" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="9" value="" style="ellipse;html=1;shape=startState;fillColor=#000000;strokeColor=#ff0000;" parent="1" vertex="1">
-                    <mxGeometry x="70" y="285" width="30" height="30" as="geometry"/>
-                </mxCell>
-                <mxCell id="10" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0.867;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="9" target="7" edge="1">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="210" y="330" as="targetPoint"/>
-                        <mxPoint x="110" y="390" as="sourcePoint"/>
-                        <Array as="points"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="133" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" target="7">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="260" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="260"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="134" value="BecomeAvailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="133">
-                    <mxGeometry x="-0.308" y="-9" relative="1" as="geometry">
-                        <mxPoint x="5" y="-19" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="189" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="104">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="860" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="860"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="190" value="TransactionStoppedAndUserActionRequired" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="189">
-                    <mxGeometry x="-0.3632" relative="1" as="geometry">
-                        <mxPoint x="-35" y="-10" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="204" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;spacingLeft=8;" edge="1" parent="1" source="101" target="203">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="540"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="101" value="Charging" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="120" y="520" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="193" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="102">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="620" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="620"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="194" value="PauseChargingEV" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="193">
-                    <mxGeometry x="-0.176" y="5" relative="1" as="geometry">
-                        <mxPoint x="2" y="-5" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="214" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="105" target="213">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="1020"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="105" value="Reserved" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="120" y="1000" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="216" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="106" target="215">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="1140"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="106" value="Unavailable" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="120" y="1120" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="217" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="300" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="300"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="232" value="I1_ReturnToAvailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="217">
-                    <mxGeometry x="0.9517" y="-6" relative="1" as="geometry">
-                        <mxPoint x="33" y="-4" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="218" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="1140" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="1140"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="220" value="I8_ReturnToUnavailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="218">
-                    <mxGeometry x="0.7671" y="-2" relative="1" as="geometry">
-                        <mxPoint x="30" y="-8" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="219" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="1020" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="1020"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="221" value="I7_ReturnToReserved" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="219">
-                    <mxGeometry x="0.8661" y="-4" relative="1" as="geometry">
-                        <mxPoint x="35" y="-6" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="222" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="900" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="900"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="223" value="I6_ReturnToFinishing" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="222">
-                    <mxGeometry x="0.8928" y="-3" relative="1" as="geometry">
-                        <mxPoint x="33" y="-7" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="224" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="780" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="780"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="225" value="I5_ReturnToSuspendedEVSE" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="224">
-                    <mxGeometry x="0.9051" y="-4" relative="1" as="geometry">
-                        <mxPoint x="10" y="-6" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="226" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="660" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="660"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="227" value="I4_ReturnToSuspendedEV" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="226">
-                    <mxGeometry x="0.935" y="-1" relative="1" as="geometry">
-                        <mxPoint x="26" y="-9" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="228" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="540" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="540"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="229" value="I3_ReturnToCharging" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="228">
-                    <mxGeometry x="0.9352" y="-7" relative="1" as="geometry">
-                        <mxPoint x="32" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="230" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="680" y="420" as="targetPoint"/>
-                        <Array as="points">
-                            <mxPoint x="800" y="420"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="231" value="I2_ReturnToPreparing" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="230">
-                    <mxGeometry x="0.9511" y="-2" relative="1" as="geometry">
-                        <mxPoint x="36" y="-8" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="107" value="Faulted" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="720" y="1280" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="185" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="101">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="500" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="500"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="186" value="StartCharging" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="185">
-                    <mxGeometry x="-0.5184" y="-1" relative="1" as="geometry">
-                        <mxPoint x="21" y="-11" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="202" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="100" target="201">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="420"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="100" value="Preparing" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="120" y="400" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="195" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="103">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="740" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="740"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="196" value="PauseChargingEVSE" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="195">
-                    <mxGeometry x="-0.0756" relative="1" as="geometry">
-                        <mxPoint x="-15" y="-10" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="206" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="102" target="205">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="660"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="102" value="SuspendedEV" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="120" y="640" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="191" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="105">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="980" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="980"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="192" value="ReserveConnector" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="191">
-                    <mxGeometry x="-0.2041" y="2" relative="1" as="geometry">
-                        <mxPoint x="4" y="-8" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="212" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="104" target="211">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="900"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="104" value="Finishing" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="120" y="880" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="197" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="106">
-                    <mxGeometry relative="1" as="geometry">
-                        <mxPoint x="40" y="1100" as="sourcePoint"/>
-                        <Array as="points">
-                            <mxPoint x="160" y="1100"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="198" value="ChangeAvailabilityToUnavailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="197">
-                    <mxGeometry x="-0.1438" y="7" relative="1" as="geometry">
-                        <mxPoint x="-30" y="-3" as="offset"/>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="208" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="103" target="207">
-                    <mxGeometry relative="1" as="geometry">
-                        <Array as="points">
-                            <mxPoint x="360" y="780"/>
-                        </Array>
-                    </mxGeometry>
-                </mxCell>
-                <mxCell id="103" value="SuspendedEVSE" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
-                    <mxGeometry x="120" y="760" width="160" height="40" as="geometry"/>
-                </mxCell>
-                <mxCell id="199" value="UsageInitiated&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;PauseChargingEVSE&lt;br&gt;ReserveConnector&lt;br&gt;ChangeAvailabilityToUnavailable" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="280" width="240" height="120" as="geometry"/>
-                </mxCell>
-                <mxCell id="201" value="BecomeAvailable&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;PauseChargingEVSE&lt;br&gt;TransactionStoppedAndUserActionRequired" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="400" width="240" height="120" as="geometry"/>
-                </mxCell>
-                <mxCell id="203" value="BecomeAvailable&lt;br&gt;PauseChargingEV&lt;br&gt;PauseChargingEVSE&lt;br&gt;TransactionStoppedAndUserActionRequired&lt;br&gt;ChangeAvailabilityToUnavailable" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="520" width="240" height="120" as="geometry"/>
-                </mxCell>
-                <mxCell id="205" value="BecomeAvailable&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEVSE&lt;br&gt;TransactionStoppedAndUserActionRequired&lt;br&gt;ChangeAvailabilityToUnavailable" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="640" width="240" height="120" as="geometry"/>
-                </mxCell>
-                <mxCell id="207" value="BecomeAvailable&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;TransactionStoppedAndUserActionRequired&lt;br&gt;ChangeAvailabilityToUnavailable" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="760" width="260" height="120" as="geometry"/>
-                </mxCell>
-                <mxCell id="211" value="BecomeAvailable&lt;br&gt;UsageInitiated&lt;br&gt;ChangeAvailabilityToUnavailable" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="880" width="260" height="120" as="geometry"/>
-                </mxCell>
-                <mxCell id="213" value="BecomeAvailable&lt;br&gt;UsageInitiated&lt;br&gt;ChangeAvailabilityToUnavailable" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="1000" width="260" height="120" as="geometry"/>
-                </mxCell>
-                <mxCell id="215" value="BecomeAvailable&lt;br&gt;UsageInitiated&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;PauseChargingEVSE" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
-                    <mxGeometry x="360" y="1120" width="240" height="120" as="geometry"/>
-                </mxCell>
-            </root>
-        </mxGraphModel>
-    </diagram>
+<mxfile host="app.diagrams.net" modified="2024-05-16T07:40:43.747Z" agent="Mozilla/5.0 (X11; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0" version="24.4.2" etag="LGcMmMoyQHaw1c13RP_t" type="device">
+  <diagram id="enTwcsW3kJKdFbbsoOIB" name="Page-1">
+    <mxGraphModel dx="2015" dy="749" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="120" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;" parent="1" target="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="1330" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="760" y="1330" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="121" value="FaultDetected" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="120" vertex="1" connectable="0">
+          <mxGeometry x="0.5379" relative="1" as="geometry">
+            <mxPoint x="-50" y="-25" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="187" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" target="100" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="380" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="380" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="188" value="UsageInitiated" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="187" vertex="1" connectable="0">
+          <mxGeometry x="-0.669" y="2" relative="1" as="geometry">
+            <mxPoint x="14" y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="200" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" source="7" target="199" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="300" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="7" value="Available" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="280" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="9" value="" style="ellipse;html=1;shape=startState;fillColor=#000000;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="70" y="285" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="10" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0.867;exitY=0.5;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="9" target="7" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="210" y="330" as="targetPoint" />
+            <mxPoint x="110" y="390" as="sourcePoint" />
+            <Array as="points" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="133" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;" parent="1" target="7" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="260" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="260" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="134" value="BecomeAvailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="133" vertex="1" connectable="0">
+          <mxGeometry x="-0.308" y="-9" relative="1" as="geometry">
+            <mxPoint x="5" y="-19" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="189" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" target="104" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="860" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="860" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="190" value="TransactionStoppedAndUserActionRequired" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="189" vertex="1" connectable="0">
+          <mxGeometry x="-0.3632" relative="1" as="geometry">
+            <mxPoint x="-35" y="-10" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="204" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;spacingLeft=8;" parent="1" source="101" target="203" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="540" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="101" value="Charging" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="520" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="193" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" target="102" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="620" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="620" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="194" value="PauseChargingEV" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="193" vertex="1" connectable="0">
+          <mxGeometry x="-0.176" y="5" relative="1" as="geometry">
+            <mxPoint x="2" y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="214" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" source="105" target="213" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="1020" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="105" value="Reserved" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="1000" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="216" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" source="106" target="215" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="1140" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="106" value="Unavailable" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="1120" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="217" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="300" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="300" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="232" value="I1_ReturnToAvailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="217" vertex="1" connectable="0">
+          <mxGeometry x="0.9517" y="-6" relative="1" as="geometry">
+            <mxPoint x="33" y="-4" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="218" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="1140" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="1140" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="220" value="I8_ReturnToUnavailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="218" vertex="1" connectable="0">
+          <mxGeometry x="0.7671" y="-2" relative="1" as="geometry">
+            <mxPoint x="30" y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="219" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="1020" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="1020" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="221" value="I7_ReturnToReserved" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="219" vertex="1" connectable="0">
+          <mxGeometry x="0.8661" y="-4" relative="1" as="geometry">
+            <mxPoint x="35" y="-6" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="222" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="900" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="900" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="223" value="I6_ReturnToFinishing" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="222" vertex="1" connectable="0">
+          <mxGeometry x="0.8928" y="-3" relative="1" as="geometry">
+            <mxPoint x="33" y="-7" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="224" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="780" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="780" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="225" value="I5_ReturnToSuspendedEVSE" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="224" vertex="1" connectable="0">
+          <mxGeometry x="0.9051" y="-4" relative="1" as="geometry">
+            <mxPoint x="10" y="-6" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="226" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="660" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="660" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="227" value="I4_ReturnToSuspendedEV" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="226" vertex="1" connectable="0">
+          <mxGeometry x="0.935" y="-1" relative="1" as="geometry">
+            <mxPoint x="26" y="-9" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="228" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="540" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="540" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="229" value="I3_ReturnToCharging" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="228" vertex="1" connectable="0">
+          <mxGeometry x="0.9352" y="-7" relative="1" as="geometry">
+            <mxPoint x="32" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="230" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" parent="1" source="107" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="420" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="420" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="231" value="I2_ReturnToPreparing" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="230" vertex="1" connectable="0">
+          <mxGeometry x="0.9511" y="-2" relative="1" as="geometry">
+            <mxPoint x="36" y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="107" value="Faulted" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="720" y="1400" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="185" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" target="101" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="500" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="500" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="186" value="StartCharging" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="185" vertex="1" connectable="0">
+          <mxGeometry x="-0.5184" y="-1" relative="1" as="geometry">
+            <mxPoint x="21" y="-11" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="202" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" source="100" target="201" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="420" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="100" value="Preparing" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="400" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="195" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" target="103" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="740" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="740" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="196" value="PauseChargingEVSE" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="195" vertex="1" connectable="0">
+          <mxGeometry x="-0.0756" relative="1" as="geometry">
+            <mxPoint x="-15" y="-10" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="206" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" source="102" target="205" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="660" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="102" value="SuspendedEV" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="640" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="191" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" target="105" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="980" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="980" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="192" value="ReserveConnector" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="191" vertex="1" connectable="0">
+          <mxGeometry x="-0.2041" y="2" relative="1" as="geometry">
+            <mxPoint x="4" y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="212" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" source="104" target="211" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="900" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="104" value="Finishing" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="880" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="197" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" target="106" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="1100" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="1100" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="198" value="ChangeAvailabilityToUnavailable" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" parent="197" vertex="1" connectable="0">
+          <mxGeometry x="-0.1438" y="7" relative="1" as="geometry">
+            <mxPoint x="-30" y="-3" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="208" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" parent="1" source="103" target="207" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="780" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="103" value="SuspendedEVSE" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" parent="1" vertex="1">
+          <mxGeometry x="120" y="760" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="199" value="UsageInitiated&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;PauseChargingEVSE&lt;br&gt;ReserveConnector&lt;br&gt;&lt;div&gt;ChangeAvailabilityToUnavailable&lt;/div&gt;&lt;div&gt;Inoperative&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="280" width="240" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="201" value="BecomeAvailable&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;PauseChargingEVSE&lt;br&gt;&lt;div&gt;TransactionStoppedAndUserActionRequired&lt;/div&gt;&lt;div&gt;Inoperative&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="400" width="240" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="203" value="BecomeAvailable&lt;br&gt;PauseChargingEV&lt;br&gt;PauseChargingEVSE&lt;br&gt;TransactionStoppedAndUserActionRequired&lt;br&gt;&lt;div&gt;ChangeAvailabilityToUnavailable&lt;/div&gt;&lt;div&gt;Inoperative&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="520" width="240" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="205" value="BecomeAvailable&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEVSE&lt;br&gt;TransactionStoppedAndUserActionRequired&lt;br&gt;&lt;div&gt;ChangeAvailabilityToUnavailable&lt;br&gt;&lt;/div&gt;&lt;div&gt;Inoperative&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="640" width="240" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="207" value="BecomeAvailable&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;TransactionStoppedAndUserActionRequired&lt;br&gt;&lt;div&gt;ChangeAvailabilityToUnavailable&lt;/div&gt;&lt;div&gt;Inoperative&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="760" width="260" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="211" value="BecomeAvailable&lt;br&gt;UsageInitiated&lt;br&gt;&lt;div&gt;ChangeAvailabilityToUnavailable&lt;br&gt;&lt;/div&gt;&lt;div&gt;Inoperative&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="880" width="260" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="213" value="BecomeAvailable&lt;br&gt;UsageInitiated&lt;br&gt;&lt;div&gt;ChangeAvailabilityToUnavailable&lt;/div&gt;&lt;div&gt;Inoperative&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="1000" width="260" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="215" value="BecomeAvailable&lt;br&gt;UsageInitiated&lt;br&gt;StartCharging&lt;br&gt;PauseChargingEV&lt;br&gt;&lt;div&gt;PauseChargingEVSE&lt;/div&gt;Inoperative" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" parent="1" vertex="1">
+          <mxGeometry x="360" y="1120" width="240" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="0FHAPFW-caIVr1jyMbh_-232" style="edgeStyle=none;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" source="0FHAPFW-caIVr1jyMbh_-233" target="0FHAPFW-caIVr1jyMbh_-236">
+          <mxGeometry relative="1" as="geometry">
+            <Array as="points">
+              <mxPoint x="360" y="1260" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0FHAPFW-caIVr1jyMbh_-233" value="Inoperative" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;" vertex="1" parent="1">
+          <mxGeometry x="120" y="1240" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="0FHAPFW-caIVr1jyMbh_-234" style="edgeStyle=none;html=1;entryX=0.25;entryY=0;entryDx=0;entryDy=0;strokeColor=#000000;" edge="1" parent="1" target="0FHAPFW-caIVr1jyMbh_-233">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="40" y="1220" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="160" y="1220" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0FHAPFW-caIVr1jyMbh_-235" value="Inoperative" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="0FHAPFW-caIVr1jyMbh_-234">
+          <mxGeometry x="-0.1438" y="7" relative="1" as="geometry">
+            <mxPoint x="-30" y="-3" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0FHAPFW-caIVr1jyMbh_-236" value="BecomeAvailable" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;spacingLeft=8;" vertex="1" parent="1">
+          <mxGeometry x="360" y="1240" width="240" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="0FHAPFW-caIVr1jyMbh_-237" style="edgeStyle=none;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000000;" edge="1" parent="1" source="107">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="680" y="1260" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="800" y="1260" />
+            </Array>
+            <mxPoint x="810" y="1410" as="sourcePoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0FHAPFW-caIVr1jyMbh_-238" value="I9_ReturnToInoperative" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="0FHAPFW-caIVr1jyMbh_-237">
+          <mxGeometry x="0.7671" y="-2" relative="1" as="geometry">
+            <mxPoint x="30" y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
 </mxfile>

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -7,6 +7,7 @@
 #include <ocpp/common/evse_security.hpp>
 #include <ocpp/common/evse_security_impl.hpp>
 #include <ocpp/common/support_older_cpp_versions.hpp>
+#include <ocpp/v16/charge_point_state_machine.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/smart_charging.hpp>
 #include <ocpp/v16/types.hpp>
@@ -77,7 +78,7 @@ public:
     /// storage will be used
     /// \param bootreason reason for calling the start function
     /// \return
-    bool start(const std::map<int, ChargePointStatus>& connector_status_map = {},
+    bool start(const FSMConnectorStates& connector_status_map = {},
                BootReasonEnum bootreason = BootReasonEnum::PowerUp);
 
     /// \brief Restarts the ChargePoint if it has been stopped before. The ChargePoint is reinitialized, connects to the
@@ -86,7 +87,7 @@ public:
     /// (Available, Unavailable, Faulted). connector_status_map is empty, last availability states from the persistant
     /// storage will be used
     /// \param bootreason reason for calling the start function
-    bool restart(const std::map<int, ChargePointStatus>& connector_status_map = {},
+    bool restart(const FSMConnectorStates& connector_status_map = {},
                  BootReasonEnum bootreason = BootReasonEnum::ApplicationReset);
 
     // \brief Resets the internal state machine for the connectors using the given \p connector_status_map

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -193,7 +193,7 @@ private:
     /// \brief This function is called after a successful connection to the Websocket
     void connected_callback();
     void init_websocket();
-    void init_state_machine(const std::map<int, ChargePointStatus>& connector_status_map);
+    void init_state_machine(const FSMConnectorStates& connector_status_map);
     WebsocketConnectionOptions get_ws_connection_options();
     std::unique_ptr<ocpp::MessageQueue<v16::MessageType>> create_message_queue();
     void message_callback(const std::string& message);
@@ -384,7 +384,7 @@ public:
     /// (Available, Unavailable, Faulted)
     /// \param bootreason reason for calling the start function
     /// \return
-    bool start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason);
+    bool start(const FSMConnectorStates& connector_status_map, BootReasonEnum bootreason);
 
     /// \brief Restarts the ChargePoint if it has been stopped before. The ChargePoint is reinitialized, connects to the
     /// websocket and starts to communicate OCPP messages again
@@ -392,12 +392,12 @@ public:
     /// (Available, Unavailable, Faulted). connector_status_map is empty, last availability states from the persistant
     /// storage will be used
     /// \param bootreason reason for calling the restart function
-    bool restart(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason);
+    bool restart(const FSMConnectorStates& connector_status_map, BootReasonEnum bootreason);
 
     /// \brief Resets the internal state machine for the connectors using the given \p connector_status_map
     /// \param connector_status_map state of connectors including connector 0 with reduced set of states (Available,
     /// Unavailable, Faulted)
-    void reset_state_machine(const std::map<int, ChargePointStatus>& connector_status_map);
+    void reset_state_machine(const FSMConnectorStates& connector_status_map);
 
     /// \brief Stops the ChargePoint, stops timers, transactions and the message queue and disconnects from the
     /// websocket

--- a/include/ocpp/v16/charge_point_state_machine.hpp
+++ b/include/ocpp/v16/charge_point_state_machine.hpp
@@ -25,6 +25,10 @@ enum class FSMEvent {
     ReserveConnector,
     TransactionStoppedAndUserActionRequired,
     ChangeAvailabilityToUnavailable,
+    Operative,
+    OperativeQuiet,
+    Inoperative,
+    InoperativeQuiet,
     // FaultDetected - note: this event is handled via a separate function
     I1_ReturnToAvailable,
     I2_ReturnToPreparing,
@@ -34,9 +38,25 @@ enum class FSMEvent {
     I6_ReturnToFinishing,
     I7_ReturnToReserved,
     I8_ReturnToUnavailable,
+    I9_ReturnToInoperative,
 };
 
-using FSMState = ChargePointStatus;
+enum class FSMState {
+    // ChargePointStatus
+    Available,
+    Preparing,
+    Charging,
+    SuspendedEVSE,
+    SuspendedEV,
+    Finishing,
+    Reserved,
+    Unavailable,
+    Faulted,
+    // not a ChargePointStatus
+    Inoperative,
+};
+
+using FSMConnectorStates = std::map<int, FSMState>;
 
 using FSMStateTransitions = std::map<FSMEvent, FSMState>;
 
@@ -76,7 +96,7 @@ public:
         const ocpp::DateTime& timestamp, const std::optional<CiString<50>>& info,
         const std::optional<CiString<255>>& vendor_id, const std::optional<CiString<50>>& vendor_error_code)>;
     ChargePointStates(const ConnectorStatusCallback& connector_status_callback);
-    void reset(std::map<int, ChargePointStatus> connector_status_map);
+    void reset(const FSMConnectorStates& connector_status_map);
 
     void submit_event(const int connector_id, FSMEvent event, const ocpp::DateTime& timestamp,
                       const std::optional<CiString<50>>& info = std::nullopt);

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -21,11 +21,11 @@ ChargePoint::ChargePoint(const std::string& config, const fs::path& share_path, 
 
 ChargePoint::~ChargePoint() = default;
 
-bool ChargePoint::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {
+bool ChargePoint::start(const FSMConnectorStates& connector_status_map, BootReasonEnum bootreason) {
     return this->charge_point->start(connector_status_map, bootreason);
 }
 
-bool ChargePoint::restart(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {
+bool ChargePoint::restart(const FSMConnectorStates& connector_status_map, BootReasonEnum bootreason) {
     return this->charge_point->restart(connector_status_map, bootreason);
 }
 

--- a/lib/ocpp/v16/charge_point_state_machine.cpp
+++ b/lib/ocpp/v16/charge_point_state_machine.cpp
@@ -11,6 +11,32 @@
 namespace ocpp {
 namespace v16 {
 
+constexpr ChargePointStatus convert(FSMState state) {
+    switch (state) {
+    case FSMState::Available:
+        return ChargePointStatus::Available;
+    case FSMState::Preparing:
+        return ChargePointStatus::Preparing;
+    case FSMState::Charging:
+        return ChargePointStatus::Charging;
+    case FSMState::SuspendedEVSE:
+        return ChargePointStatus::SuspendedEVSE;
+    case FSMState::SuspendedEV:
+        return ChargePointStatus::SuspendedEV;
+    case FSMState::Finishing:
+        return ChargePointStatus::Finishing;
+    case FSMState::Reserved:
+        return ChargePointStatus::Reserved;
+    case FSMState::Unavailable:
+        return ChargePointStatus::Unavailable;
+    case FSMState::Inoperative:
+        return ChargePointStatus::Unavailable;
+    case FSMState::Faulted:
+    default:
+        return ChargePointStatus::Faulted;
+    }
+}
+
 static const FSMDefinition FSM_DEF = {
     {FSMState::Available,
      {
@@ -20,6 +46,8 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::PauseChargingEVSE, FSMState::SuspendedEVSE},
          {FSMEvent::ReserveConnector, FSMState::Reserved},
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::Preparing,
      {
@@ -28,6 +56,8 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::PauseChargingEV, FSMState::SuspendedEV},
          {FSMEvent::PauseChargingEVSE, FSMState::SuspendedEVSE},
          {FSMEvent::TransactionStoppedAndUserActionRequired, FSMState::Finishing},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::Charging,
      {
@@ -36,6 +66,8 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::PauseChargingEVSE, FSMState::SuspendedEVSE},
          {FSMEvent::TransactionStoppedAndUserActionRequired, FSMState::Finishing},
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::SuspendedEV,
      {
@@ -44,6 +76,8 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::PauseChargingEVSE, FSMState::SuspendedEVSE},
          {FSMEvent::TransactionStoppedAndUserActionRequired, FSMState::Finishing},
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::SuspendedEVSE,
      {
@@ -52,18 +86,24 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::PauseChargingEV, FSMState::SuspendedEV},
          {FSMEvent::TransactionStoppedAndUserActionRequired, FSMState::Finishing},
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::Finishing,
      {
          {FSMEvent::BecomeAvailable, FSMState::Available},
          {FSMEvent::UsageInitiated, FSMState::Preparing},
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::Reserved,
      {
          {FSMEvent::BecomeAvailable, FSMState::Available},
          {FSMEvent::UsageInitiated, FSMState::Preparing},
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::Unavailable,
      {
@@ -72,6 +112,8 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::StartCharging, FSMState::Charging},
          {FSMEvent::PauseChargingEV, FSMState::SuspendedEV},
          {FSMEvent::PauseChargingEVSE, FSMState::SuspendedEVSE},
+         {FSMEvent::Inoperative, FSMState::Inoperative},
+         {FSMEvent::InoperativeQuiet, FSMState::Inoperative},
      }},
     {FSMState::Faulted,
      {
@@ -83,6 +125,12 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::I6_ReturnToFinishing, FSMState::Finishing},
          {FSMEvent::I7_ReturnToReserved, FSMState::Reserved},
          {FSMEvent::I8_ReturnToUnavailable, FSMState::Unavailable},
+         {FSMEvent::I9_ReturnToInoperative, FSMState::Inoperative},
+     }},
+    {FSMState::Inoperative,
+     {
+         {FSMEvent::Operative, FSMState::Available},
+         {FSMEvent::OperativeQuiet, FSMState::Available},
      }},
 };
 
@@ -100,6 +148,12 @@ static const FSMDefinition FSM_DEF_CONNECTOR_ZERO = {
      {
          {FSMEvent::I1_ReturnToAvailable, FSMState::Available},
          {FSMEvent::I8_ReturnToUnavailable, FSMState::Unavailable},
+         {FSMEvent::I9_ReturnToInoperative, FSMState::Inoperative},
+     }},
+    {FSMState::Inoperative,
+     {
+         {FSMEvent::Operative, FSMState::Available},
+         {FSMEvent::OperativeQuiet, FSMState::Available},
      }},
 };
 
@@ -132,8 +186,14 @@ bool ChargePointFSM::handle_event(FSMEvent event, const ocpp::DateTime timestamp
     // fall through: transition found
     state = dest_state_it->second;
 
-    if (!faulted) {
-        status_notification_callback(state, this->error_code, timestamp, info, std::nullopt, std::nullopt);
+    bool bNotify = !faulted;
+
+    if ((event == FSMEvent::OperativeQuiet) || (event == FSMEvent::InoperativeQuiet)) {
+        bNotify = false;
+    }
+
+    if (bNotify) {
+        status_notification_callback(convert(state), this->error_code, timestamp, info, std::nullopt, std::nullopt);
     }
 
     return true;
@@ -151,10 +211,11 @@ bool ChargePointFSM::handle_fault(const ChargePointErrorCode& error_code, const 
     this->error_code = error_code;
     if (this->error_code == ChargePointErrorCode::NoError) {
         faulted = false;
-        status_notification_callback(state, this->error_code, timestamp, info, vendor_id, vendor_error_code);
+        status_notification_callback(convert(state), this->error_code, timestamp, info, vendor_id, vendor_error_code);
     } else {
         faulted = true;
-        status_notification_callback(FSMState::Faulted, error_code, timestamp, info, vendor_id, vendor_error_code);
+        status_notification_callback(ChargePointStatus::Faulted, error_code, timestamp, info, vendor_id,
+                                     vendor_error_code);
     }
 
     return true;
@@ -171,9 +232,10 @@ bool ChargePointFSM::handle_error(const ChargePointErrorCode& error_code, const 
 
     this->error_code = error_code;
     if (!faulted) {
-        status_notification_callback(this->state, error_code, timestamp, info, vendor_id, vendor_error_code);
+        status_notification_callback(convert(this->state), error_code, timestamp, info, vendor_id, vendor_error_code);
     } else {
-        status_notification_callback(FSMState::Faulted, error_code, timestamp, info, vendor_id, vendor_error_code);
+        status_notification_callback(ChargePointStatus::Faulted, error_code, timestamp, info, vendor_id,
+                                     vendor_error_code);
     }
     return true;
 }
@@ -181,17 +243,17 @@ bool ChargePointFSM::handle_error(const ChargePointErrorCode& error_code, const 
 ChargePointStates::ChargePointStates(const ConnectorStatusCallback& callback) : connector_status_callback(callback) {
 }
 
-void ChargePointStates::reset(std::map<int, ChargePointStatus> connector_status_map) {
+void ChargePointStates::reset(const FSMConnectorStates& connector_status_map) {
     const std::lock_guard<std::mutex> lck(state_machines_mutex);
     state_machines.clear();
 
     for (size_t connector_id = 0; connector_id < connector_status_map.size(); ++connector_id) {
         const auto initial_state = connector_status_map.at(connector_id);
 
-        if (connector_id == 0 and initial_state != ChargePointStatus::Available and
-            initial_state != ChargePointStatus::Unavailable and initial_state != ChargePointStatus::Faulted) {
+        if (connector_id == 0 and initial_state != FSMState::Available and initial_state != FSMState::Unavailable and
+            initial_state != FSMState::Faulted and initial_state != FSMState::Inoperative) {
             throw std::runtime_error("Invalid initial status for connector 0: " +
-                                     conversions::charge_point_status_to_string(initial_state));
+                                     conversions::charge_point_status_to_string(convert(initial_state)));
         } else if (connector_id == 0) {
             state_machine_connector_zero = std::make_unique<ChargePointFSM>(
                 [this](const ChargePointStatus status, const ChargePointErrorCode error_code,
@@ -254,9 +316,9 @@ void ChargePointStates::submit_error(const int connector_id, const ChargePointEr
 ChargePointStatus ChargePointStates::get_state(int connector_id) {
     const std::lock_guard<std::mutex> lck(state_machines_mutex);
     if (connector_id > 0 && (size_t)connector_id <= this->state_machines.size()) {
-        return state_machines.at(connector_id - 1).get_state();
+        return convert(state_machines.at(connector_id - 1).get_state());
     } else if (connector_id == 0) {
-        return state_machine_connector_zero->get_state();
+        return convert(state_machine_connector_zero->get_state());
     }
 
     // fall through on invalid id

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -129,6 +129,7 @@ bool DatabaseHandler::authorization_cache_clear() {
     if (retval == false) {
         throw QueryExecutionException(this->database->get_error_message());
     }
+    return retval;
 }
 
 size_t DatabaseHandler::authorization_cache_get_binary_size() {


### PR DESCRIPTION
## Describe your changes
A connector/EVSE can be made unavailable for multiple reasons. However when made Inoperative via OCPP ChangeAvailability this should not be overridden.
An additional state has been added to ensure that unexpected events do not trigger a StatusNotification nor do they trigger a state change.

(this change is linked to changes in EvseManager)
https://github.com/EVerest/everest-core/pull/690

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

