### PR TITLE
Add option to disable compilation of v16 or v201 if you have no need for one of those 2 options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,13 @@ option(LIBOCPP_BUILD_EXAMPLES "Build charge_point and central_system binaries." 
 option(OCPP_INSTALL "Install the library (shared data might be installed anyway)" ${EVC_MAIN_PROJECT})
 option(LIBOCPP_ENABLE_DEPRECATED_WEBSOCKETPP "Usage of deprecated websocket++ instead of libwebsockets" OFF)
 
+option(LIBOCPP_ENABLE_V16 "Enable OCPP 1.6 in the ocpp library" ON)
+option(LIBOCPP_ENABLE_V201 "Enable OCPP 2.0.1 in the ocpp library" ON)
+
+if((NOT LIBOCPP_ENABLE_V16) AND (NOT LIBOCPP_ENABLE_V201))
+    message(FATAL_ERROR "At least one of LIBOCPP_ENABLE_V16 and LIBOCPP_ENABLE_V201 needs to be ON")
+endif()
+
 if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TESTING) AND BUILD_TESTING)
     set(LIBOCPP_BUILD_TESTING ON)
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,6 +39,7 @@ if(LIBOCPP_ENABLE_V16)
             ocpp/v16/smart_charging.cpp
             ocpp/v16/charge_point_configuration.cpp
             ocpp/v16/charge_point_state_machine.cpp
