### PR TITLE
OCPP1.6: Changed SecurityEventNotification name

### DIFF
--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -663,6 +663,7 @@ inline const std::string TAMPERDETECTIONACTIVATED = "TamperDetectionActivated"; 
 inline const std::string INVALIDFIRMWARESIGNATURE = "InvalidFirmwareSignature";
 inline const std::string INVALIDFIRMWARESIGNINGCERTIFICATE = "InvalidFirmwareSigningCertificate";
 inline const std::string INVALIDCSMSCERTIFICATE = "InvalidCsmsCertificate";
+inline const std::string INVALIDCENTRALSYSTEMCERTIFICATE = "InvalidCentralSystemCertificate";
 inline const std::string INVALIDCHARGINGSTATIONCERTIFICATE = "InvalidChargingStationCertificate";
 inline const std::string INVALIDCHARGEPOINTCERTIFICATE = "InvalidChargePointCertificate"; // for OCPP1.6
 inline const std::string INVALIDTLSVERSION = "InvalidTLSVersion";

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2485,7 +2485,7 @@ void ChargePointImpl::handleInstallCertificateRequest(ocpp::Call<InstallCertific
     this->send<InstallCertificateResponse>(call_result);
 
     if (response.status == InstallCertificateStatusEnumType::Rejected) {
-        this->securityEventNotification(ocpp::security_events::INVALIDCSMSCERTIFICATE,
+        this->securityEventNotification(ocpp::security_events::INVALIDCENTRALSYSTEMCERTIFICATE,
                                         ocpp::conversions::install_certificate_result_to_string(result), true);
     }
 }


### PR DESCRIPTION
## Describe your changes
changed SecurityEventNotification name for OCPP1.6 from InvalidCsmsCertificate (OCPP201) to InvalidCentralSystemCertificate (OCPP16)

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

