### PR TITLE
Bump libevse version

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -31,7 +31,7 @@ websocketpp:
   cmake_condition: "LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP"
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: 4330ce2e28e25535dd01558edb2331891c146769
+  git_tag: v0.7.0
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
   git_tag: v4.3.3  


### PR DESCRIPTION
## Describe your changes

Updated to libevse-security v0.7.0, that deprecates OpenSSL V 1.1.1

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

