### PR TITLE
Refactored OCPP16 error handling in state machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.12.0
+    VERSION 0.13.0
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -7,6 +7,7 @@
 #include <ocpp/common/evse_security.hpp>
 #include <ocpp/common/evse_security_impl.hpp>
 #include <ocpp/common/support_older_cpp_versions.hpp>
+#include <ocpp/v16/charge_point_state_machine.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/smart_charging.hpp>
 #include <ocpp/v16/types.hpp>
@@ -240,28 +241,28 @@ public:
     /// \param connector
     void on_resume_charging(int32_t connector);
 
-    /// \brief This function should be called if an error with the given \p error_code is present. This function will
-    /// trigger a StatusNotification.req containing the given \p error_code . It will not change the present state of
-    /// the state machine.
+    /// \brief This function should be called if an error with the given \p error_info is present. This function will
+    /// trigger a StatusNotification.req containing the given \p error_info . It will change the present state of
+    /// the state machine to faulted, in case the corresponding flag is set in the given \p error_info. This function
+    /// can be called multiple times for different errors. Errors reported using this function stay active as long as
+    /// they are cleared by \ref on_error_cleared().
     /// \param connector
-    /// \param error_code
-    /// \param info Additional free format information related to the error
-    /// \param vendor_id This identifies the vendor-specific implementation
-    /// \param vendor_error_code This contains the vendor-specific error code
-    void on_error(int32_t connector, const ChargePointErrorCode& error_code,
-                  const std::optional<CiString<50>>& info = std::nullopt,
-                  const std::optional<CiString<255>>& vendor_id = std::nullopt,
-                  const std::optional<CiString<50>>& vendor_error_code = std::nullopt);
+    /// \param error_info Additional information related to
+    /// the error
+    void on_error(int32_t connector, const ErrorInfo& error_info);
 
-    /// \brief This function should be called if a fault is detected that prevents further charging operations. The \p
-    /// error_code indicates the reason for the fault.
-    /// \param info Additional free format information related to the error
-    /// \param vendor_id This identifies the vendor-specific implementation
-    /// \param vendor_error_code This contains the vendor-specific error code
-    void on_fault(int32_t connector, const ChargePointErrorCode& error_code,
-                  const std::optional<CiString<50>>& info = std::nullopt,
-                  const std::optional<CiString<255>>& vendor_id = std::nullopt,
-                  const std::optional<CiString<50>>& vendor_error_code = std::nullopt);
+    /// \brief This function should be called if an error with the given \p uuid has been cleared. If this leads to the
+    /// fact that no other error is active anymore, this function will initiate a StatusNotification.req that reports
+    /// the current state and no error
+    ///  \param connector
+    /// \param uuid of a previously reported error. If uuid is not
+    /// known, the event will be ignored
+    void on_error_cleared(int32_t connector, const std::string uuid);
+
+    /// \brief Clears all previously reported errors at the same time for the given \p connector . This will
+    /// clear a previously reported "Faulted" state if present
+    ///  \param connector
+    void on_all_errors_cleared(int32_t connector);
 
     /// \brief Chargepoint notifies about new log status \p log_status . This function should be called during a
     /// Diagnostics / Log upload to indicate the current \p log_status .

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -21,7 +21,6 @@
 #include <ocpp/common/types.hpp>
 #include <ocpp/common/websocket/websocket.hpp>
 #include <ocpp/v16/charge_point_configuration.hpp>
-#include <ocpp/v16/charge_point_state_machine.hpp>
 #include <ocpp/v16/connector.hpp>
 #include <ocpp/v16/database_handler.hpp>
 #include <ocpp/v16/messages/Authorize.hpp>
@@ -546,24 +545,27 @@ public:
     /// \param connector
     void on_resume_charging(int32_t connector);
 
-    /// \brief This function should be called if an error with the given \p error_code is present. This function will
-    /// trigger a StatusNotification.req containing the given \p error_code . It will not change the present state of
-    /// the state machine.
+    /// \brief This function should be called if an error with the given \p error_info is present. This function will
+    /// trigger a StatusNotification.req containing the given \p error_info . It will change the present state of
+    /// the state machine to faulted, in case the corresponding flag is set in the given \p error_info. This function
+    /// can be called multiple times for different errors. Errors reported using this function stay active as long as
+    /// they are cleared by \ref on_error_cleared().
     /// \param connector
-    /// \param error_code
-    /// \param info Additional free format information related to the error
-    /// \param vendor_id This identifies the vendor-specific implementation
-    /// \param vendor_error_code This contains the vendor-specific error code
-    void on_error(int32_t connector, const ChargePointErrorCode& error_code, const std::optional<CiString<50>>& info,
-                  const std::optional<CiString<255>>& vendor_id, const std::optional<CiString<50>>& vendor_error_code);
+    /// \param error_info Additional information related to the error
+    void on_error(int32_t connector, const ErrorInfo& error_info);
 
