### PR TITLE
Add helper class holding the EVSE's

### DIFF
--- a/include/ocpp/common/custom_iterators.hpp
+++ b/include/ocpp/common/custom_iterators.hpp
@@ -8,28 +8,43 @@
 
 namespace ocpp {
 
+// This file contains the implementation of a couple of custom iterators, enabling the iteration and abstraction of more complex containers.
+// For example we want to be able to iterate a std::vector<std::unique_ptr<T>> and get references to T from the iterator
+//
+// ForwardIterator<T> implements a custom iterator for type T that does not depend on any underlying container.
+//   You can add this for your type by returning ForwardIterator<T> from begin() and end()
+// ForwardIterator can only be constructed by passing a ForwardIteratorBase derived struct in a unique_ptr.
+//   ForwardIteratorBase is an abstract class that allows us to implement container specific functionality.
+// VectorOfUniquePtrIterator is an implementation of the ForwardIteratorBase specifically catered to the example of std::vector<std:unique_ptr<T>>
+//   So to implement the begin() and end() functions for your type, you could do the following:
+//   std::vector<std::unique_ptr<T>> container;
+//   ForwardIterator<T> begin() {
+//       return ForwardIterator<T>(std::make_unique<VectorOfUniquePtrIterator<T>>(container.begin()));
+//   }
+
+/// \brief Abstract struct to implement to enable the use of the ForwardIterator<T>
+template <typename T> struct ForwardIteratorBase {
+    virtual ~ForwardIteratorBase() = default;
+
+    /// \brief Get a reference to the value pointed to by the iterator
+    virtual T& deref() const = 0;
+    /// \brief Increment the iterator once to the next position
+    virtual void advance() = 0;
+    /// \brief Check for equality between this iterator and \p other
+    virtual bool not_equal(const ForwardIteratorBase& other) = 0;
+};
+
 /// \brief Helper struct that allows the of an iterator in an interface, can be implemented using any forward iterator
-template <typename T> struct ForwardIteratorWrapper {
+template <typename T> struct ForwardIterator {
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = T;
     using pointer = value_type*;
     using reference = value_type&;
-
-    /// \brief Abstract struct to implement to enable the use of this iterator wrapper
-    struct Base {
-        virtual ~Base() = default;
-
-        /// \brief Get a reference to the value pointed to by the iterator
-        virtual reference deref() const = 0;
-        /// \brief Increment the iterator once to the next position
-        virtual void advance() = 0;
-        /// \brief Check for equality between this iterator and \p other
-        virtual bool not_equal(const Base& other) = 0;
-    };
+    using base = ForwardIteratorBase<T>;
 
     /// \brief Construct a new wrapper using any type that implements the abstract struct Base
-    explicit ForwardIteratorWrapper(std::unique_ptr<Base> it) : it{std::move(it)} {
+    explicit ForwardIterator(std::unique_ptr<base> it) : it{std::move(it)} {
     }
 
     /// \brief Get a reference to the value pointed to by the iterator
@@ -38,30 +53,29 @@ template <typename T> struct ForwardIteratorWrapper {
     };
 
     /// \brief Increment the iterator once to the next position
-    ForwardIteratorWrapper& operator++() {
+    ForwardIterator& operator++() {
         it->advance();
         return *this;
     }
 
     /// \brief Check for inequality between this \p a and \p b
-    friend bool operator!=(const ForwardIteratorWrapper& a, const ForwardIteratorWrapper& b) {
+    friend bool operator!=(const ForwardIterator& a, const ForwardIterator& b) {
         return a.it->not_equal(*b.it);
     };
 
 private:
-    std::unique_ptr<Base> it;
+    std::unique_ptr<base> it;
 };
 
-/// \brief Implementation for the ForwardIteratorWrapper based on a vector of unique_ptr with type T
-template <typename T> struct UniquePtrVectorIterator : ForwardIteratorWrapper<T>::Base {
+/// \brief Implementation for the ForwardIteratorBase based on a vector of unique_ptr with type T
+template <typename T> struct VectorOfUniquePtrIterator : ForwardIteratorBase<T> {
     using iterator_type = typename std::vector<std::unique_ptr<T>>::iterator;
-    using reference = typename ForwardIteratorWrapper<T>::reference;
-    using base = typename ForwardIteratorWrapper<T>::Base;
+    using base = ForwardIteratorBase<T>;
 
-    explicit UniquePtrVectorIterator(iterator_type it) : it{it} {
+    explicit VectorOfUniquePtrIterator(iterator_type it) : it{it} {
     }
 
-    reference deref() const override {
+    T& deref() const override {
         return *it->get();
     }
 
@@ -70,7 +84,7 @@ template <typename T> struct UniquePtrVectorIterator : ForwardIteratorWrapper<T>
     }
 
     bool not_equal(const base& other) override {
-        return it != dynamic_cast<const UniquePtrVectorIterator&>(other).it;
+        return it != dynamic_cast<const VectorOfUniquePtrIterator&>(other).it;
     }
 
 private:

--- a/include/ocpp/common/custom_iterators.hpp
+++ b/include/ocpp/common/custom_iterators.hpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace ocpp {
+
+/// \brief Helper struct that allows the of an iterator in an interface, can be implemented using any forward iterator
+template <typename T> struct ForwardIteratorWrapper {
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    /// \brief Abstract struct to implement to enable the use of this iterator wrapper
+    struct Base {
+        virtual ~Base() = default;
+
+        /// \brief Get a reference to the value pointed to by the iterator
+        virtual reference deref() const = 0;
+        /// \brief Increment the iterator once to the next position
+        virtual void advance() = 0;
+        /// \brief Check for equality between this iterator and \p other
+        virtual bool not_equal(const Base& other) = 0;
+    };
+
+    /// \brief Construct a new wrapper using any type that implements the abstract struct Base
+    explicit ForwardIteratorWrapper(std::unique_ptr<Base> it) : it{std::move(it)} {
+    }
+
+    /// \brief Get a reference to the value pointed to by the iterator
+    reference operator*() const {
+        return it->deref();
+    };
+
+    /// \brief Increment the iterator once to the next position
+    ForwardIteratorWrapper& operator++() {
+        it->advance();
+        return *this;
+    }
+
+    /// \brief Check for inequality between this \p a and \p b
+    friend bool operator!=(const ForwardIteratorWrapper& a, const ForwardIteratorWrapper& b) {
+        return a.it->not_equal(*b.it);
+    };
+
+private:
+    std::unique_ptr<Base> it;
+};
+
+/// \brief Implementation for the ForwardIteratorWrapper based on a vector of unique_ptr with type T
+template <typename T> struct UniquePtrVectorIterator : ForwardIteratorWrapper<T>::Base {
+    using iterator_type = typename std::vector<std::unique_ptr<T>>::iterator;
+    using reference = typename ForwardIteratorWrapper<T>::reference;
+    using base = typename ForwardIteratorWrapper<T>::Base;
+
+    explicit UniquePtrVectorIterator(iterator_type it) : it{it} {
+    }
+
+    reference deref() const override {
+        return *it->get();
+    }
+
+    void advance() override {
+        ++it;
+    }
+
+    bool not_equal(const base& other) override {
+        return it != dynamic_cast<const UniquePtrVectorIterator&>(other).it;
+    }
+
+private:
+    iterator_type it;
+};
+
+} // namespace ocpp

--- a/include/ocpp/common/custom_iterators.hpp
+++ b/include/ocpp/common/custom_iterators.hpp
@@ -8,14 +8,16 @@
 
 namespace ocpp {
 
-// This file contains the implementation of a couple of custom iterators, enabling the iteration and abstraction of more complex containers.
-// For example we want to be able to iterate a std::vector<std::unique_ptr<T>> and get references to T from the iterator
+// This file contains the implementation of a couple of custom iterators, enabling the iteration and abstraction of more
+// complex containers. For example we want to be able to iterate a std::vector<std::unique_ptr<T>> and get references to
+// T from the iterator
 //
 // ForwardIterator<T> implements a custom iterator for type T that does not depend on any underlying container.
 //   You can add this for your type by returning ForwardIterator<T> from begin() and end()
 // ForwardIterator can only be constructed by passing a ForwardIteratorBase derived struct in a unique_ptr.
 //   ForwardIteratorBase is an abstract class that allows us to implement container specific functionality.
-// VectorOfUniquePtrIterator is an implementation of the ForwardIteratorBase specifically catered to the example of std::vector<std:unique_ptr<T>>
+// VectorOfUniquePtrIterator is an implementation of the ForwardIteratorBase specifically catered to the example of
+// std::vector<std:unique_ptr<T>>
 //   So to implement the begin() and end() functions for your type, you could do the following:
 //   std::vector<std::unique_ptr<T>> container;
 //   ForwardIterator<T> begin() {
@@ -34,7 +36,8 @@ template <typename T> struct ForwardIteratorBase {
     virtual bool not_equal(const ForwardIteratorBase& other) = 0;
 };
 
-/// \brief Helper struct that allows the of an iterator in an interface, can be implemented using any forward iterator
+/// \brief Helper struct that allows the use of an iterator in an interface, can be implemented using any forward
+/// iterator
 template <typename T> struct ForwardIterator {
     using iterator_category = std::forward_iterator_tag;
     using difference_type = std::ptrdiff_t;

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -28,7 +28,7 @@ private:
 /// \brief Class used to access the Evse instances
 class EvseManagerInterface {
 public:
-    using EvseIterator = ForwardIteratorWrapper<EvseInterface>;
+    using EvseIterator = ForwardIterator<EvseInterface>;
 
     /// \brief Default destructor
     virtual ~EvseManagerInterface() = default;

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <ocpp/common/custom_iterators.hpp>
+#include <ocpp/v201/evse.hpp>
+
+namespace ocpp {
+namespace v201 {
+
+/// \brief Exception used when an evse that does not exist is accessed.
+class EvseOutOfRangeException : public std::exception {
+public:
+    explicit EvseOutOfRangeException(int32_t id) : msg{"Evse with id " + std::to_string(id) + " does not exist"} {
+    }
+
+    ~EvseOutOfRangeException() noexcept override = default;
+
+    const char* what() const noexcept override {
+        return msg.c_str();
+    }
+
+private:
+    std::string msg;
+};
+
+/// \brief Class used to access the Evse instances
+class EvseManagerInterface {
+public:
+    using EvseIterator = ForwardIteratorWrapper<EvseInterface>;
+
+    /// \brief Default destructor
+    virtual ~EvseManagerInterface() = default;
+
+    /// \brief Get a reference to the evse with \p id
+    /// \note If \p id is not present this could throw an EvseOutOfRangeException
+    virtual EvseInterface& get_evse(int32_t id) = 0;
+
+    /// \brief Get a const reference to the evse with \p id
+    /// \note If \p id is not present this could throw an EvseOutOfRangeException
+    virtual const EvseInterface& get_evse(int32_t id) const = 0;
+
+    /// \brief Check if an evse with \p id exists
+    virtual bool does_evse_exist(int32_t id) const = 0;
+
+    /// \brief Gets an iterator pointing to the first evse
+    virtual EvseIterator begin() = 0;
+    /// \brief Gets an iterator pointing past the last evse
+    virtual EvseIterator end() = 0;
+};
+
+class EvseManager : public EvseManagerInterface {
+private:
+    std::vector<std::unique_ptr<EvseInterface>> evses;
+
+public:
+    EvseManager(const std::map<int32_t, int32_t>& evse_connector_structure, DeviceModel& device_model,
+                std::shared_ptr<DatabaseHandler> database_handler,
+                std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
+                const std::function<void(const MeterValue& meter_value, EnhancedTransaction& transaction)>&
+                    transaction_meter_value_req,
+                const std::function<void(int32_t evse_id)>& pause_charging_callback);
+
+    EvseInterface& get_evse(int32_t id) override;
+    const EvseInterface& get_evse(int32_t id) const override;
+
+    bool does_evse_exist(int32_t id) const override;
+
+    EvseIterator begin() override;
+    EvseIterator end() override;
+};
+
+} // namespace v201
+} // namespace ocpp

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -64,8 +64,7 @@ private:
     std::vector<ChargingProfile> station_wide_charging_profiles;
 
 public:
-    SmartChargingHandler(EvseManagerInterface& evse_manager,
-                         std::shared_ptr<DeviceModel>& device_model);
+    SmartChargingHandler(EvseManagerInterface& evse_manager, std::shared_ptr<DeviceModel>& device_model);
 
     ///
     /// \brief validates the given \p profile according to the specification.

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -10,7 +10,7 @@
 
 #include <memory>
 #include <ocpp/v201/database_handler.hpp>
-#include <ocpp/v201/evse.hpp>
+#include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/transaction.hpp>
 
@@ -55,7 +55,7 @@ std::ostream& operator<<(std::ostream& os, const ProfileValidationResultEnum val
 /// to calculate the composite schedules
 class SmartChargingHandler {
 private:
-    std::map<int32_t, std::unique_ptr<EvseInterface>>& evses;
+    EvseManagerInterface& evse_manager;
     std::shared_ptr<DeviceModel>& device_model;
 
     std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler;
@@ -64,8 +64,8 @@ private:
     std::vector<ChargingProfile> station_wide_charging_profiles;
 
 public:
-    explicit SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
-                                  std::shared_ptr<DeviceModel>& device_model);
+    SmartChargingHandler(EvseManagerInterface& evse_manager,
+                         std::shared_ptr<DeviceModel>& device_model);
 
     ///
     /// \brief validates the given \p profile according to the specification.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -63,6 +63,7 @@ if(LIBOCPP_ENABLE_V201)
             ocpp/v201/device_model_storage_sqlite.cpp
             ocpp/v201/enums.cpp
             ocpp/v201/evse.cpp
+            ocpp/v201/evse_manager.cpp
             ocpp/v201/init_device_model_db.cpp
             ocpp/v201/notify_report_requests_splitter.cpp
             ocpp/v201/message_queue.cpp

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -6,7 +6,7 @@
 namespace ocpp {
 namespace v201 {
 
-using EvseIteratorImpl = UniquePtrVectorIterator<EvseInterface>;
+using EvseIteratorImpl = VectorOfUniquePtrIterator<EvseInterface>;
 
 EvseManager::EvseManager(const std::map<int32_t, int32_t>& evse_connector_structure, DeviceModel& device_model,
                          std::shared_ptr<DatabaseHandler> database_handler,

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v201/evse_manager.hpp>
+
+namespace ocpp {
+namespace v201 {
+
+using EvseIteratorImpl = UniquePtrVectorIterator<EvseInterface>;
+
+EvseManager::EvseManager(const std::map<int32_t, int32_t>& evse_connector_structure, DeviceModel& device_model,
+                         std::shared_ptr<DatabaseHandler> database_handler,
+                         std::shared_ptr<ComponentStateManagerInterface> component_state_manager,
+                         const std::function<void(const MeterValue& meter_value, EnhancedTransaction& transaction)>&
+                             transaction_meter_value_req,
+                         const std::function<void(int32_t evse_id)>& pause_charging_callback) {
+    evses.reserve(evse_connector_structure.size());
+    for (const auto& [evse_id, connectors] : evse_connector_structure) {
+        evses.push_back(std::make_unique<Evse>(evse_id, connectors, device_model, database_handler,
+                                               component_state_manager, transaction_meter_value_req,
+                                               pause_charging_callback));
+    }
+}
+
+EvseManager::EvseIterator EvseManager::begin() {
+    return EvseIterator(std::make_unique<EvseIteratorImpl>(this->evses.begin()));
+}
+EvseManager::EvseIterator EvseManager::end() {
+    return EvseIterator(std::make_unique<EvseIteratorImpl>(this->evses.end()));
+}
+
+EvseInterface& EvseManager::get_evse(int32_t id) {
+    if (id > this->evses.size()) {
+        throw EvseOutOfRangeException(id);
+    }
+    return *this->evses.at(id - 1);
+}
+
+const EvseInterface& EvseManager::get_evse(int32_t id) const {
+    if (id > this->evses.size()) {
+        throw EvseOutOfRangeException(id);
+    }
+    return *this->evses.at(id - 1);
+}
+
+bool EvseManager::does_evse_exist(int32_t id) const {
+    return id <= this->evses.size();
+}
+
+} // namespace v201
+} // namespace ocpp

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -113,7 +113,7 @@ ProfileValidationResultEnum SmartChargingHandler::validate_profile(ChargingProfi
     }
 
     if (evse_id != STATION_WIDE_ID) {
-        auto& evse = *evses[evse_id];
+        auto& evse = evse_manager.get_evse(evse_id);
         result = this->validate_profile_schedules(profile, &evse);
     } else {
         result = this->validate_profile_schedules(profile);
@@ -204,7 +204,7 @@ ProfileValidationResultEnum SmartChargingHandler::validate_tx_profile(const Char
         return result;
     }
 
-    auto& evse = *evses[evse_id];
+    auto& evse = evse_manager.get_evse(evse_id);
     if (!evse.has_active_transaction()) {
         return ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction;
     }

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -96,9 +96,9 @@ CurrentPhaseType SmartChargingHandler::get_current_phase_type(const std::optiona
     return CurrentPhaseType::Unknown;
 }
 
-SmartChargingHandler::SmartChargingHandler(std::map<int32_t, std::unique_ptr<EvseInterface>>& evses,
+SmartChargingHandler::SmartChargingHandler(EvseManagerInterface& evse_manager,
                                            std::shared_ptr<DeviceModel>& device_model) :
-    evses(evses), device_model(device_model) {
+    evse_manager(evse_manager), device_model(device_model) {
 }
 
 ProfileValidationResultEnum SmartChargingHandler::validate_profile(ChargingProfile& profile, int32_t evse_id) {
@@ -144,8 +144,8 @@ ProfileValidationResultEnum SmartChargingHandler::validate_profile(ChargingProfi
 }
 
 ProfileValidationResultEnum SmartChargingHandler::validate_evse_exists(int32_t evse_id) const {
-    return evses.find(evse_id) == evses.end() ? ProfileValidationResultEnum::EvseDoesNotExist
-                                              : ProfileValidationResultEnum::Valid;
+    return evse_manager.does_evse_exist(evse_id) ? ProfileValidationResultEnum::Valid
+                                                 : ProfileValidationResultEnum::EvseDoesNotExist;
 }
 
 ProfileValidationResultEnum SmartChargingHandler::validate_charging_station_max_profile(const ChargingProfile& profile,

--- a/tests/lib/ocpp/v201/mocks/component_state_manager_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/component_state_manager_mock.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
 
 #include <gmock/gmock.h>
 

--- a/tests/lib/ocpp/v201/mocks/device_model_storage_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/device_model_storage_mock.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
 
 #include <gmock/gmock.h>
 

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -12,7 +12,7 @@ namespace ocpp::v201 {
 
 class EvseManagerFake : public EvseManagerInterface {
 private:
-    using EvseIteratorImpl = UniquePtrVectorIterator<EvseInterface>;
+    using EvseIteratorImpl = VectorOfUniquePtrIterator<EvseInterface>;
 
     std::vector<std::unique_ptr<EvseInterface>> evses;
     std::vector<std::unique_ptr<EnhancedTransaction>> transactions;
@@ -54,7 +54,7 @@ public:
         return id <= this->evses.size();
     }
 
-    void open_transaction(int evse_id, std::string transaction_id) {
+    void open_transaction(int evse_id, const std::string& transaction_id) {
         auto& transaction = this->transactions.at(evse_id - 1);
         transaction = std::make_unique<EnhancedTransaction>();
         transaction->transactionId = transaction_id;

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include <evse_mock.hpp>
+#include <ocpp/v201/evse_manager.hpp>
+
+namespace ocpp::v201 {
+
+class EvseManagerFake : public EvseManagerInterface {
+private:
+    using EvseIteratorImpl = UniquePtrVectorIterator<EvseInterface>;
+
+    std::vector<std::unique_ptr<EvseInterface>> evses;
+    std::vector<std::unique_ptr<EnhancedTransaction>> transactions;
+
+public:
+    explicit EvseManagerFake(size_t nr_of_evses) {
+        transactions.resize(nr_of_evses);
+        for (size_t i = 0; i < nr_of_evses; i++) {
+            auto mock = std::make_unique<EvseMock>();
+            ON_CALL(*mock, get_id).WillByDefault(testing::Return(i + 1));
+            ON_CALL(*mock, get_transaction).WillByDefault(testing::ReturnRef(this->transactions.at(i)));
+            ON_CALL(*mock, has_active_transaction()).WillByDefault(testing::Return(false));
+            evses.push_back(std::move(mock));
+        }
+    }
+
+    EvseIterator begin() override {
+        return EvseIterator(std::make_unique<EvseIteratorImpl>(this->evses.begin()));
+    }
+    EvseIterator end() override {
+        return EvseIterator(std::make_unique<EvseIteratorImpl>(this->evses.end()));
+    }
+
+    EvseInterface& get_evse(int32_t id) override {
+        if (id > this->evses.size()) {
+            throw EvseOutOfRangeException(id);
+        }
+        return *this->evses.at(id - 1);
+    }
+
+    const EvseInterface& get_evse(int32_t id) const override {
+        if (id > this->evses.size()) {
+            throw EvseOutOfRangeException(id);
+        }
+        return *this->evses.at(id - 1);
+    }
+
+    bool does_evse_exist(int32_t id) const override {
+        return id <= this->evses.size();
+    }
+
+    void open_transaction(int evse_id, std::string transaction_id) {
+        auto& transaction = this->transactions.at(evse_id - 1);
+        transaction = std::make_unique<EnhancedTransaction>();
+        transaction->transactionId = transaction_id;
+
+        auto& mock = this->get_mock(evse_id);
+        EXPECT_CALL(mock, get_transaction).WillRepeatedly(testing::ReturnRef(this->transactions.at(evse_id - 1)));
+        EXPECT_CALL(mock, has_active_transaction()).WillRepeatedly(testing::Return(true));
+    }
+
+    EvseMock& get_mock(int32_t evse_id) {
+        return dynamic_cast<EvseMock&>(*evses.at(evse_id - 1).get());
+    }
+};
+
+} // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/mocks/evse_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_mock.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#pragma once
 
 #include "gmock/gmock.h"
 
@@ -8,8 +10,8 @@
 namespace ocpp::v201 {
 class EvseMock : public EvseInterface {
 public:
-    MOCK_METHOD(EVSE, get_evse_info, ());
-    MOCK_METHOD(uint32_t, get_number_of_connectors, ());
+    MOCK_METHOD(int32_t, get_id, (), (const));
+    MOCK_METHOD(uint32_t, get_number_of_connectors, (), (const));
     MOCK_METHOD(void, open_transaction,
                 (const std::string& transaction_id, const int32_t connector_id, const DateTime& timestamp,
                  const MeterValue& meter_start, const std::optional<IdToken>& id_token,
@@ -21,8 +23,8 @@ public:
     MOCK_METHOD(void, close_transaction,
                 (const DateTime& timestamp, const MeterValue& meter_stop, const ReasonEnum& reason));
     MOCK_METHOD(void, start_checking_max_energy_on_invalid_id, ());
-    MOCK_METHOD(bool, has_active_transaction, ());
-    MOCK_METHOD(bool, has_active_transaction, (int32_t connector_id));
+    MOCK_METHOD(bool, has_active_transaction, (), (const));
+    MOCK_METHOD(bool, has_active_transaction, (int32_t connector_id), (const));
     MOCK_METHOD(void, release_transaction, ());
     MOCK_METHOD(std::unique_ptr<EnhancedTransaction>&, get_transaction, ());
     MOCK_METHOD(void, submit_event, (const int32_t connector_id, ConnectorEvent event));

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -812,7 +812,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfEvseDoesNotExist_ThenPr
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID + 1);
+    auto sut = handler.validate_profile(profile, NR_OF_EVSES + 1);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::EvseDoesNotExist));
 }


### PR DESCRIPTION
## Describe your changes

I've noticed the pattern of sharing a references to maps holding unique_ptrs and sharing references to unique_ptrs themselves and though we are exposing to much in that way. The map can be changed most of the time and the ptrs influenced as well.

This change adds a new class that holds the EVSE classes and only exposes them in a way that they are not mutable. This class is then much more easy to pass along to other users of the EVSEs.

I also added a specific exception when trying to access an EVSE with an invalid evse_id.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

