### PR TITLE
OCPP1.6: Fix handling of malformed Authorize.conf

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2823,17 +2823,16 @@ IdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const bool aut
 
     IdTagInfo id_tag_info;
     if (enhanced_message.messageType == MessageType::AuthorizeResponse) {
-        ocpp::CallResult<AuthorizeResponse> call_result = enhanced_message.message;
         try {
+            ocpp::CallResult<AuthorizeResponse> call_result = enhanced_message.message;
             this->database_handler->insert_or_update_authorization_cache_entry(idTag, call_result.msg.idTagInfo);
             return call_result.msg.idTagInfo;
         } catch (const QueryExecutionException& e) {
             EVLOG_warning << "Could not insert or update authorization cache entry";
-            return call_result.msg.idTagInfo;
+            return {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
         } catch (const json::exception& e) {
             EVLOG_warning << "CSMS returned a malformed response to the AuthorizeRequest, assuming id tag is invalid.";
-            id_tag_info = {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
-            return id_tag_info;
+            return {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
         }
     } else if (enhanced_message.offline) {
         if (this->configuration->getAllowOfflineTxForUnknownId() != std::nullopt &&


### PR DESCRIPTION
## Describe your changes
Moved implicit instatiation of CallResult<AuthorizeResponse> within try-block. Without this change the exception is not caught.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