-    /// \brief This function should be called if a fault is detected that prevents further charging operations. The \p
-    /// error_code indicates the reason for the fault.
-    /// \param info Additional free format information related to the error
-    /// \param vendor_id This identifies the vendor-specific implementation
-    /// \param vendor_error_code This contains the vendor-specific error code
-    void on_fault(int32_t connector, const ChargePointErrorCode& error_code, const std::optional<CiString<50>>& info,
-                  const std::optional<CiString<255>>& vendor_id, const std::optional<CiString<50>>& vendor_error_code);
+    /// \brief This function should be called if an error with the given \p uuid has been cleared. If this leads to the
+    /// fact that no other error is active anymore, this function will initiate a StatusNotification.req that reports
+    /// the current state and no error
+    ///  \param connector
+    /// \param uuid of a previously reported error. If uuid is not
+    /// known, the event will be ignored
+    void on_error_cleared(int32_t connector, const std::string uuid);
+
+    /// \brief Clears all previously reported errors at the same time for the given \p connector . This will
+    /// clear a previously reported "Faulted" state if present
+    ///  \param connector
+    void on_all_errors_cleared(int32_t connector);
 
     /// \brief Chargepoint notifies about new log status \p log_status . This function should be called during a
     /// Diagnostics / Log upload to indicate the current \p log_status .

--- a/include/ocpp/v16/charge_point_state_machine.hpp
+++ b/include/ocpp/v16/charge_point_state_machine.hpp
@@ -36,6 +36,27 @@ enum class FSMEvent {
     I8_ReturnToUnavailable,
 };
 
+/// \brief Contains all relevant information to handle errros in OCPP1.6
+struct ErrorInfo {
+    std::string uuid;                // uuid
+    ChargePointErrorCode error_code; /// defined by OCPP1.6
+    bool is_fault; /// indicates if state should change to "Faulted", if not set, state will not change and error is
+                   /// only informational
+    std::optional<CiString<50>> info;              /// defined by OCPP1.6
+    std::optional<CiString<255>> vendor_id;        /// defined by OCPP1.6
+    std::optional<CiString<50>> vendor_error_code; /// defined by OCPP1.6
+    DateTime timestamp;                            // timestamp
+
+    ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault);
+    ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault,
+              const std::optional<std::string> info);
+    ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault,
+              const std::optional<std::string> info, const std::optional<std::string> vendor_id);
+    ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault,
+              const std::optional<std::string> info, const std::optional<std::string> vendor_id,
+              const std::optional<std::string> vendor_error_code);
+};
+
 using FSMState = ChargePointStatus;
 
 using FSMStateTransitions = std::map<FSMEvent, FSMState>;
@@ -49,24 +70,28 @@ public:
         const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
         const std::optional<CiString<50>>& vendor_error_code)>;
     explicit ChargePointFSM(const StatusNotificationCallback& status_notification_callback, FSMState initial_state);
+    ChargePointFSM(ChargePointFSM&& other) noexcept;
+    ChargePointFSM(const ChargePointFSM&) = delete;
+    ChargePointFSM& operator=(const ChargePointFSM&) = delete;
 
     bool handle_event(FSMEvent event, const ocpp::DateTime timestamp, const std::optional<CiString<50>>& info);
-    bool handle_error(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
-                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                      const std::optional<CiString<50>>& vendor_error_code);
-    bool handle_fault(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
-                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                      const std::optional<CiString<50>>& vendor_error_code);
+    bool handle_error(const ErrorInfo& error_info);
+    bool handle_error_cleared(const std::string uuid);
+    bool handle_all_errors_cleared();
+    void trigger_status_notification();
 
-    FSMState get_state() const;
+    FSMState get_state();
+    std::optional<ErrorInfo> get_latest_error();
 
 private:
     StatusNotificationCallback status_notification_callback;
     // track current state
 
-    bool faulted;
-    ChargePointErrorCode error_code;
     FSMState state;
