### PR TITLE
v1.6: On call of onEnable, on disable from business-logic, persist this change inside database

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3962,10 +3962,14 @@ void ChargePointImpl::on_reservation_end(int32_t connector) {
 }
 
 void ChargePointImpl::on_enabled(int32_t connector) {
+    std::lock_guard<std::mutex> change_availability_lock(change_availability_mutex);
+    this->database_handler->insert_or_update_connector_availability(connector, AvailabilityType::Operative);
     this->status->submit_event(connector, FSMEvent::BecomeAvailable, ocpp::DateTime());
 }
 
 void ChargePointImpl::on_disabled(int32_t connector) {
+    std::lock_guard<std::mutex> change_availability_lock(change_availability_mutex);
+    this->database_handler->insert_or_update_connector_availability(connector, AvailabilityType::Inoperative);
     this->status->submit_event(connector, FSMEvent::ChangeAvailabilityToUnavailable, ocpp::DateTime());
 }
 


### PR DESCRIPTION
…nge inside database

## Describe your changes
Storage of enable/disable calls inside database.

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/626

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

