### PR TITLE
bug: correct precision of meter_start

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -210,7 +210,7 @@ public:
     /// \param timestamp of the start of transaction
     /// \param signed_meter_value e.g. in OCMF format
     void on_transaction_started(const int32_t& connector, const std::string& session_id, const std::string& id_token,
-                                const int32_t& meter_start, std::optional<int32_t> reservation_id,
+                                const double meter_start, std::optional<int32_t> reservation_id,
                                 const ocpp::DateTime& timestamp, std::optional<std::string> signed_meter_value);
 
     /// \brief Notifies chargepoint that the transaction on the given \p connector with the given \p reason has been

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -516,7 +516,7 @@ public:
     /// \param timestamp of the start of transaction
     /// \param signed_meter_value e.g. in OCMF format
     void on_transaction_started(const int32_t& connector, const std::string& session_id, const std::string& id_token,
-                                const int32_t& meter_start, std::optional<int32_t> reservation_id,
+                                const double meter_start, std::optional<int32_t> reservation_id,
                                 const ocpp::DateTime& timestamp, std::optional<std::string> signed_meter_value);
 
     /// \brief Notifies chargepoint that the transaction on the given \p connector with the given \p reason has been

--- a/include/ocpp/v16/transaction.hpp
+++ b/include/ocpp/v16/transaction.hpp
@@ -52,7 +52,7 @@ public:
     /// \brief Creates a new Transaction object, taking ownership of the provided \p meter_values_sample_timer
     /// on the provided \p connector
     Transaction(const int32_t transaction_id, const int32_t& connector, const std::string& session_id,
-                const CiString<20>& id_token, const int32_t& meter_start, std::optional<int32_t> reservation_id,
+                const CiString<20>& id_token, const double meter_start, std::optional<int32_t> reservation_id,
                 const ocpp::DateTime& timestamp, std::unique_ptr<Everest::SteadyTimer> meter_values_sample_timer);
 
     /// \brief Provides the energy in Wh at the start of the transaction

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -103,7 +103,7 @@ void ChargePoint::on_session_stopped(const int32_t connector, const std::string&
 }
 
 void ChargePoint::on_transaction_started(const int32_t& connector, const std::string& session_id,
-                                         const std::string& id_token, const int32_t& meter_start,
+                                         const std::string& id_token, const double meter_start,
                                          std::optional<int32_t> reservation_id, const ocpp::DateTime& timestamp,
                                          std::optional<std::string> signed_meter_value) {
     this->charge_point->on_transaction_started(connector, session_id, id_token, meter_start, reservation_id, timestamp,

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2338,8 +2338,7 @@ void ChargePointImpl::sign_certificate(const ocpp::CertificateSigningUseEnum& ce
         this->configuration->getUseTPM());
 
     if (response.status != GetCertificateSignRequestStatus::Accepted || !response.csr.has_value()) {
-        EVLOG_error << "Create CSR (TPM=" << this->configuration->getUseTPM() << ")"
-                    << " failed for:"
+        EVLOG_error << "Create CSR (TPM=" << this->configuration->getUseTPM() << ")" << " failed for:"
                     << ocpp::conversions::certificate_signing_use_enum_to_string(certificate_signing_use);
 
         std::string gen_error =

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2338,7 +2338,8 @@ void ChargePointImpl::sign_certificate(const ocpp::CertificateSigningUseEnum& ce
         this->configuration->getUseTPM());
 
     if (response.status != GetCertificateSignRequestStatus::Accepted || !response.csr.has_value()) {
-        EVLOG_error << "Create CSR (TPM=" << this->configuration->getUseTPM() << ")" << " failed for:"
+        EVLOG_error << "Create CSR (TPM=" << this->configuration->getUseTPM() << ")"
+                    << " failed for:"
                     << ocpp::conversions::certificate_signing_use_enum_to_string(certificate_signing_use);
 
         std::string gen_error =

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3539,7 +3539,7 @@ void ChargePointImpl::on_session_stopped(const int32_t connector, const std::str
 }
 
 void ChargePointImpl::on_transaction_started(const int32_t& connector, const std::string& session_id,
-                                             const std::string& id_token, const int32_t& meter_start,
+                                             const std::string& id_token, const double meter_start,
                                              std::optional<int32_t> reservation_id, const ocpp::DateTime& timestamp,
                                              std::optional<std::string> signed_meter_value) {
     if (this->status->get_state(connector) == ChargePointStatus::Reserved) {

--- a/lib/ocpp/v16/transaction.cpp
+++ b/lib/ocpp/v16/transaction.cpp
@@ -10,8 +10,8 @@ namespace ocpp {
 namespace v16 {
 
 Transaction::Transaction(const int32_t internal_transaction_id, const int32_t& connector, const std::string& session_id,
-                         const CiString<20>& id_token, const double meter_start,
-                         std::optional<int32_t> reservation_id, const ocpp::DateTime& timestamp,
+                         const CiString<20>& id_token, const double meter_start, std::optional<int32_t> reservation_id,
+                         const ocpp::DateTime& timestamp,
                          std::unique_ptr<Everest::SteadyTimer> meter_values_sample_timer) :
     internal_transaction_id(internal_transaction_id),
     connector(connector),

--- a/lib/ocpp/v16/transaction.cpp
+++ b/lib/ocpp/v16/transaction.cpp
@@ -10,7 +10,7 @@ namespace ocpp {
 namespace v16 {
 
 Transaction::Transaction(const int32_t internal_transaction_id, const int32_t& connector, const std::string& session_id,
-                         const CiString<20>& id_token, const int32_t& meter_start,
+                         const CiString<20>& id_token, const double meter_start,
                          std::optional<int32_t> reservation_id, const ocpp::DateTime& timestamp,
                          std::unique_ptr<Everest::SteadyTimer> meter_values_sample_timer) :
     internal_transaction_id(internal_transaction_id),


### PR DESCRIPTION
The meter start value (the energy in Wh that a powermeter reports at the beginning of a transaction) is internally represented in the transaction class (for ocpp 1.6) as a `StampedEnergyWh`. `StampedEnergyWh` records this value as a `double` and hence its constructor should also accept the energy as a `double` (it used to take an `int32`).
Furthermore, the set of `on_transaction_started` for ocpp 1.6 also only accepted `int32` values.  These have been changed to `double` too, as there should be no reason to truncate them before.  Furthermore the `meter_start` argument is passed by value now.  Passing by reference for these *simple* and small types is just not necessary.

Note: the same could be done for the `on_transaction_stopped` functions.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

