### PR TITLE
pause charging when maxEnergyOnInvalidId is equal

### DIFF
--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -311,7 +311,8 @@ void Evse::check_max_energy_on_invalid_id() {
         if (opt_energy_value.has_value() and active_energy_import_start_value.has_value()) {
             auto charged_energy = opt_energy_value.value() - active_energy_import_start_value.value();
 
-            if (charged_energy > static_cast<float>(max_energy_on_invalid_id.value())) {
+            // TODO float compare with epsilon
+            if (charged_energy >= static_cast<float>(max_energy_on_invalid_id.value())) {
                 this->pause_charging_callback();
                 transaction->check_max_active_import_energy = false; // No need to check anymore
             }


### PR DESCRIPTION
## Describe your changes

There is a oversight in the OCPP specifications

- C15.FR.06
- C15.FR.07
- E05.FR.02
- E05.FR.03

Each of them state:

> MaxEnergyOnInvalidId is set and has NOT been exceeded.

But for C15.FR.07 and  E05.FR.03 the requirement definition states:

> Energy delivery to the EV SHALL be allowed until the amount of energy specified in MaxEnergyOnInvalidId has been reached.

The intent seems to be reached in all cases, Lambert is requesting a change in the specification.

A added benefit of this change that a couple of OCTT test cases can be performed without a load.

## Issue ticket number and link

## Checklist before requesting a review
- [ x] I have performed a self-review of my code
- [ x] I have made corresponding changes to the documentation
- [ x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

