### PR TITLE
Plug&Charge authorization in case OCSP can not be generated

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2970,7 +2970,15 @@ ocpp::v201::AuthorizeResponse ChargePointImpl::data_transfer_pnc_authorize(
                     forward_to_csms = true;
                 } else {
                     EVLOG_warning << "Online: OCSP data could not be generated";
-                    authorize_response.idTokenInfo.status = ocpp::v201::AuthorizationStatusEnum::Invalid;
+                    if (central_contract_validation_allowed) {
+                        EVLOG_info << "Online: OCSP data could not be generated. Pass contract validation to CSMS";
+                        authorize_req.certificate = certificate.value();
+                        forward_to_csms = true;
+                    } else {
+                        EVLOG_warning
+                            << "Online: OCSP data could not be generated and CentralContractValidation not allowed";
+                        authorize_response.idTokenInfo.status = ocpp::v201::AuthorizationStatusEnum::Invalid;
+                    }
                 }
             }
         } else { // Offline

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -704,8 +704,15 @@ AuthorizeResponse ChargePoint::validate_token(const IdToken id_token, const std:
                         response = this->authorize_req(id_token, std::nullopt, generated_ocsp_request_data_list);
                         forwarded_to_csms = true;
                     } else {
-                        EVLOG_warning << "Online: OCSP data could not be generated";
-                        response.idTokenInfo.status = AuthorizationStatusEnum::Invalid;
+                        if (central_contract_validation_allowed) {
+                            EVLOG_info << "Online: OCSP data could not be generated. Pass contract validation to CSMS";
+                            response = this->authorize_req(id_token, certificate, std::nullopt);
+                            forwarded_to_csms = true;
+                        } else {
+                            EVLOG_warning
+                                << "Online: OCSP data could not be generated and CentralContractValidation not allowed";
+                            response.idTokenInfo.status = AuthorizationStatusEnum::Invalid;
+                        }
                     }
                 }
             } else { // Offline


### PR DESCRIPTION
## Describe your changes
Without this change, a Plug&Charge authorization request failed when the OCSP could not be generated, e.g. because the contract certificate chain did not contain any OCSP extension. Those contract certificates exist in the real world. This commit changes the behavior in case no OCSP data could be generated. If CentralContractValidationAllowed is true, the certificate is send as part of the Authorize.req instead of rejecting the request directly.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

