### PR TITLE
Replace recv_loop with the new callback handler since they do the same; calling callbacks from a different thread

### DIFF
--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -57,7 +57,6 @@ private:
     void tls_init(struct ssl_ctx_st* ctx, const std::string& path_chain, const std::string& path_key, bool tpm_key,
                   std::optional<std::string>& password);
     void client_loop();
-    void recv_loop();
 
     /// \brief Called when a TLS websocket connection is established, calls the connected callback
     void on_conn_connected();
@@ -101,10 +100,6 @@ private:
     std::condition_variable msg_send_cv;
     std::mutex msg_send_cv_mutex;
 
-    std::unique_ptr<std::thread> recv_message_thread;
-    std::mutex recv_mutex;
-    std::queue<std::string> recv_message_queue;
-    std::condition_variable recv_message_cv;
     std::string recv_buffered_message;
 
     std::unique_ptr<std::thread> deferred_callback_thread;


### PR DESCRIPTION
## Describe your changes
The recv_loop is used to handle messages from a different thread than the one transmitting them. Sometimes when we receive a message we transmit a response and wait on the result. If we are calling that from the same thread we've created a deadlock.

Recently I introduced a new thread for handling callbacks. The recv_loop is essentially also calling a callback so could make use of the same thread instead of having its own.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

