### PR TITLE
Add missing return value to DatabaseHandler::authorization_cache_clea…

### DIFF
--- a/include/ocpp/v201/database_handler.hpp
+++ b/include/ocpp/v201/database_handler.hpp
@@ -55,8 +55,7 @@ public:
     void authorization_cache_delete_entry(const std::string& id_token_hash);
 
     /// \brief Deletes all entries of the AUTH_CACHE table. Returns true if the operation was successful, else false
-    /// \return
-    bool authorization_cache_clear();
+    void authorization_cache_clear();
 
     ///\brief Get the binary size of the authorization cache table
     ///

--- a/lib/ocpp/v16/database_handler.cpp
+++ b/lib/ocpp/v16/database_handler.cpp
@@ -283,7 +283,6 @@ void DatabaseHandler::clear_authorization_cache() {
     if (retval == false) {
         throw QueryExecutionException(this->database->get_error_message());
     }
-    return retval;
 }
 
 void DatabaseHandler::insert_or_update_connector_availability(int32_t connector,

--- a/lib/ocpp/v16/database_handler.cpp
+++ b/lib/ocpp/v16/database_handler.cpp
@@ -283,6 +283,7 @@ void DatabaseHandler::clear_authorization_cache() {
     if (retval == false) {
         throw QueryExecutionException(this->database->get_error_message());
     }
+    return retval;
 }
 
 void DatabaseHandler::insert_or_update_connector_availability(int32_t connector,

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -129,6 +129,7 @@ bool DatabaseHandler::authorization_cache_clear() {
     if (retval == false) {
         throw QueryExecutionException(this->database->get_error_message());
     }
+    return retval;
 }
 
 size_t DatabaseHandler::authorization_cache_get_binary_size() {

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -124,12 +124,11 @@ void DatabaseHandler::authorization_cache_delete_entry(const std::string& id_tok
     }
 }
 
-bool DatabaseHandler::authorization_cache_clear() {
+void DatabaseHandler::authorization_cache_clear() {
     const auto retval = this->database->clear_table("AUTH_CACHE");
     if (retval == false) {
         throw QueryExecutionException(this->database->get_error_message());
     }
-    return retval;
 }
 
 size_t DatabaseHandler::authorization_cache_get_binary_size() {


### PR DESCRIPTION
…r for both v16 and v201

## Describe your changes
Add missing return value to DatabaseHandler::authorization_cache_clear for both v16 and v201

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/641

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