+            ocpp/v16/message_queue.cpp
             ocpp/v16/profile.cpp
             ocpp/v16/transaction.cpp
             ocpp/v16/enums.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,7 +18,6 @@ target_sources(ocpp
     PRIVATE
         ocpp/common/call_types.cpp
         ocpp/common/charging_station_base.cpp
-        ocpp/common/message_queue.cpp
         ocpp/common/ocpp_logging.cpp
         ocpp/common/schemas.cpp
         ocpp/common/types.cpp
@@ -29,39 +28,52 @@ target_sources(ocpp
         ocpp/common/database/database_handler_common.cpp
         ocpp/common/database/database_schema_updater.cpp
         ocpp/common/database/sqlite_statement.cpp
-        ocpp/v16/charge_point.cpp
-        ocpp/v16/database_handler.cpp
-        ocpp/v16/charge_point_impl.cpp
-        ocpp/v16/smart_charging.cpp
-        ocpp/v16/charge_point_configuration.cpp
-        ocpp/v16/charge_point_state_machine.cpp
-        ocpp/v16/profile.cpp
-        ocpp/v16/transaction.cpp
-        ocpp/v16/enums.cpp
-        ocpp/v16/ocpp_types.cpp
-        ocpp/v16/types.cpp
-        ocpp/v201/average_meter_values.cpp
-        ocpp/v201/charge_point.cpp
-        ocpp/v201/smart_charging.cpp
-        ocpp/v201/connector.cpp
-        ocpp/v201/ctrlr_component_variables.cpp
-        ocpp/v201/database_handler.cpp
-        ocpp/v201/device_model.cpp
-        ocpp/v201/device_model_storage_sqlite.cpp
-        ocpp/v201/enums.cpp
-        ocpp/v201/evse.cpp
-        ocpp/v201/notify_report_requests_splitter.cpp
-        ocpp/v201/ocpp_types.cpp
-        ocpp/v201/ocsp_updater.cpp
-        ocpp/v201/transaction.cpp
-        ocpp/v201/types.cpp
-        ocpp/v201/utils.cpp
-        ocpp/v201/component_state_manager.cpp
 )
 
+if(LIBOCPP_ENABLE_V16)
+    target_sources(ocpp
+        PRIVATE
+            ocpp/v16/charge_point.cpp
+            ocpp/v16/database_handler.cpp
+            ocpp/v16/charge_point_impl.cpp
+            ocpp/v16/smart_charging.cpp
+            ocpp/v16/charge_point_configuration.cpp
+            ocpp/v16/charge_point_state_machine.cpp
+            ocpp/v16/profile.cpp
+            ocpp/v16/transaction.cpp
+            ocpp/v16/enums.cpp
+            ocpp/v16/ocpp_types.cpp
+            ocpp/v16/types.cpp
+    )
+    add_subdirectory(ocpp/v16/messages)
+endif()
+
+if(LIBOCPP_ENABLE_V201)
+    target_sources(ocpp
+        PRIVATE
+            ocpp/v201/average_meter_values.cpp
+            ocpp/v201/charge_point.cpp
+            ocpp/v201/smart_charging.cpp
+            ocpp/v201/connector.cpp
+            ocpp/v201/ctrlr_component_variables.cpp
+            ocpp/v201/database_handler.cpp
+            ocpp/v201/device_model.cpp
+            ocpp/v201/device_model_storage_sqlite.cpp
+            ocpp/v201/enums.cpp
+            ocpp/v201/evse.cpp
+            ocpp/v201/notify_report_requests_splitter.cpp
+            ocpp/v201/message_queue.cpp
+            ocpp/v201/ocpp_types.cpp
+            ocpp/v201/ocsp_updater.cpp
+            ocpp/v201/transaction.cpp
+            ocpp/v201/types.cpp
+            ocpp/v201/utils.cpp
+            ocpp/v201/component_state_manager.cpp
+    )
+    add_subdirectory(ocpp/v201/messages)
+endif()
+
 add_subdirectory(ocpp/common/websocket)
-add_subdirectory(ocpp/v16/messages)
-add_subdirectory(ocpp/v201/messages)
 
 option(LIBOCPP_USE_BOOST_FILESYSTEM "Usage of boost/filesystem.hpp instead of std::filesystem" OFF)
 

--- a/lib/ocpp/v16/message_queue.cpp
+++ b/lib/ocpp/v16/message_queue.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/common/message_queue.hpp>
+
+#include <everest/logging.hpp>
+
+namespace ocpp {
+
+template <> ControlMessage<v16::MessageType>::ControlMessage(const json& message) {
+    this->message = message.get<json::array_t>();
+    this->messageType = v16::conversions::string_to_messagetype(message.at(CALL_ACTION));
+    this->message_attempts = 0;
+    this->initial_unique_id = this->message[MESSAGE_ID];
+}
+
+template <> bool ControlMessage<v16::MessageType>::isTransactionMessage() const {
+    if (this->messageType == v16::MessageType::StartTransaction ||
+        this->messageType == v16::MessageType::StopTransaction || this->messageType == v16::MessageType::MeterValues ||
+        this->messageType == v16::MessageType::SecurityEventNotification) {
+        return true;
+    }
+    return false;
+}
+
+template <> bool ControlMessage<v16::MessageType>::isTransactionUpdateMessage() const {
+    return (this->messageType == v16::MessageType::MeterValues);
+}
+
+template <> bool ControlMessage<v16::MessageType>::isBootNotificationMessage() const {
+    return this->messageType == v16::MessageType::BootNotification;
+}
+
+template <> v16::MessageType MessageQueue<v16::MessageType>::string_to_messagetype(const std::string& s) {
+    return v16::conversions::string_to_messagetype(s);
+}
+
+template <> std::string MessageQueue<v16::MessageType>::messagetype_to_string(v16::MessageType m) {
+    return v16::conversions::messagetype_to_string(m);
+}
+
+} // namespace ocpp

--- a/lib/ocpp/v201/message_queue.cpp
+++ b/lib/ocpp/v201/message_queue.cpp
@@ -7,30 +7,6 @@
 
 namespace ocpp {
 
-template <> ControlMessage<v16::MessageType>::ControlMessage(const json& message) {
-    this->message = message.get<json::array_t>();
-    this->messageType = v16::conversions::string_to_messagetype(message.at(CALL_ACTION));
-    this->message_attempts = 0;
-    this->initial_unique_id = this->message[MESSAGE_ID];
-}
-
-template <> bool ControlMessage<v16::MessageType>::isTransactionMessage() const {
-    if (this->messageType == v16::MessageType::StartTransaction ||
-        this->messageType == v16::MessageType::StopTransaction || this->messageType == v16::MessageType::MeterValues ||
-        this->messageType == v16::MessageType::SecurityEventNotification) {
-        return true;
-    }
-    return false;
-}
-
-template <> bool ControlMessage<v16::MessageType>::isTransactionUpdateMessage() const {
-    return (this->messageType == v16::MessageType::MeterValues);
-}
-
-template <> bool ControlMessage<v16::MessageType>::isBootNotificationMessage() const {
-    return this->messageType == v16::MessageType::BootNotification;
-}
-
 template <> ControlMessage<v201::MessageType>::ControlMessage(const json& message) {
     this->message = message.get<json::array_t>();
     this->messageType = v201::conversions::string_to_messagetype(message.at(CALL_ACTION));
@@ -58,16 +34,8 @@ template <> bool ControlMessage<v201::MessageType>::isBootNotificationMessage() 
     return this->messageType == v201::MessageType::BootNotification;
 }
 
-template <> v16::MessageType MessageQueue<v16::MessageType>::string_to_messagetype(const std::string& s) {
-    return v16::conversions::string_to_messagetype(s);
-}
-
 template <> v201::MessageType MessageQueue<v201::MessageType>::string_to_messagetype(const std::string& s) {
     return v201::conversions::string_to_messagetype(s);
-}
-
-template <> std::string MessageQueue<v16::MessageType>::messagetype_to_string(v16::MessageType m) {
-    return v16::conversions::messagetype_to_string(m);
 }
 
 template <> std::string MessageQueue<v201::MessageType>::messagetype_to_string(const v201::MessageType m) {


### PR DESCRIPTION
## Describe your changes

Instead of adding a bunch of layers to the CMake libraries I've used options instead since they are more easily integrated.
Added options `LIBOCPP_ENABLE_V16` and `LIBOCPP_ENABLE_V201` which default to `ON`. Set to `OFF` to disable compilation of one of the parts.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

