### PR TITLE
Fix the error caused by X509_STORE_CTX not using const_cast for type …

### DIFF
--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -161,10 +161,11 @@ static bool verify_csms_cn(const std::string& hostname, bool preverified, const 
     // This thus gives also the position (in the chain)  of the currently to be verified certificate.
     // If depth is 0, we need to check the leaf certificate;
     // If depth > 0, we are verifying a CA (or SUB-CA) certificate and thus trust "preverified"
-    int depth = X509_STORE_CTX_get_error_depth(ctx);
+
+    int depth = X509_STORE_CTX_get_error_depth(const_cast<X509_STORE_CTX*>ctx);
 
     if (!preverified) {
-        int error = X509_STORE_CTX_get_error(ctx);
+        int error = X509_STORE_CTX_get_error(const_cast<X509_STORE_CTX*>ctx);
         EVLOG_warning << "Invalid certificate error '" << X509_verify_cert_error_string(error) << "' (at chain depth '"
                       << depth << "')";
     }
@@ -172,7 +173,7 @@ static bool verify_csms_cn(const std::string& hostname, bool preverified, const 
     // only check for CSMS server certificate
     if (depth == 0 and preverified) {
         // Get server certificate
-        X509* server_cert = X509_STORE_CTX_get_current_cert(ctx);
+        X509* server_cert = X509_STORE_CTX_get_current_cert(const_cast<X509_STORE_CTX*>ctx);
 
         // TODO (ioan): this manual verification is done because libwebsocket does not take into account
         // the host parameter that we are setting during 'tls_init'. This function should be removed


### PR DESCRIPTION
…conversion;

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

