### PR TITLE
v1.6: Reject call of RemoteStart.req with negative connector

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1661,7 +1661,7 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
     std::vector<int32_t> referenced_connectors;
 
     if (call.msg.connectorId) {
-        if (call.msg.connectorId.value() == 0) {
+        if (call.msg.connectorId.value() == 0 or call.msg.connectorId.value() < 0) {
             EVLOG_warning << "Received RemoteStartTransactionRequest with connector id 0";
             response.status = RemoteStartStopStatus::Rejected;
             ocpp::CallResult<RemoteStartTransactionResponse> call_result(response, call.uniqueId);

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1661,8 +1661,8 @@ void ChargePointImpl::handleRemoteStartTransactionRequest(ocpp::Call<RemoteStart
     std::vector<int32_t> referenced_connectors;
 
     if (call.msg.connectorId) {
-        if (call.msg.connectorId.value() == 0 or call.msg.connectorId.value() < 0) {
-            EVLOG_warning << "Received RemoteStartTransactionRequest with connector id 0";
+        if (call.msg.connectorId.value() <= 0) {
+            EVLOG_warning << "Received RemoteStartTransactionRequest with connector id <= 0";
             response.status = RemoteStartStopStatus::Rejected;
             ocpp::CallResult<RemoteStartTransactionResponse> call_result(response, call.uniqueId);
             this->send<RemoteStartTransactionResponse>(call_result);


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/628

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

