### PR TITLE
OCPP1.6: Added MaxMessageSize to handle large StopTransaction.req

### DIFF
--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -262,6 +262,13 @@
             "type": "string",
             "readOnly": true,
             "default": "Energy.Active.Import.Register,Energy.Active.Export.Register,Power.Active.Import,Voltage,Current.Import,Frequency,Current.Offered,Power.Offered"
+        },
+        "MaxMessageSize": {
+            "$comment": "Maximum size in bytes for messages sent to the CSMS via websocket. If a message exceeds this size, data of the message may be dropped",
+            "type": "integer",
+            "readOnly": true,
+            "minimum": 32000,
+            "default": 65000
         }
     },
     "additionalProperties": false

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -90,6 +90,8 @@ public:
     bool getUseTPM();
     std::string getSupportedMeasurands();
     KeyValue getSupportedMeasurandsKeyValue();
+    int getMaxMessageSize();
+    KeyValue getMaxMessageSizeKeyValue();
 
     int32_t getRetryBackoffRandomRange();
     void setRetryBackoffRandomRange(int32_t retry_backoff_random_range);

--- a/include/ocpp/v16/utils.hpp
+++ b/include/ocpp/v16/utils.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
 
+#include <ocpp/common/call_types.hpp>
+#include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/types.hpp>
 
 namespace ocpp {
@@ -9,6 +11,21 @@ namespace utils {
 bool is_transaction_message_type(const MessageType& message_type) {
     return message_type == MessageType::StartTransaction or message_type == MessageType::StopTransaction or
            message_type == MessageType::MeterValues or message_type == MessageType::SecurityEventNotification;
+}
+
+size_t get_message_size(const ocpp::Call<StopTransactionRequest>& call) {
+    return json(call).at(CALL_PAYLOAD).dump().length();
+}
+
+/// \brief Drops every second entry from transactionData as long as the message size of the \p call is greater than the
+/// \p max_message_size
+void drop_transaction_data(size_t max_message_size, ocpp::Call<StopTransactionRequest>& call) {
+    auto& transaction_data = call.msg.transactionData.value();
+    while (get_message_size(call) > max_message_size && transaction_data.size() > 2) {
+        for (size_t i = 1; i < transaction_data.size() - 1; i = i + 2) {
+            transaction_data.erase(transaction_data.begin() + i);
+        }
+    }
 }
 } // namespace utils
 } // namespace v16

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -570,6 +570,18 @@ KeyValue ChargePointConfiguration::getSupportedMeasurandsKeyValue() {
     return kv;
 }
 
+int ChargePointConfiguration::getMaxMessageSize() {
+    return this->config["Internal"]["MaxMessageSize"];
+}
+
+KeyValue ChargePointConfiguration::getMaxMessageSizeKeyValue() {
+    KeyValue kv;
+    kv.key = "MaxMessageSize";
+    kv.readonly = true;
+    kv.value.emplace(std::to_string(this->getMaxMessageSize()));
+    return kv;
+}
+
 KeyValue ChargePointConfiguration::getWebsocketPingPayloadKeyValue() {
     KeyValue kv;
     kv.key = "WebsocketPingPayload";
@@ -2344,6 +2356,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     }
     if (key == "SupportedMeasurands") {
         return this->getSupportedMeasurandsKeyValue();
+    }
+    if (key == "MaxMessageSize") {
+        return this->getMaxMessageSizeKeyValue();
     }
     if (key == "QueueAllMessages") {
         return this->getQueueAllMessagesKeyValue();

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3648,6 +3648,12 @@ void ChargePointImpl::stop_transaction(int32_t connector, Reason reason, std::op
     auto message_id = this->message_queue->createMessageId();
     ocpp::Call<StopTransactionRequest> call(req, message_id);
 
+    const auto max_message_size = this->configuration->getMaxMessageSize();
+    if (utils::get_message_size(call) > max_message_size) {
+        EVLOG_warning << "StopTransaction.req is too large. Dropping transaction data";
+        utils::drop_transaction_data(max_message_size, call);
+    }
+
     {
         std::lock_guard<std::mutex> lock(this->stop_transaction_mutex);
         this->send<StopTransactionRequest>(call);


### PR DESCRIPTION
## Describe your changes
Depending on the configuration of `MeterValueSampleInterval` , `ClockAlignedDataInterval`, `StopTxnSampledData` and `StopTxnAlignedData` the `transactionData` field of the `StopTransaction.req` message can become really large. 

Therefore the following changes have been added:
* Introduced new configuration key MaxMessageSize
* MaxMessageSize is used in the StopTransaction.req initiation and it is checked if the message to be sent exceeds this limit
* Every 2nd entry of `transactionData`  is dropped as long as the size of the message exceeds the value of `MaxMessageSize`
* First and last entries are never removed. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

