### PR TITLE
BUGFIX - Don't send security event notification until Registration is completed

### DIFF
--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -82,9 +82,7 @@ private:
     void handle_deferred_callback_queue();
 
     /// \brief Add a callback to the queue of callbacks to be executed. All will be executed from a single thread
-    void push_deferred_callback(std::function<void()> callback);
-
-    void stop_deferred_callback_handler();
+    void push_deferred_callback(const std::function<void()> &callback);
 
 private:
     std::shared_ptr<EvseSecurity> evse_security;
@@ -109,7 +107,7 @@ private:
     std::condition_variable recv_message_cv;
     std::string recv_buffered_message;
 
-    std::thread deferred_callback_thread;
+    std::unique_ptr<std::thread> deferred_callback_thread;
     std::queue<std::function<void()>> deferred_callback_queue;
     std::mutex deferred_callback_mutex;
     std::condition_variable deferred_callback_cv;

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -82,7 +82,7 @@ private:
     void handle_deferred_callback_queue();
 
     /// \brief Add a callback to the queue of callbacks to be executed. All will be executed from a single thread
-    void push_deferred_callback(const std::function<void()> &callback);
+    void push_deferred_callback(const std::function<void()>& callback);
 
 private:
     std::shared_ptr<EvseSecurity> evse_security;

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -78,6 +78,12 @@ private:
 
     void poll_message(const std::shared_ptr<WebsocketMessage>& msg);
 
+    /// \brief Function to handle the deferred callbacks
+    void handle_deferred_callback_queue();
+
+    /// \brief Add a callback to the queue of callbacks to be executed. All will be executed from a single thread
+    void push_deferred_callback(std::function<void()> callback);
+
 private:
     std::shared_ptr<EvseSecurity> evse_security;
 
@@ -100,6 +106,11 @@ private:
     std::queue<std::string> recv_message_queue;
     std::condition_variable recv_message_cv;
     std::string recv_buffered_message;
+
+    std::thread deferred_callback_handler;
+    std::queue<std::function<void()>> deferred_callback_queue;
+    std::mutex deferred_callback_mutex;
+    std::condition_variable deferred_callback_cv;
 };
 
 } // namespace ocpp

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -84,6 +84,8 @@ private:
     /// \brief Add a callback to the queue of callbacks to be executed. All will be executed from a single thread
     void push_deferred_callback(std::function<void()> callback);
 
+    void stop_deferred_callback_handler();
+
 private:
     std::shared_ptr<EvseSecurity> evse_security;
 
@@ -107,10 +109,11 @@ private:
     std::condition_variable recv_message_cv;
     std::string recv_buffered_message;
 
-    std::thread deferred_callback_handler;
+    std::thread deferred_callback_thread;
     std::queue<std::function<void()>> deferred_callback_queue;
     std::mutex deferred_callback_mutex;
     std::condition_variable deferred_callback_cv;
+    bool stop_deferred_handler;
 };
 
 } // namespace ocpp

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -741,6 +741,9 @@ private:
     /// If \param persist is set to true, the change will be persisted across a reboot
     void execute_change_availability_request(ChangeAvailabilityRequest request, bool persist);
 