+    std::unordered_map<std::string, ErrorInfo> active_errors;
+    std::mutex active_errors_mutex;
+
+    bool is_faulted();
 };
 
 class ChargePointStates {
@@ -80,14 +105,14 @@ public:
 
     void submit_event(const int connector_id, FSMEvent event, const ocpp::DateTime& timestamp,
                       const std::optional<CiString<50>>& info = std::nullopt);
-    void submit_fault(const int connector_id, const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
-                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                      const std::optional<CiString<50>>& vendor_error_code);
-    void submit_error(const int connector_id, const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
-                      const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                      const std::optional<CiString<50>>& vendor_error_code);
+    void submit_error(const int connector_id, const ErrorInfo& error_info);
+    void submit_error_cleared(const int connector_id, const std::string uuid);
+    void submit_all_errors_cleared(const int32_t connector_id);
+    void trigger_status_notification(const int connector_id);
+    void trigger_status_notifications();
 
     ChargePointStatus get_state(int connector_id);
+    std::optional<ErrorInfo> get_latest_error(int connector_id);
 
 private:
     ConnectorStatusCallback connector_status_callback;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -283,6 +283,11 @@ public:
     /// \param connector_id     Faulted connector id
     virtual void on_faulted(const int32_t evse_id, const int32_t connector_id) = 0;
 
+    /// \brief Event handler that should be called when the fault on the connector on the given evse_id is cleared.
+    /// \param evse_id          EVSE id where fault was cleared
+    /// \param connector_id     Connector id where fault was cleared
+    virtual void on_fault_cleared(const int32_t evse_id, const int32_t connector_id) = 0;
+
     /// \brief Event handler that should be called when the connector on the given evse_id and connector_id is reserved.
     /// \param evse_id          Reserved EVSE id
     /// \param connector_id     Reserved connector id
@@ -824,6 +829,8 @@ public:
     void on_enabled(const int32_t evse_id, const int32_t connector_id) override;
 
     void on_faulted(const int32_t evse_id, const int32_t connector_id) override;
+
+    void on_fault_cleared(const int32_t evse_id, const int32_t connector_id) override;
 
     void on_reserved(const int32_t evse_id, const int32_t connector_id) override;
 

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -130,16 +130,16 @@ void ChargePoint::on_resume_charging(int32_t connector) {
     this->charge_point->on_resume_charging(connector);
 }
 
-void ChargePoint::on_error(int32_t connector, const ChargePointErrorCode& error_code,
-                           const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                           const std::optional<CiString<50>>& vendor_error_code) {
-    this->charge_point->on_error(connector, error_code, info, vendor_id, vendor_error_code);
+void ChargePoint::on_error(int32_t connector, const ErrorInfo& error_info) {
+    this->charge_point->on_error(connector, error_info);
 }
 
-void ChargePoint::on_fault(int32_t connector, const ChargePointErrorCode& error_code,
-                           const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                           const std::optional<CiString<50>>& vendor_error_code) {
-    this->charge_point->on_fault(connector, error_code, info, vendor_id, vendor_error_code);
+void ChargePoint::on_error_cleared(int32_t connector, const std::string uuid) {
+    this->charge_point->on_error_cleared(connector, uuid);
+}
+
+void ChargePoint::on_all_errors_cleared(int32_t connector) {
+    this->charge_point->on_all_errors_cleared(connector);
 }
 
 void ChargePoint::on_log_status_notification(int32_t request_id, std::string log_status) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -996,10 +996,7 @@ void ChargePointImpl::connected_callback() {
         // on_open in a Booted state can happen after a successful reconnect.
         // according to spec, a charge point should not send a BootNotification after a reconnect
         // still we send StatusNotification.req for all connectors after a reconnect
-        for (int32_t connector = 0; connector <= this->configuration->getNumberOfConnectors(); connector++) {
-            this->status_notification(connector, ChargePointErrorCode::NoError, this->status->get_state(connector),
-                                      ocpp::DateTime());
-        }
+        this->status->trigger_status_notifications();
         break;
     }
     case ChargePointConnectionState::Pending: {
@@ -1282,10 +1279,7 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
         this->update_clock_aligned_meter_values_interval();
 
         // send initial StatusNotification.req
-        for (int32_t connector = 0; connector <= this->configuration->getNumberOfConnectors(); connector++) {
-            this->status_notification(connector, ChargePointErrorCode::NoError, this->status->get_state(connector),
-                                      ocpp::DateTime());
-        }
+        this->status->trigger_status_notifications();
 
         if (this->is_pnc_enabled()) {
             this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
@@ -2200,12 +2194,17 @@ void ChargePointImpl::handleTriggerMessageRequest(ocpp::Call<TriggerMessageReque
         if (!call.msg.connectorId.has_value()) {
             // send a status notification for every connector
             for (int32_t c = 0; c <= this->configuration->getNumberOfConnectors(); c++) {
-                this->status_notification(c, ChargePointErrorCode::NoError, this->status->get_state(c),
-                                          ocpp::DateTime(), std::nullopt, std::nullopt, std::nullopt, true);
+                ErrorInfo error_info =
+                    this->status->get_latest_error(c).value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
+                this->status_notification(c, error_info.error_code, this->status->get_state(c), ocpp::DateTime(),
+                                          error_info.info, error_info.vendor_id, error_info.vendor_error_code, true);
             }
         } else {
-            this->status_notification(connector, ChargePointErrorCode::NoError, this->status->get_state(connector),
-                                      ocpp::DateTime(), std::nullopt, std::nullopt, std::nullopt, true);
+            ErrorInfo error_info =
+                this->status->get_latest_error(connector).value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
+            this->status_notification(connector, error_info.error_code, this->status->get_state(connector),
+                                      ocpp::DateTime(), error_info.info, error_info.vendor_id,
+                                      error_info.vendor_error_code, true);
         }
         break;
     }
@@ -2315,12 +2314,17 @@ void ChargePointImpl::handleExtendedTriggerMessageRequest(ocpp::Call<ExtendedTri
         if (!call.msg.connectorId.has_value()) {
             // send a status notification for every connector
             for (int32_t c = 0; c <= this->configuration->getNumberOfConnectors(); c++) {
-                this->status_notification(c, ChargePointErrorCode::NoError, this->status->get_state(c),
-                                          ocpp::DateTime(), std::nullopt, std::nullopt, std::nullopt, true);
+                ErrorInfo error_info =
+                    this->status->get_latest_error(c).value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
+                this->status_notification(c, error_info.error_code, this->status->get_state(c), ocpp::DateTime(),
+                                          error_info.info, error_info.vendor_id, error_info.vendor_error_code, true);
             }
         } else {
-            this->status_notification(connector, ChargePointErrorCode::NoError, this->status->get_state(connector),
-                                      ocpp::DateTime(), std::nullopt, std::nullopt, std::nullopt, true);
+            ErrorInfo error_info =
+                this->status->get_latest_error(connector).value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
+            this->status_notification(connector, error_info.error_code, this->status->get_state(connector),
+                                      ocpp::DateTime(), error_info.info, error_info.vendor_id,
+                                      error_info.vendor_error_code, true);
         }
         break;
     }
@@ -3758,16 +3762,16 @@ void ChargePointImpl::on_resume_charging(int32_t connector) {
     this->status->submit_event(connector, FSMEvent::StartCharging, ocpp::DateTime());
 }
 
-void ChargePointImpl::on_error(int32_t connector, const ChargePointErrorCode& error_code,
-                               const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                               const std::optional<CiString<50>>& vendor_error_code) {
-    this->status->submit_error(connector, error_code, ocpp::DateTime(), info, vendor_id, vendor_error_code);
+void ChargePointImpl::on_error(int32_t connector, const ErrorInfo& error_info) {
+    this->status->submit_error(connector, error_info);
 }
 
-void ChargePointImpl::on_fault(int32_t connector, const ChargePointErrorCode& error_code,
-                               const std::optional<CiString<50>>& info, const std::optional<CiString<255>>& vendor_id,
-                               const std::optional<CiString<50>>& vendor_error_code) {
-    this->status->submit_fault(connector, error_code, ocpp::DateTime(), info, vendor_id, vendor_error_code);
+void ChargePointImpl::on_error_cleared(int32_t connector, const std::string uuid) {
+    this->status->submit_error_cleared(connector, uuid);
+}
+
+void ChargePointImpl::on_all_errors_cleared(int32_t connector) {
+    this->status->submit_all_errors_cleared(connector);
 }
 
 void ChargePointImpl::on_log_status_notification(int32_t request_id, std::string log_status) {

--- a/lib/ocpp/v16/charge_point_state_machine.cpp
+++ b/lib/ocpp/v16/charge_point_state_machine.cpp
@@ -103,20 +103,94 @@ static const FSMDefinition FSM_DEF_CONNECTOR_ZERO = {
      }},
 };
 
-ChargePointFSM::ChargePointFSM(const StatusNotificationCallback& status_notification_callback_,
-                               FSMState initial_state) :
-    status_notification_callback(status_notification_callback_),
-    state(initial_state),
-    error_code(ChargePointErrorCode::NoError),
-    faulted(false) {
-    // FIXME (aw): do we need to call the callback here already?
+ErrorInfo::ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault) :
+    uuid(uuid), timestamp(DateTime()), error_code(error_code), is_fault(is_fault) {
 }
 
-FSMState ChargePointFSM::get_state() const {
-    if (faulted) {
+ErrorInfo::ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault,
+                     const std::optional<std::string> info) :
+    ErrorInfo(uuid, error_code, is_fault) {
+    if (!info.has_value()) {
+        return;
+    }
+
+    // CiString for info is allowed to have max of 50 characters
+    if (info.value().size() > 50) {
+        this->info = info.value().substr(0, 50);
+    } else {
+        this->info = info;
+    }
+}
+
+ErrorInfo::ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault,
+                     const std::optional<std::string> info, const std::optional<std::string> vendor_id) :
+    ErrorInfo(uuid, error_code, is_fault, info) {
+    if (!vendor_id.has_value()) {
+        return;
+    }
+
+    // CiString for vendor_id is allowed to have max of 50 characters
+    if (vendor_id.value().size() > 255) {
+        this->vendor_id = vendor_id.value().substr(0, 255);
+    } else {
+        this->vendor_id = vendor_id;
+    }
+}
+
+ErrorInfo::ErrorInfo(const std::string uuid, const ChargePointErrorCode error_code, const bool is_fault,
+                     const std::optional<std::string> info, const std::optional<std::string> vendor_id,
+                     const std::optional<std::string> vendor_error_code) :
+    ErrorInfo(uuid, error_code, is_fault, info, vendor_id) {
+    if (!vendor_error_code.has_value()) {
+        return;
+    }
+    // CiString for vendor_error_code is allowed to have max of 50 characters
+    if (vendor_error_code.value().size() > 50) {
+        this->vendor_error_code = vendor_error_code.value().substr(0, 50);
+    } else {
+        this->vendor_error_code = vendor_error_code;
+    }
+}
+
+ChargePointFSM::ChargePointFSM(const StatusNotificationCallback& status_notification_callback_,
+                               FSMState initial_state) :
+    status_notification_callback(status_notification_callback_), state(initial_state) {
+}
+
+ChargePointFSM::ChargePointFSM(ChargePointFSM&& other) noexcept :
+    status_notification_callback(std::move(other.status_notification_callback)),
+    state(other.state),
+    active_errors(std::move(other.active_errors)) {
+}
+
+FSMState ChargePointFSM::get_state() {
+    if (this->is_faulted()) {
         return FSMState::Faulted;
     }
     return state;
+}
+
+bool ChargePointFSM::is_faulted() {
+    // check if there is any active fault
+    return std::find_if(this->active_errors.begin(), this->active_errors.end(),
+                        [](const std::pair<std::string, ErrorInfo>& entry) { return entry.second.is_fault; }) !=
+           this->active_errors.end();
+}
+
+std::optional<ErrorInfo> ChargePointFSM::get_latest_error() {
+    std::lock_guard<std::mutex> lk(active_errors_mutex);
+
+    if (this->active_errors.empty()) {
+        return std::nullopt;
+    }
+
+    auto latest_error = (*this->active_errors.begin()).second;
+    for (const auto& [uuid, error_info] : this->active_errors) {
+        if (error_info.timestamp > latest_error.timestamp) {
+            latest_error = error_info;
+        }
+    }
+    return latest_error;
 }
 
 bool ChargePointFSM::handle_event(FSMEvent event, const ocpp::DateTime timestamp,
@@ -132,50 +206,75 @@ bool ChargePointFSM::handle_event(FSMEvent event, const ocpp::DateTime timestamp
     // fall through: transition found
     state = dest_state_it->second;
 
-    if (!faulted) {
-        status_notification_callback(state, this->error_code, timestamp, info, std::nullopt, std::nullopt);
+    const auto error_info = this->get_latest_error().value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
+
+    // only send a StatusNotification.req with the updated state if not in faulted
+    if (!this->is_faulted()) {
+        status_notification_callback(state, error_info.error_code, timestamp, info, error_info.vendor_id,
+                                     error_info.vendor_error_code);
     }
 
     return true;
 }
 
-bool ChargePointFSM::handle_fault(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
-                                  const std::optional<CiString<50>>& info,
-                                  const std::optional<CiString<255>>& vendor_id,
-                                  const std::optional<CiString<50>>& vendor_error_code) {
-    if (error_code == this->error_code) {
+bool ChargePointFSM::handle_error(const ErrorInfo& error_info) {
+    std::lock_guard<std::mutex> lk(active_errors_mutex);
+    if (this->active_errors.count(error_info.uuid)) {
         // has already been handled and reported
         return false;
     }
 
-    this->error_code = error_code;
-    if (this->error_code == ChargePointErrorCode::NoError) {
-        faulted = false;
-        status_notification_callback(state, this->error_code, timestamp, info, vendor_id, vendor_error_code);
+    this->active_errors.insert({error_info.uuid, error_info});
+
+    if (!this->is_faulted()) {
+        status_notification_callback(this->state, error_info.error_code, error_info.timestamp, error_info.info,
+                                     error_info.vendor_id, error_info.vendor_error_code);
     } else {
-        faulted = true;
-        status_notification_callback(FSMState::Faulted, error_code, timestamp, info, vendor_id, vendor_error_code);
+        status_notification_callback(FSMState::Faulted, error_info.error_code, error_info.timestamp, error_info.info,
+                                     error_info.vendor_id, error_info.vendor_error_code);
     }
+    return true;
+}
+
+bool ChargePointFSM::handle_error_cleared(const std::string uuid) {
+    std::lock_guard<std::mutex> lk(active_errors_mutex);
+    this->active_errors.erase(uuid);
+
+    // dont report StatusNotification if still "Faulted"
+    if (this->is_faulted()) {
+        return false;
+    }
+
+    // dont report StatusNotification if errors are still active
+    if (this->active_errors.size() > 0) {
+        return false;
+    }
+
+    // no fault present and no error active, so we can send a StatusNotification.req and return to previous state
+    status_notification_callback(this->state, ChargePointErrorCode::NoError, DateTime(), std::nullopt, std::nullopt,
+                                 std::nullopt);
 
     return true;
 }
 
-bool ChargePointFSM::handle_error(const ChargePointErrorCode& error_code, const ocpp::DateTime& timestamp,
-                                  const std::optional<CiString<50>>& info,
-                                  const std::optional<CiString<255>>& vendor_id,
-                                  const std::optional<CiString<50>>& vendor_error_code) {
-    if (error_code == this->error_code) {
-        // has already been handled and reported
-        return false;
-    }
-
-    this->error_code = error_code;
-    if (!faulted) {
-        status_notification_callback(this->state, error_code, timestamp, info, vendor_id, vendor_error_code);
-    } else {
-        status_notification_callback(FSMState::Faulted, error_code, timestamp, info, vendor_id, vendor_error_code);
-    }
+bool ChargePointFSM::handle_all_errors_cleared() {
+    std::lock_guard<std::mutex> lk(active_errors_mutex);
+    this->active_errors.clear();
+    status_notification_callback(this->state, ChargePointErrorCode::NoError, DateTime(), std::nullopt, std::nullopt,
+                                 std::nullopt);
     return true;
+}
+
+void ChargePointFSM::trigger_status_notification() {
+    // get latest error or report NoError
+    const auto error_info = this->get_latest_error().value_or(ErrorInfo("", ChargePointErrorCode::NoError, false));
+    if (!this->is_faulted()) {
+        status_notification_callback(this->state, error_info.error_code, error_info.timestamp, error_info.info,
+                                     error_info.vendor_id, error_info.vendor_error_code);
+    } else {
+        status_notification_callback(FSMState::Faulted, error_info.error_code, error_info.timestamp, error_info.info,
+                                     error_info.vendor_id, error_info.vendor_error_code);
+    }
 }
 
 ChargePointStates::ChargePointStates(const ConnectorStatusCallback& callback) : connector_status_callback(callback) {
@@ -227,27 +326,45 @@ void ChargePointStates::submit_event(const int connector_id, FSMEvent event, con
     }
 }
 
-void ChargePointStates::submit_fault(const int connector_id, const ChargePointErrorCode& error_code,
-                                     const ocpp::DateTime& timestamp, const std::optional<CiString<50>>& info,
-                                     const std::optional<CiString<255>>& vendor_id,
-                                     const std::optional<CiString<50>>& vendor_error_code) {
+void ChargePointStates::submit_error(const int connector_id, const ErrorInfo& error_info) {
     const std::lock_guard<std::mutex> lck(state_machines_mutex);
     if (connector_id == 0) {
-        this->state_machine_connector_zero->handle_fault(error_code, timestamp, info, vendor_id, vendor_error_code);
+        this->state_machine_connector_zero->handle_error(error_info);
     } else if (connector_id > 0 && (size_t)connector_id <= state_machines.size()) {
-        state_machines.at(connector_id - 1).handle_fault(error_code, timestamp, info, vendor_id, vendor_error_code);
+        state_machines.at(connector_id - 1).handle_error(error_info);
     }
 }
 
-void ChargePointStates::submit_error(const int connector_id, const ChargePointErrorCode& error_code,
-                                     const ocpp::DateTime& timestamp, const std::optional<CiString<50>>& info,
-                                     const std::optional<CiString<255>>& vendor_id,
-                                     const std::optional<CiString<50>>& vendor_error_code) {
+void ChargePointStates::submit_error_cleared(const int connector_id, const std::string uuid) {
     const std::lock_guard<std::mutex> lck(state_machines_mutex);
     if (connector_id == 0) {
-        this->state_machine_connector_zero->handle_error(error_code, timestamp, info, vendor_id, vendor_error_code);
+        this->state_machine_connector_zero->handle_error_cleared(uuid);
     } else if (connector_id > 0 && (size_t)connector_id <= state_machines.size()) {
-        state_machines.at(connector_id - 1).handle_error(error_code, timestamp, info, vendor_id, vendor_error_code);
+        state_machines.at(connector_id - 1).handle_error_cleared(uuid);
+    }
+}
+
+void ChargePointStates::submit_all_errors_cleared(const int32_t connector_id) {
+    const std::lock_guard<std::mutex> lck(state_machines_mutex);
+    if (connector_id == 0) {
+        this->state_machine_connector_zero->handle_all_errors_cleared();
+    } else if (connector_id > 0 && (size_t)connector_id <= state_machines.size()) {
+        state_machines.at(connector_id - 1).handle_all_errors_cleared();
+    }
+}
+
+void ChargePointStates::trigger_status_notification(const int connector_id) {
+    if (connector_id == 0) {
+        this->state_machine_connector_zero->trigger_status_notification();
+    } else {
+        this->state_machines.at(connector_id - 1).trigger_status_notification();
+    }
+}
+
+void ChargePointStates::trigger_status_notifications() {
+    this->state_machine_connector_zero->trigger_status_notification();
+    for (size_t connector_id = 0; connector_id < state_machines.size(); ++connector_id) {
+        this->state_machines.at(connector_id).trigger_status_notification();
     }
 }
 
@@ -261,6 +378,15 @@ ChargePointStatus ChargePointStates::get_state(int connector_id) {
 
     // fall through on invalid id
     return ChargePointStatus::Unavailable;
+}
+
+std::optional<ErrorInfo> ChargePointStates::get_latest_error(int connector_id) {
+    const std::lock_guard<std::mutex> lck(state_machines_mutex);
+    if (connector_id > 0 && (size_t)connector_id <= this->state_machines.size()) {
+        return state_machines.at(connector_id - 1).get_latest_error();
+    } else {
+        return state_machine_connector_zero->get_latest_error();
+    }
 }
 
 } // namespace v16

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -606,6 +606,10 @@ void ChargePoint::on_faulted(const int32_t evse_id, const int32_t connector_id) 
     this->evses.at(evse_id)->submit_event(connector_id, ConnectorEvent::Error);
 }
 
+void ChargePoint::on_fault_cleared(const int32_t evse_id, const int32_t connector_id) {
+    this->evses.at(evse_id)->submit_event(connector_id, ConnectorEvent::ErrorCleared);
+}
+
 void ChargePoint::on_reserved(const int32_t evse_id, const int32_t connector_id) {
     this->evses.at(evse_id)->submit_event(connector_id, ConnectorEvent::Reserve);
 }

--- a/tests/lib/ocpp/v16/CMakeLists.txt
+++ b/tests/lib/ocpp/v16/CMakeLists.txt
@@ -1,4 +1,9 @@
 target_sources(libocpp_unit_tests PRIVATE
         test_database_migration_files.cpp
         test_smart_charging_handler.cpp
+<<<<<<< Updated upstream
         )
+=======
+        test_charge_point_state_machine.cpp
+)
+>>>>>>> Stashed changes

--- a/tests/lib/ocpp/v16/test_charge_point_state_machine.cpp
+++ b/tests/lib/ocpp/v16/test_charge_point_state_machine.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <ocpp/v16/charge_point_state_machine.hpp>
+#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_types.hpp>
+
+using namespace ocpp::v16;
+using ::testing::_;
+
+class MockStatusNotificationCallback {
+public:
+    MOCK_METHOD(void, Call,
+                (FSMState state, ChargePointErrorCode error_code, ocpp::DateTime timestamp,
+                 std::optional<ocpp::CiString<50>> info, std::optional<ocpp::CiString<255>> vendor_id,
+                 std::optional<ocpp::CiString<50>> vendor_error_code));
+};
+
+class ChargePointStateMachineTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        status_notification_callback = [&](FSMState state, ChargePointErrorCode error_code, ocpp::DateTime timestamp,
+                                           std::optional<ocpp::CiString<50>> info,
+                                           std::optional<ocpp::CiString<255>> vendor_id,
+                                           std::optional<ocpp::CiString<50>> vendor_error_code) {
+            mock_callback.Call(state, error_code, timestamp, info, vendor_id, vendor_error_code);
+        };
+
+        state_machine = std::make_unique<ChargePointFSM>(status_notification_callback, FSMState::Available);
+    }
+
+    std::unique_ptr<ChargePointFSM> state_machine;
+    MockStatusNotificationCallback mock_callback;
+    std::function<void(FSMState, ChargePointErrorCode, ocpp::DateTime, std::optional<ocpp::CiString<50>>,
+                       std::optional<ocpp::CiString<255>>, std::optional<ocpp::CiString<50>>)>
+        status_notification_callback;
+};
+
+TEST_F(ChargePointStateMachineTest, HandleError) {
+    ErrorInfo error_info_1("uuid1", ChargePointErrorCode::ConnectorLockFailure, true);
+    ErrorInfo error_info_2("uuid2", ChargePointErrorCode::GroundFailure, true);
+    EXPECT_CALL(mock_callback, Call(FSMState::Faulted, ChargePointErrorCode::ConnectorLockFailure, _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(mock_callback, Call(FSMState::Faulted, ChargePointErrorCode::GroundFailure, _, _, _, _)).Times(1);
+
+    state_machine->handle_error(error_info_1);
+    state_machine->handle_error(error_info_2);
+}
+
+TEST_F(ChargePointStateMachineTest, HandleError__ChangeState) {
+    ErrorInfo error_info_1("uuid1", ChargePointErrorCode::GroundFailure, false, "InfoField", "vendor_id");
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::GroundFailure, _, _, _, _)).Times(1);
+    EXPECT_CALL(mock_callback, Call(FSMState::Preparing, ChargePointErrorCode::GroundFailure, _, _, _, _)).Times(1);
+
+    state_machine->handle_error(error_info_1);
+    state_machine->handle_event(FSMEvent::UsageInitiated, ocpp::DateTime(), "AnotherInfoField");
+}
+
+TEST_F(ChargePointStateMachineTest, HandleErrorCleared) {
+    ErrorInfo error_info("uuid1", ChargePointErrorCode::ConnectorLockFailure, true);
+    state_machine->handle_error(error_info);
+
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::NoError, _, _, _, _)).Times(1);
+
+    state_machine->handle_error_cleared("uuid1");
+}
+
+TEST_F(ChargePointStateMachineTest, HandleErrorCleared__TwoErrors__OneCleared) {
+    ErrorInfo error_info_1("uuid1", ChargePointErrorCode::ConnectorLockFailure, false);
+    ErrorInfo error_info_2("uuid2", ChargePointErrorCode::GroundFailure, false);
+
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::ConnectorLockFailure, _, _, _, _))
+        .Times(1);
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::GroundFailure, _, _, _, _)).Times(1);
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::NoError, _, _, _, _)).Times(0);
+
+    state_machine->handle_error(error_info_1);
+    state_machine->handle_error(error_info_2);
+    state_machine->handle_error_cleared("uuid2");
+
+    const auto latest_error = state_machine->get_latest_error();
+
+    EXPECT_TRUE(latest_error.has_value());
+    EXPECT_EQ(latest_error.value().error_code, ChargePointErrorCode::ConnectorLockFailure);
+}
+
+TEST_F(ChargePointStateMachineTest, HandleError__NonFault) {
+    ErrorInfo error_info("uuid1", ChargePointErrorCode::ConnectorLockFailure, false);
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::ConnectorLockFailure, _, _, _, _))
+        .Times(1);
+
+    state_machine->handle_error(error_info);
+}
+
+TEST_F(ChargePointStateMachineTest, HandleErrorCleared__NonFault) {
+    ErrorInfo error_info("uuid1", ChargePointErrorCode::ConnectorLockFailure, false);
+
+    state_machine->handle_error(error_info);
+
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::NoError, _, _, _, _)).Times(1);
+
+    state_machine->handle_error_cleared("uuid1");
+}
+
+TEST_F(ChargePointStateMachineTest, HandleErrorCleared__ClearUnknown) {
+    ErrorInfo error_info("uuid1", ChargePointErrorCode::ConnectorLockFailure, false);
+
+    state_machine->handle_error(error_info);
+
+    EXPECT_CALL(mock_callback, Call(FSMState::Available, ChargePointErrorCode::NoError, _, _, _, _)).Times(0);
+
+    state_machine->handle_error_cleared("uuid2");
+    state_machine->handle_error_cleared("uuid3");
+    state_machine->handle_error_cleared("uuid4");
+}


### PR DESCRIPTION
* changed ChargePoint interface: only two functions on_error and on_error_cleared remain
* these two functions can be used to report and clear informational errors (no change to Faulted state) or fault errors
* ErrorInfo struct was introduced to have a compact datatype for the ErrorInformation used in a StatusNotification.req
* Added tests for error handling in ChargePointFSM
* StatusNotification.req triggered by TriggerMessage.req could contain wrong information before the added changes
* Added more simple fault handling to OCPP201 as well

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

