### PR TITLE
Bump version of liblog to v0.2.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -15,7 +15,7 @@ nlohmann_json_schema_validator:
     ]
 liblog:
   git: https://github.com/EVerest/liblog.git
-  git_tag: v0.2.1
+  git_tag: v0.2.2
   options: ["BUILD_EXAMPLES OFF"]
 libtimer:
   git: https://github.com/EVerest/libtimer.git


### PR DESCRIPTION
## Describe your changes
Bump version of liblog to prevent BUILD_TESTING=ON for liblog in case of BUILD_TESTING=ON for libocpp

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