+    /// @brief Generate the security event notification on bootup and send after a succesful registration
+    void generate_bootup_security_event_notification();
+
 public:
     /// \brief Construct a new ChargePoint object
     /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1308,7 +1308,8 @@ void WebsocketTlsTPM::handle_deferred_callback_queue() {
         std::function<void()> callback;
         {
             std::unique_lock lock(this->deferred_callback_mutex);
-            this->deferred_callback_cv.wait(lock, [this]() { return !this->deferred_callback_queue.empty() || !stop_deferred_handler; });
+            this->deferred_callback_cv.wait(
+                lock, [this]() { return !this->deferred_callback_queue.empty() || !stop_deferred_handler; });
 
             if (stop_deferred_handler) {
                 break;

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1086,9 +1086,11 @@ int WebsocketTlsTPM::process_callback(void* wsi_ptr, int callback_reason, void* 
             // 'user' is X509_STORE and 'len' is preverify_ok (1) in case the pre-verification was successful
             EVLOG_debug << "Verifying server certs!";
 
-            if (false == verify_csms_cn(this->connection_options.csms_uri.get_hostname(), (len == 1),
-                                        reinterpret_cast<X509_STORE_CTX*>(user),
-                                        this->connection_options.verify_csms_allow_wildcards)) {
+            if (!verify_csms_cn(this->connection_options.csms_uri.get_hostname(), (len == 1),
+                                reinterpret_cast<X509_STORE_CTX*>(user),
+                                this->connection_options.verify_csms_allow_wildcards)) {
+                this->push_deferred_callback(
+                    [this]() { this->connection_failed_callback(ConnectionFailedReason::InvalidCSMSCertificate); });
                 // Return 1 to fail the cert
                 return 1;
             }

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -208,7 +208,9 @@ static bool verify_csms_cn(const std::string& hostname, bool preverified, const 
 
 WebsocketTlsTPM::WebsocketTlsTPM(const WebsocketConnectionOptions& connection_options,
                                  std::shared_ptr<EvseSecurity> evse_security) :
-    WebsocketBase(), evse_security(evse_security) {
+    WebsocketBase(),
+    evse_security(evse_security),
+    deferred_callback_handler(&WebsocketTlsTPM::handle_deferred_callback_queue, this) {
 
     set_connection_options(connection_options);
 
@@ -746,11 +748,10 @@ void WebsocketTlsTPM::close(const WebsocketCloseReason code, const std::string& 
     // Clear any irrelevant data after a DC
     recv_buffered_message.clear();
 
-    std::thread closing([this]() {
+    this->push_deferred_callback([this]() {
         this->closed_callback(WebsocketCloseReason::Normal);
         this->disconnected_callback();
     });
-    closing.detach();
 }
 
 void WebsocketTlsTPM::on_conn_connected() {
@@ -763,8 +764,7 @@ void WebsocketTlsTPM::on_conn_connected() {
     // Clear any irrelevant data after a DC
     recv_buffered_message.clear();
 
-    std::thread connected([this]() { this->connected_callback(this->connection_options.security_profile); });
-    connected.detach();
+    this->push_deferred_callback([this]() { this->connected_callback(this->connection_options.security_profile); });
 }
 
 void WebsocketTlsTPM::on_conn_close() {
@@ -772,7 +772,6 @@ void WebsocketTlsTPM::on_conn_close() {
 
     std::lock_guard<std::mutex> lk(this->connection_mutex);
     this->m_is_connected = false;
-    this->disconnected_callback();
     this->cancel_reconnect_timer();
 
     // Notify any message senders that are waiting, since we can't send messages any more
@@ -781,11 +780,10 @@ void WebsocketTlsTPM::on_conn_close() {
     // Clear any irrelevant data after a DC
     recv_buffered_message.clear();
 
-    std::thread closing([this]() {
+    this->push_deferred_callback([this]() {
         this->closed_callback(WebsocketCloseReason::Normal);
         this->disconnected_callback();
     });
-    closing.detach();
 }
 
 void WebsocketTlsTPM::on_conn_fail() {
@@ -793,8 +791,7 @@ void WebsocketTlsTPM::on_conn_fail() {
 
     std::lock_guard<std::mutex> lk(this->connection_mutex);
     if (this->m_is_connected) {
-        std::thread disconnect([this]() { this->disconnected_callback(); });
-        disconnect.detach();
+        this->push_deferred_callback([this]() { this->disconnected_callback(); });
     }
 
     this->m_is_connected = false;
@@ -1286,6 +1283,27 @@ int WebsocketTlsTPM::process_callback(void* wsi_ptr, int callback_reason, void* 
 
     // Return -1 on fatal error (-1 is request to close the socket)
     return 0;
+}
+
+void WebsocketTlsTPM::push_deferred_callback(std::function<void()> callback) {
+    std::scoped_lock tmp_lock(this->deferred_callback_mutex);
+    this->deferred_callback_queue.push(callback);
+    this->deferred_callback_cv.notify_one();
+}
+
+void WebsocketTlsTPM::handle_deferred_callback_queue() {
+    while (true) {
+        std::function<void()> callback;
+        {
+            std::unique_lock lock(this->deferred_callback_mutex);
+            this->deferred_callback_cv.wait(lock, [this]() { return !this->deferred_callback_queue.empty(); });
+            callback = this->deferred_callback_queue.front();
+            this->deferred_callback_queue.pop();
+        }
+        // This needs to be out of lock scope otherwise we still keep the mutex locked while executing the callback.
+        // This would block the callers of push_deferred_callback()
+        callback();
+    }
 }
 
 } // namespace ocpp

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -208,9 +208,7 @@ static bool verify_csms_cn(const std::string& hostname, bool preverified, const 
 
 WebsocketTlsTPM::WebsocketTlsTPM(const WebsocketConnectionOptions& connection_options,
                                  std::shared_ptr<EvseSecurity> evse_security) :
-    WebsocketBase(),
-    evse_security(evse_security),
-    stop_deferred_handler(false) {
+    WebsocketBase(), evse_security(evse_security), stop_deferred_handler(false) {
 
     set_connection_options(connection_options);
 
@@ -637,7 +635,8 @@ bool WebsocketTlsTPM::connect() {
     }
 
     if (this->deferred_callback_thread == nullptr) {
-        this->deferred_callback_thread = std::make_unique<std::thread>(&WebsocketTlsTPM::handle_deferred_callback_queue, this);
+        this->deferred_callback_thread =
+            std::make_unique<std::thread>(&WebsocketTlsTPM::handle_deferred_callback_queue, this);
     }
 
     // Stop any pending reconnect timer
@@ -1295,7 +1294,7 @@ int WebsocketTlsTPM::process_callback(void* wsi_ptr, int callback_reason, void* 
     return 0;
 }
 
-void WebsocketTlsTPM::push_deferred_callback(const std::function<void()> &callback) {
+void WebsocketTlsTPM::push_deferred_callback(const std::function<void()>& callback) {
     std::scoped_lock tmp_lock(this->deferred_callback_mutex);
     this->deferred_callback_queue.push(callback);
     this->deferred_callback_cv.notify_one();

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -185,28 +185,6 @@ void ChargePoint::start(BootReasonEnum bootreason) {
     // get transaction messages from db (if there are any) so they can be sent again.
     this->message_queue->get_transaction_messages_from_db();
     this->start_websocket();
-
-    if (this->bootreason == BootReasonEnum::RemoteReset) {
-        this->security_event_notification_req(
-            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
-            std::optional<CiString<255>>("Charging Station rebooted due to requested remote reset!"), true, true);
-    } else if (this->bootreason == BootReasonEnum::ScheduledReset) {
-        this->security_event_notification_req(
-            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
-            std::optional<CiString<255>>("Charging Station rebooted due to a scheduled reset!"), true, true);
-    } else if (this->bootreason == BootReasonEnum::PowerUp) {
-        std::string startup_message = "Charging Station powered up! Firmware version: ";
-        startup_message.append(
-            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
-        this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
-                                              std::optional<CiString<255>>(startup_message), true, true);
-    } else {
-        std::string startup_message = "Charging station reset or reboot. Firmware version: ";
-        startup_message.append(
-            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
-        this->security_event_notification_req(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
-                                              std::optional<CiString<255>>(startup_message), true, true);
-    }
 }
 
 void ChargePoint::start_websocket() {
@@ -2236,6 +2214,8 @@ void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationR
         this->update_aligned_data_interval();
         this->component_state_manager->send_status_notification_all_connectors();
         this->ocsp_updater.start();
+
+        this->generate_bootup_security_event_notification();
     } else {
         auto retry_interval = DEFAULT_BOOT_NOTIFICATION_RETRY_INTERVAL;
         if (msg.interval > 0) {
@@ -3414,6 +3394,30 @@ void ChargePoint::execute_change_availability_request(ChangeAvailabilityRequest 
         }
     } else {
         this->set_cs_operative_status(request.operationalStatus, persist);
+    }
+}
+
+void ChargePoint::generate_bootup_security_event_notification() {
+    if (this->bootreason == BootReasonEnum::RemoteReset) {
+        this->security_event_notification_req(
+            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+            std::optional<CiString<255>>("Charging Station rebooted due to requested remote reset!"), true, true);
+    } else if (this->bootreason == BootReasonEnum::ScheduledReset) {
+        this->security_event_notification_req(
+            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+            std::optional<CiString<255>>("Charging Station rebooted due to a scheduled reset!"), true, true);
+    } else if (this->bootreason == BootReasonEnum::PowerUp) {
+        std::string startup_message = "Charging Station powered up! Firmware version: ";
+        startup_message.append(
+            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+        this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
+                                              std::optional<CiString<255>>(startup_message), true, true);
+    } else {
+        std::string startup_message = "Charging station reset or reboot. Firmware version: ";
+        startup_message.append(
+            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+        this->security_event_notification_req(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+                                              std::optional<CiString<255>>(startup_message), true, true);
     }
 }
 

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -125,10 +125,10 @@ void DatabaseHandler::authorization_cache_delete_entry(const std::string& id_tok
 }
 
 bool DatabaseHandler::authorization_cache_clear() {
-    const auto retval = this->database->clear_table("AUTH_CACHE");
-    if (retval == false) {
-        throw QueryExecutionException(this->database->get_error_message());
-    }
+    return this->database->clear_table("AUTH_CACHE");
+    // if (retval == false) {
+    //     throw QueryExecutionException(this->database->get_error_message());
+    // }
 }
 
 size_t DatabaseHandler::authorization_cache_get_binary_size() {

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -311,7 +311,8 @@ void Evse::check_max_energy_on_invalid_id() {
         if (opt_energy_value.has_value() and active_energy_import_start_value.has_value()) {
             auto charged_energy = opt_energy_value.value() - active_energy_import_start_value.value();
 
-            if (charged_energy > static_cast<float>(max_energy_on_invalid_id.value())) {
+            // TODO float compare with epsilon
+            if (charged_energy >= static_cast<float>(max_energy_on_invalid_id.value())) {
                 this->pause_charging_callback();
                 transaction->check_max_active_import_energy = false; // No need to check anymore
             }


### PR DESCRIPTION
## Describe your changes
- Remove generation of security even notification from ChargePoint::start and move it to after registration status is Accepted.
- Create private function to generate security event notification

## Issue ticket number and link
633-security-event-notifications-sent-even-when-regisration-is-not-accepted

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

