### PR TITLE
Added monitor triggering/filtering base capabilities

### DIFF
--- a/config/v201/component_schemas/standardized/InternalCtrlr.json
+++ b/config/v201/component_schemas/standardized/InternalCtrlr.json
@@ -449,8 +449,8 @@
           "default": "5",
           "type": "integer"
       },
-      "VariableMonitoringProcessTime": {
-          "variable_name": "VariableMonitoringProcessTime",
+      "MonitorsProcessingInterval": {
+          "variable_name": "MonitorsProcessingInterval",
           "characteristics": {
               "supportsMonitoring": false,
               "dataType": "integer"

--- a/config/v201/component_schemas/standardized/InternalCtrlr.json
+++ b/config/v201/component_schemas/standardized/InternalCtrlr.json
@@ -449,6 +449,22 @@
           "default": "5",
           "type": "integer"
       },
+      "VariableMonitoringProcessTime": {
+          "variable_name": "VariableMonitoringProcessTime",
+          "characteristics": {
+              "supportsMonitoring": false,
+              "dataType": "integer"
+          },
+          "attributes": [
+              {
+                  "type": "Actual",
+                  "mutability": "ReadOnly"
+              }
+          ],
+          "description": "Defines the interval at which the periodic monitors will be processed, in seconds",
+          "default": "1",
+          "type": "integer"
+      },
       "MaxCustomerInformationDataLength": {
           "variable_name": "MaxCustomerInformationDataLength",
           "characteristics": {

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -17,7 +17,7 @@
         }
       ],
       "description": "Whether monitoring is enabled.",
-      "default": true,
+      "default": false,
       "type": "boolean"
     },
     "MonitoringCtrlrAvailable": {

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -113,7 +113,7 @@
       ],
       "description": "When set and the Charging Station is offline, the Charging Station shall queue any notifyEventRequest messages triggered by a monitor with a severity number equal to or lower than the severity configured here.",
       "type": "integer",
-      "default": 0
+      "default": 1
     },    
     "ActiveMonitoringBase": {
       "variable_name": "ActiveMonitoringBase",

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -33,7 +33,8 @@
         }
       ],
       "description": "Whether monitoring is available,",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "ActiveMonitoringBase": {
       "variable_name": "ActiveMonitoringBase",
@@ -64,7 +65,8 @@
         }
       ],
       "description": "Shows the currently used MonitoringLevel. Valid values are severity levels of SetMonitoringLevelRequest: 0-9.",
-      "type": "integer"    
+      "type": "integer",
+      "default": 9 
     },
     "BytesPerMessageClearVariableMonitoring": {
       "variable_name": "BytesPerMessage",
@@ -144,7 +146,7 @@
       ],
       "description": "When set and the Charging Station is offline, the Charging Station shall queue any notifyEventRequest messages triggered by a monitor with a severity number equal to or lower than the severity configured here.",
       "type": "integer",
-      "default": 1
+      "default": 9
     }
   },
   "required": [

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -64,8 +64,7 @@
         }
       ],
       "description": "Shows the currently used MonitoringLevel. Valid values are severity levels of SetMonitoringLevelRequest: 0-9.",
-      "type": "integer"
-    }
+      "type": "integer"    
     },
     "BytesPerMessageClearVariableMonitoring": {
       "variable_name": "BytesPerMessage",
@@ -146,7 +145,8 @@
       "description": "When set and the Charging Station is offline, the Charging Station shall queue any notifyEventRequest messages triggered by a monitor with a severity number equal to or lower than the severity configured here.",
       "type": "integer",
       "default": 1
-    },    
+    }
+  },
   "required": [
     "BytesPerMessageSetVariableMonitoring",
     "ItemsPerMessageSetVariableMonitoring"

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -35,6 +35,38 @@
       "description": "Whether monitoring is available,",
       "type": "boolean"
     },
+    "ActiveMonitoringBase": {
+      "variable_name": "ActiveMonitoringBase",
+      "characteristics": {
+        "valuesList": "All,FactoryDefault,HardWiredOnly",
+        "supportsMonitoring": true,
+        "dataType": "OptionList"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadOnly"
+        }
+      ],
+      "description": "Shows the currently used MonitoringBase. Valid values according MonitoringBaseEnumType: All, FactoryDefault, HardwiredOnly.",
+      "type": "string"
+    },
+    "ActiveMonitoringLevel": {
+      "variable_name": "ActiveMonitoringLevel",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "integer"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadOnly"
+        }
+      ],
+      "description": "Shows the currently used MonitoringLevel. Valid values are severity levels of SetMonitoringLevelRequest: 0-9.",
+      "type": "integer"
+    }
+    },
     "BytesPerMessageClearVariableMonitoring": {
       "variable_name": "BytesPerMessage",
       "characteristics": {
@@ -115,38 +147,6 @@
       "type": "integer",
       "default": 1
     },    
-    "ActiveMonitoringBase": {
-      "variable_name": "ActiveMonitoringBase",
-      "characteristics": {
-        "valuesList": "All,FactoryDefault,HardWiredOnly",
-        "supportsMonitoring": true,
-        "dataType": "OptionList"
-      },
-      "attributes": [
-        {
-          "type": "Actual",
-          "mutability": "ReadOnly"
-        }
-      ],
-      "description": "Shows the currently used MonitoringBase. Valid values according MonitoringBaseEnumType: All, FactoryDefault, HardwiredOnly.",
-      "type": "string"
-    },
-    "ActiveMonitoringLevel": {
-      "variable_name": "ActiveMonitoringLevel",
-      "characteristics": {
-        "supportsMonitoring": true,
-        "dataType": "integer"
-      },
-      "attributes": [
-        {
-          "type": "Actual",
-          "mutability": "ReadOnly"
-        }
-      ],
-      "description": "Shows the currently used MonitoringLevel. Valid values are severity levels of SetMonitoringLevelRequest: 0-9.",
-      "type": "integer"
-    }
-  },
   "required": [
     "BytesPerMessageSetVariableMonitoring",
     "ItemsPerMessageSetVariableMonitoring"

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -112,7 +112,8 @@
         }
       ],
       "description": "When set and the Charging Station is offline, the Charging Station shall queue any notifyEventRequest messages triggered by a monitor with a severity number equal to or lower than the severity configured here.",
-      "type": "integer"
+      "type": "integer",
+      "default": 0
     },    
     "ActiveMonitoringBase": {
       "variable_name": "ActiveMonitoringBase",

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -4,6 +4,21 @@
   "name": "MonitoringCtrlr",
   "type": "object",
   "properties": {
+    "MonitoringCtrlrEnabled": {
+      "variable_name": "Enabled",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "boolean"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadWrite"
+        }
+      ],
+      "description": "Whether monitoring is enabled.",
+      "type": "boolean"
+    },
     "MonitoringCtrlrAvailable": {
       "variable_name": "Available",
       "characteristics": {
@@ -50,22 +65,7 @@
       "instance": "SetVariableMonitoring",
       "description": "Maximum number of bytes in a SetVariableMonitoring message,",
       "type": "integer"
-    },
-    "MonitoringCtrlrEnabled": {
-      "variable_name": "Enabled",
-      "characteristics": {
-        "supportsMonitoring": true,
-        "dataType": "boolean"
-      },
-      "attributes": [
-        {
-          "type": "Actual",
-          "mutability": "ReadWrite"
-        }
-      ],
-      "description": "Whether monitoring is enabled.",
-      "type": "boolean"
-    },
+    },    
     "ItemsPerMessageClearVariableMonitoring": {
       "variable_name": "ItemsPerMessage",
       "characteristics": {

--- a/config/v201/component_schemas/standardized/MonitoringCtrlr.json
+++ b/config/v201/component_schemas/standardized/MonitoringCtrlr.json
@@ -17,6 +17,7 @@
         }
       ],
       "description": "Whether monitoring is enabled.",
+      "default": true,
       "type": "boolean"
     },
     "MonitoringCtrlrAvailable": {
@@ -116,7 +117,7 @@
     "ActiveMonitoringBase": {
       "variable_name": "ActiveMonitoringBase",
       "characteristics": {
-        "valuesList": "All,FactoryDefault,HardwiredOnly",
+        "valuesList": "All,FactoryDefault,HardWiredOnly",
         "supportsMonitoring": true,
         "dataType": "OptionList"
       },

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1738,22 +1738,22 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| N07.FR.02 |        |        |
-| N07.FR.03 |        |        |
-| N07.FR.04 |        |        |
+| N07.FR.02 | ✅     |        |
+| N07.FR.03 | ✅     |        |
+| N07.FR.04 | ✅     |        |
 | N07.FR.05 |        |        |
-| N07.FR.06 |        |        |
-| N07.FR.07 |        |        |
-| N07.FR.10 |        |        |
+| N07.FR.06 | ✅     |        |
+| N07.FR.07 | ✅     |        |
+| N07.FR.10 | ✅     |        |
 | N07.FR.11 |        |        |
 | N07.FR.12 |        |        |
-| N07.FR.13 |        |        |
+| N07.FR.13 | ✅     |        |
 | N07.FR.14 |        |        |
-| N07.FR.15 |        |        |
-| N07.FR.16 |        |        |
-| N07.FR.17 |        |        |
-| N07.FR.18 |        |        |
-| N07.FR.19 |        |        |
+| N07.FR.15 | ✅     |        |
+| N07.FR.16 | ✅     |        |
+| N07.FR.17 | ✅     |        |
+| N07.FR.18 | ✅     |        |
+| N07.FR.19 | ✅     |        |
 
 ## Diagnostics - Periodic Event
 

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1759,12 +1759,12 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| N08.FR.02 |        |        |
+| N08.FR.02 | ✅     |        |
 | N08.FR.03 |        |        |
-| N08.FR.04 |        |        |
-| N08.FR.05 |        |        |
-| N08.FR.06 |        |        |
-| N08.FR.07 |        |        |
+| N08.FR.04 | ✅     |        |
+| N08.FR.05 | ✅     |        |
+| N08.FR.06 | ✅     |        |
+| N08.FR.07 | ✅     |        |
 
 ## Diagnostics - Get Customer Information
 

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1694,25 +1694,25 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| N04.FR.01 |        |        |
-| N04.FR.02 |        |        |
-| N04.FR.03 |        |        |
-| N04.FR.04 |        |        |
+| N04.FR.01 | ✅     |        |
+| N04.FR.02 | ✅     |        |
+| N04.FR.03 | ✅     |        |
+| N04.FR.04 | ✅     |        |
 | N04.FR.05 |        |        |
-| N04.FR.06 |        |        |
-| N04.FR.07 |        |        |
-| N04.FR.08 |        |        |
-| N04.FR.09 |        |        |
-| N04.FR.10 |        |        |
-| N04.FR.11 |        |        |
-| N04.FR.12 |        |        |
-| N04.FR.13 |        |        |
-| N04.FR.14 |        |        |
+| N04.FR.06 | ✅     |        |
+| N04.FR.07 | ✅     |        |
+| N04.FR.08 | ✅     |        |
+| N04.FR.09 | ✅     |        |
+| N04.FR.10 | ✅     |        |
+| N04.FR.11 | ✅     |        |
+| N04.FR.12 | ✅     |        |
+| N04.FR.13 | ✅     |        |
+| N04.FR.14 | ✅     |        |
 | N04.FR.15 |        |        |
-| N04.FR.16 |        |        |
+| N04.FR.16 | ✅     |        |
 | N04.FR.17 |        |        |
-| N04.FR.18 |        |        |
-| N04.FR.19 |        |        |
+| N04.FR.18 | ✅     |        |
+| N04.FR.19 | ✅     |        |
 
 ## Diagnostics - Set Monitoring Level
 

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1726,13 +1726,13 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| N06.FR.01 |        |        |
-| N06.FR.02 |        |        |
-| N06.FR.03 |        |        |
-| N06.FR.04 |        |        |
-| N06.FR.05 |        |        |
-| N06.FR.06 |        |        |
-| N06.FR.07 |        |        |
+| N06.FR.01 | ✅     |        |
+| N06.FR.02 | ✅     |        |
+| N06.FR.03 | ✅     |        |
+| N06.FR.04 | ✅     |        |
+| N06.FR.05 | ✅     |        |
+| N06.FR.06 | ✅     |        |
+| N06.FR.07 | ✅     |        |
 
 ## Diagnostics - Alert Event
 

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1718,9 +1718,9 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| N05.FR.01 |        |        |
-| N05.FR.02 |        |        |
-| N05.FR.03 |        |        |
+| N05.FR.01 | ✅     |        |
+| N05.FR.02 | ✅     |        |
+| N05.FR.03 | ✅     |        |
 
 ## Diagnostics - Clear / Remove Monitoring
 

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1656,39 +1656,39 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 ## Diagnostics - Get Monitoring report
 
-| ID        | Status | Remark |
-|-----------|--------|--------|
-| N02.FR.01 | ✅     |        |
-| N02.FR.02 |        |        |
-| N02.FR.03 | ✅     |        |
-| N02.FR.04 | ✅     |        |
-| N02.FR.05 | ✅     |        |
-| N02.FR.06 | ✅     |        |
-| N02.FR.07 | ✅     |        |
-| N02.FR.08 | ✅     |        |
-| N02.FR.09 | ✅     |        |
-| N02.FR.10 | ✅     |        |
-| N02.FR.11 | ✅     |        |
-| N02.FR.12 | ✅     |        |
-| N02.FR.13 | ✅     |        |
-| N02.FR.14 | ✅     |        |
-| N02.FR.15 | ✅     |        |
-| N02.FR.16 | ✅     |        |
-| N02.FR.17 | ✅     |        |
-| N02.FR.18 |        |        |
-| N02.FR.19 |        |        |
-| N02.FR.20 |        |        |
-| N02.FR.21 |        |        |
+| ID        | Status | Remark                                   |
+|-----------|--------|------------------------------------------|
+| N02.FR.01 | ✅     |                                          |
+| N02.FR.02 |        | Everything is supported by our charger   |
+| N02.FR.03 | ✅     |                                          |
+| N02.FR.04 | ✅     |                                          |
+| N02.FR.05 | ✅     |                                          |
+| N02.FR.06 | ✅     |                                          |
+| N02.FR.07 | ✅     |                                          |
+| N02.FR.08 | ✅     |                                          |
+| N02.FR.09 | ✅     |                                          |
+| N02.FR.10 | ✅     |                                          |
+| N02.FR.11 | ✅     |                                          |
+| N02.FR.12 | ✅     |                                          |
+| N02.FR.13 | ✅     |                                          |
+| N02.FR.14 | ✅     |                                          |
+| N02.FR.15 | ✅     |                                          |
+| N02.FR.16 | ✅     |                                          |
+| N02.FR.17 | ✅     |                                          |
+| N02.FR.18 |        |                                          |
+| N02.FR.19 |        |                                          |
+| N02.FR.20 |        |                                          |
+| N02.FR.21 |        |                                          |
 
 ## Diagnostics - Set Monitoring Base
 
-| ID        | Status | Remark |
-|-----------|--------|--------|
-| N03.FR.01 |        |        |
-| N03.FR.02 |        |        |
-| N03.FR.03 |        |        |
-| N03.FR.04 |        |        |
-| N03.FR.05 |        |        |
+| ID        | Status | Remark                                   |
+|-----------|--------|------------------------------------------|
+| N03.FR.01 | ✅     |                                          |
+| N03.FR.02 |        | Everything is supported on our charger   |
+| N03.FR.03 | ✅     |                                          |
+| N03.FR.04 | ✅     |                                          |
+| N03.FR.05 | ✅     |                                          |
 
 ## Diagnostics - Set Variable Monitoring
 

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1658,23 +1658,27 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| N02.FR.01 |        |        |
+| N02.FR.01 | ✅     |        |
 | N02.FR.02 |        |        |
-| N02.FR.03 |        |        |
-| N02.FR.04 |        |        |
-| N02.FR.05 |        |        |
-| N02.FR.06 |        |        |
-| N02.FR.07 |        |        |
-| N02.FR.08 |        |        |
-| N02.FR.09 |        |        |
-| N02.FR.10 |        |        |
-| N02.FR.11 |        |        |
-| N02.FR.12 |        |        |
-| N02.FR.13 |        |        |
-| N02.FR.14 |        |        |
-| N02.FR.15 |        |        |
-| N02.FR.16 |        |        |
-| N02.FR.17 |        |        |
+| N02.FR.03 | ✅     |        |
+| N02.FR.04 | ✅     |        |
+| N02.FR.05 | ✅     |        |
+| N02.FR.06 | ✅     |        |
+| N02.FR.07 | ✅     |        |
+| N02.FR.08 | ✅     |        |
+| N02.FR.09 | ✅     |        |
+| N02.FR.10 | ✅     |        |
+| N02.FR.11 | ✅     |        |
+| N02.FR.12 | ✅     |        |
+| N02.FR.13 | ✅     |        |
+| N02.FR.14 | ✅     |        |
+| N02.FR.15 | ✅     |        |
+| N02.FR.16 | ✅     |        |
+| N02.FR.17 | ✅     |        |
+| N02.FR.18 |        |        |
+| N02.FR.19 |        |        |
+| N02.FR.20 |        |        |
+| N02.FR.21 |        |        |
 
 ## Diagnostics - Set Monitoring Base
 

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1659,7 +1659,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | ID        | Status | Remark                                   |
 |-----------|--------|------------------------------------------|
 | N02.FR.01 | ✅     |                                          |
-| N02.FR.02 |        | Everything is supported by our charger   |
+| N02.FR.02 | ❎     | Everything is supported by our charger   |
 | N02.FR.03 | ✅     |                                          |
 | N02.FR.04 | ✅     |                                          |
 | N02.FR.05 | ✅     |                                          |
@@ -1685,7 +1685,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | ID        | Status | Remark                                   |
 |-----------|--------|------------------------------------------|
 | N03.FR.01 | ✅     |                                          |
-| N03.FR.02 |        | Everything is supported on our charger   |
+| N03.FR.02 | ❎     | Everything is supported on our charger   |
 | N03.FR.03 | ✅     |                                          |
 | N03.FR.04 | ✅     |                                          |
 | N03.FR.05 | ✅     |                                          |

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -16,6 +16,7 @@
 #include <ocpp/v201/device_model_storage.hpp>
 #include <ocpp/v201/enums.hpp>
 #include <ocpp/v201/evse_manager.hpp>
+#include <ocpp/v201/monitoring_updater.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/ocsp_updater.hpp>
 #include <ocpp/v201/types.hpp>
@@ -473,6 +474,10 @@ private:
 
     /// \brief Handler for automatic or explicit OCSP cache updates
     OcspUpdater ocsp_updater;
+
+    /// \brief Updater for triggered monitors
+    MonitoringUpdater monitoring_updater;
+
     /// \brief optional delay to resumption of message queue after reconnecting to the CSMS
     std::chrono::seconds message_queue_resume_delay = std::chrono::seconds(0);
 

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -65,6 +65,7 @@ extern const ComponentVariable& IFace;
 extern const ComponentVariable& OcspRequestInterval;
 extern const ComponentVariable& WebsocketPingPayload;
 extern const ComponentVariable& WebsocketPongTimeout;
+extern const ComponentVariable& VariableMonitoringProcessTime;
 extern const ComponentVariable& MaxCustomerInformationDataLength;
 extern const ComponentVariable& V2GCertificateExpireCheckInitialDelaySeconds;
 extern const ComponentVariable& V2GCertificateExpireCheckIntervalSeconds;

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -65,7 +65,7 @@ extern const ComponentVariable& IFace;
 extern const ComponentVariable& OcspRequestInterval;
 extern const ComponentVariable& WebsocketPingPayload;
 extern const ComponentVariable& WebsocketPongTimeout;
-extern const ComponentVariable& VariableMonitoringProcessTime;
+extern const ComponentVariable& MonitorsProcessingInterval;
 extern const ComponentVariable& MaxCustomerInformationDataLength;
 extern const ComponentVariable& V2GCertificateExpireCheckInitialDelaySeconds;
 extern const ComponentVariable& V2GCertificateExpireCheckIntervalSeconds;

--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -79,8 +79,8 @@ template <DataEnum T> bool is_type_numeric() {
 
 typedef std::function<void(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,
                            const Component& component, const Variable& variable,
-                           const VariableCharacteristics& characteristics, const std::string& value_previous,
-                           const std::string& value_current)>
+                           const VariableCharacteristics& characteristics, const VariableAttribute& attribute,
+                           const std::string& value_previous, const std::string& value_current)>
     on_variable_changed;
 
 /// \brief This class manages access to the device model representation and to the device model storage and provides
@@ -261,6 +261,8 @@ public:
     /// \return List of results of the requested operation
     std::vector<SetMonitoringResult> set_monitors(const std::vector<SetMonitoringData>& requests,
                                                   const VariableMonitorType type = VariableMonitorType::CustomMonitor);
+
+    bool update_monitor_reference(int32_t monitor_id, const std::string& reference_value);
 
     std::vector<VariableMonitoringPeriodic> get_periodic_monitors();
 

--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -64,9 +64,9 @@ template <DataEnum T> auto to_specific_type_auto(const std::string& value) {
     }
 }
 
-template<DataEnum T> bool is_type_numeric() {
+template <DataEnum T> bool is_type_numeric() {
     static_assert(T == DataEnum::string || T == DataEnum::integer || T == DataEnum::decimal ||
-                      T == DataEnum::dateTime || T == DataEnum::boolean || T == DataEnum::OptionList || 
+                      T == DataEnum::dateTime || T == DataEnum::boolean || T == DataEnum::OptionList ||
                       T == DataEnum::SequenceList || T == DataEnum::MemberList,
                   "Requested unknown datatype");
 
@@ -74,7 +74,7 @@ template<DataEnum T> bool is_type_numeric() {
         return true;
     } else {
         return false;
-    }    
+    }
 }
 
 typedef std::function<void(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,

--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -25,6 +25,11 @@ template <typename T> struct RequestDeviceModelResponse {
 /// \param value
 /// \return
 template <typename T> T to_specific_type(const std::string& value) {
+    static_assert(std::is_same<T, std::string>::value || std::is_same<T, int>::value ||
+                      std::is_same<T, double>::value || std::is_same<T, size_t>::value ||
+                      std::is_same<T, DateTime>::value || std::is_same<T, bool>::value,
+                  "Requested unknown datatype");
+
     if constexpr (std::is_same<T, std::string>::value) {
         return value;
     } else if constexpr (std::is_same<T, int>::value) {
@@ -32,18 +37,38 @@ template <typename T> T to_specific_type(const std::string& value) {
     } else if constexpr (std::is_same<T, double>::value) {
         return std::stod(value);
     } else if constexpr (std::is_same<T, size_t>::value) {
-        std::stringstream s(value);
-        size_t res;
-        s >> res;
+        size_t res = std::stoul(value);
         return res;
     } else if constexpr (std::is_same<T, DateTime>::value) {
         return DateTime(value);
     } else if constexpr (std::is_same<T, bool>::value) {
         return ocpp::conversions::string_to_bool(value);
-    } else {
-        EVLOG_AND_THROW(std::runtime_error("Requested unknown datatype"));
     }
 }
+
+template <DataEnum T> auto to_specific_type_auto(const std::string& value) {
+    static_assert(T == DataEnum::string || T == DataEnum::integer || T == DataEnum::decimal ||
+                      T == DataEnum::dateTime || T == DataEnum::boolean,
+                  "Requested unknown datatype");
+
+    if constexpr (T == DataEnum::string) {
+        return to_specific_type<std::string>(value);
+    } else if constexpr (T == DataEnum::integer) {
+        return to_specific_type<int>(value);
+    } else if constexpr (T == DataEnum::decimal) {
+        return to_specific_type<double>(value);
+    } else if constexpr (T == DataEnum::dateTime) {
+        return to_specific_type<DateTime>(value);
+    } else if constexpr (T == DataEnum::boolean) {
+        return to_specific_type<bool>(value);
+    }
+}
+
+typedef std::function<void(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,
+                           const Component& component, const Variable& variable,
+                           const VariableCharacteristics& characteristics, const std::string& value_previous,
+                           const std::string& value_current)>
+    on_variable_changed;
 
 /// \brief This class manages access to the device model representation and to the device model storage and provides
 /// functionality to support the use cases defined in the functional block Provisioning
@@ -52,6 +77,9 @@ class DeviceModel {
 private:
     DeviceModelMap device_model;
     std::unique_ptr<DeviceModelStorage> storage;
+
+    /// \brief Listener for the internal change of a variable
+    on_variable_changed variable_listener;
 
     /// \brief Private helper method that does some checks with the device model representation in memory to evaluate if
     /// a value for the given parameters can be requested. If it can be requested it will be retrieved from the device
@@ -208,6 +236,10 @@ public:
     get_custom_report_data(const std::optional<std::vector<ComponentVariable>>& component_variables = std::nullopt,
                            const std::optional<std::vector<ComponentCriterionEnum>>& component_criteria = std::nullopt);
 
+    void register_variable_listener(on_variable_changed&& listener) {
+        variable_listener = std::move(listener);
+    }
+
     /// \brief Sets the given monitor \p requests in the device model
     /// \param request
     /// \param type The type of the set monitors. HardWiredMonitor - used for OEM specific monitors,
@@ -216,6 +248,8 @@ public:
     /// \return List of results of the requested operation
     std::vector<SetMonitoringResult> set_monitors(const std::vector<SetMonitoringData>& requests,
                                                   const VariableMonitorType type = VariableMonitorType::CustomMonitor);
+
+    std::vector<VariableMonitoringPeriodic> get_periodic_monitors();
 
     /// \brief Gets the Monitoring data for the request \p criteria and \p component_variables
     /// \param criteria

--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -64,6 +64,19 @@ template <DataEnum T> auto to_specific_type_auto(const std::string& value) {
     }
 }
 
+template<DataEnum T> bool is_type_numeric() {
+    static_assert(T == DataEnum::string || T == DataEnum::integer || T == DataEnum::decimal ||
+                      T == DataEnum::dateTime || T == DataEnum::boolean || T == DataEnum::OptionList || 
+                      T == DataEnum::SequenceList || T == DataEnum::MemberList,
+                  "Requested unknown datatype");
+
+    if constexpr (T == DataEnum::integer || T == DataEnum::decimal) {
+        return true;
+    } else {
+        return false;
+    }    
+}
+
 typedef std::function<void(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,
                            const Component& component, const Variable& variable,
                            const VariableCharacteristics& characteristics, const std::string& value_previous,

--- a/include/ocpp/v201/device_model_storage.hpp
+++ b/include/ocpp/v201/device_model_storage.hpp
@@ -102,6 +102,8 @@ public:
     virtual std::optional<VariableMonitoringMeta> set_monitoring_data(const SetMonitoringData& data,
                                                                       const VariableMonitorType type) = 0;
 
+    virtual bool update_monitoring_reference(int32_t monitor_id, const std::string& reference_value) = 0;
+
     /// \brief Returns all the monitors currently in the database based
     /// on the provided filtering criteria
     /// \param criteria

--- a/include/ocpp/v201/device_model_storage.hpp
+++ b/include/ocpp/v201/device_model_storage.hpp
@@ -22,6 +22,12 @@ struct VariableMonitoringMeta {
     std::optional<std::string> reference_value;
 };
 
+struct VariableMonitoringPeriodic {
+    Component component;
+    Variable variable;
+    std::vector<VariableMonitoringMeta> monitors;
+};
+
 /// \brief Helper struct that combines VariableCharacteristics and VariableMonitoring
 struct VariableMetaData {
     VariableCharacteristics characteristics;

--- a/include/ocpp/v201/device_model_storage.hpp
+++ b/include/ocpp/v201/device_model_storage.hpp
@@ -22,6 +22,7 @@ struct VariableMonitoringMeta {
     std::optional<std::string> reference_value;
 };
 
+/// \brief Helper struct that contains all monitors related to a variable that are of a periodic type
 struct VariableMonitoringPeriodic {
     Component component;
     Variable variable;
@@ -102,7 +103,12 @@ public:
     virtual std::optional<VariableMonitoringMeta> set_monitoring_data(const SetMonitoringData& data,
                                                                       const VariableMonitorType type) = 0;
 
-    virtual bool update_monitoring_reference(int32_t monitor_id, const std::string& reference_value) = 0;
+    /// \brief Updates the reference value for a monitor. The reference values is used for the
+    /// delta monitors to detect a trigger, and must be updated when a trigger is detected
+    /// \param monitor_id Id of the monitor that requires the reference changed
+    /// \param reference_value Value to replace the reference with
+    /// \return true if the reference value could be updated, false otherwise
+    virtual bool update_monitoring_reference(const int32_t monitor_id, const std::string& reference_value) = 0;
 
     /// \brief Returns all the monitors currently in the database based
     /// on the provided filtering criteria

--- a/include/ocpp/v201/device_model_storage_sqlite.hpp
+++ b/include/ocpp/v201/device_model_storage_sqlite.hpp
@@ -56,6 +56,8 @@ public:
     std::optional<VariableMonitoringMeta> set_monitoring_data(const SetMonitoringData& data,
                                                               const VariableMonitorType type) final;
 
+    bool update_monitoring_reference(int32_t monitor_id, const std::string& reference_value) final;
+
     std::vector<VariableMonitoringMeta> get_monitoring_data(const std::vector<MonitoringCriterionEnum>& criteria,
                                                             const Component& component_id,
                                                             const Variable& variable_id) final;

--- a/include/ocpp/v201/device_model_storage_sqlite.hpp
+++ b/include/ocpp/v201/device_model_storage_sqlite.hpp
@@ -56,7 +56,7 @@ public:
     std::optional<VariableMonitoringMeta> set_monitoring_data(const SetMonitoringData& data,
                                                               const VariableMonitorType type) final;
 
-    bool update_monitoring_reference(int32_t monitor_id, const std::string& reference_value) final;
+    bool update_monitoring_reference(const int32_t monitor_id, const std::string& reference_value) final;
 
     std::vector<VariableMonitoringMeta> get_monitoring_data(const std::vector<MonitoringCriterionEnum>& criteria,
                                                             const Component& component_id,

--- a/include/ocpp/v201/enums.hpp
+++ b/include/ocpp/v201/enums.hpp
@@ -1191,10 +1191,11 @@ enum class VariableMonitorType {
 
 // from: NotifyEventRequest
 enum class EventNotificationEnum {
-    HardWiredNotification,
-    HardWiredMonitor,
-    PreconfiguredMonitor,
-    CustomMonitor,
+    HardWiredNotification, // The software implemented by the manufacturer triggered a hardwired notification.
+    HardWiredMonitor,      // Triggered by a monitor, which is hardwired by the manufacturer.
+    PreconfiguredMonitor,  // Triggered by a monitor, which is preconfigured by the manufacturer.
+    CustomMonitor, // Triggered by a monitor, which is set with the setvariablemonitoringrequest message by the Charging
+                   // Station Operator.
 };
 
 namespace conversions {

--- a/include/ocpp/v201/monitoring_updater.hpp
+++ b/include/ocpp/v201/monitoring_updater.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
 
 #pragma once
 

--- a/include/ocpp/v201/monitoring_updater.hpp
+++ b/include/ocpp/v201/monitoring_updater.hpp
@@ -24,6 +24,9 @@ struct TriggeredMonitorData {
     std::string value_previous;
     std::string value_current;
 
+    // \brief Write-only values will not have the value reported
+    bool is_writeonly;
+
     /// \brief If the trigger was sent to the CSMS. We'll keep a copy since we'll also detect
     /// when the monitor returns back to normal
     bool csms_sent;
@@ -65,8 +68,8 @@ public:
 private:
     void on_variable_changed(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,
                              const Component& component, const Variable& variable,
-                             const VariableCharacteristics& characteristics, const std::string& value_old,
-                             const std::string& value_current);
+                             const VariableCharacteristics& characteristics, const VariableAttribute& attribute,
+                             const std::string& value_old, const std::string& value_current);
 
     void process_periodic_monitors();
 

--- a/include/ocpp/v201/monitoring_updater.hpp
+++ b/include/ocpp/v201/monitoring_updater.hpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <unordered_map>
+
+#include <everest/timer.hpp>
+
+#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_types.hpp>
+
+#include <ocpp/v201/device_model_storage.hpp>
+
+namespace ocpp::v201 {
+
+class DeviceModel;
+
+struct TriggeredMonitorData {
+    VariableMonitoringMeta monitor_meta;
+    Component component;
+    Variable variable;
+
+    std::string value_previous;
+    std::string value_current;
+
+    /// \brief If the trigger was sent to the CSMS. We'll keep a copy since we'll also detect
+    /// when the monitor returns back to normal
+    bool csms_sent;
+
+    /// \brief The trigger has been cleared, that is it returned to normal after a problem
+    /// was detected. Can be removed from the map when it was cleared
+    bool cleared;
+};
+
+struct PeriodicMonitorData {
+    VariableMonitoringMeta monitor_meta;
+    Component component;
+    Variable variable;
+
+    /// \brief Last time we've triggered a periodic delta monitor
+    std::chrono::time_point<std::chrono::steady_clock> last_trigger_steady;
+
+    /// \brief Next time when we require to trigger a clock aligned value
+    std::chrono::time_point<std::chrono::system_clock> next_trigger_clock_aligned;
+};
+
+typedef std::function<void(const std::vector<EventData>&)> notify_events;
+typedef std::function<bool()> is_offline;
+
+class MonitoringUpdater {
+
+public:
+    MonitoringUpdater() = delete;
+    MonitoringUpdater(std::shared_ptr<DeviceModel> device_model, notify_events notify_csms_events,
+                      is_offline is_chargepoint_offline);
+    ~MonitoringUpdater();
+
+public:
+    void start_monitoring();
+    void stop_monitoring();
+
+    void process_triggered_monitors();
+
+private:
+    void on_variable_changed(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,
+                             const Component& component, const Variable& variable,
+                             const VariableCharacteristics& characteristics, const std::string& value_old,
+                             const std::string& value_current);
+
+    void process_periodic_monitors();
+
+private:
+    std::shared_ptr<DeviceModel> device_model;
+    Everest::SteadyTimer monitors_timer;
+
+    // TODO (ioan): does this have to be persisted in case of a reboot?
+    int32_t unique_id;
+
+    notify_events notify_csms_events;
+    is_offline is_chargepoint_offline;
+
+    // TODO (ioan): not entirely clear, but according to N07.FR.13 these seem to be persistent across reboots?
+    std::unordered_map<int32_t, TriggeredMonitorData> triggered_monitors;
+    std::unordered_map<int32_t, PeriodicMonitorData> periodic_monitors;
+};
+
+} // namespace ocpp::v201

--- a/include/ocpp/v201/monitoring_updater.hpp
+++ b/include/ocpp/v201/monitoring_updater.hpp
@@ -74,7 +74,7 @@ private:
     std::shared_ptr<DeviceModel> device_model;
     Everest::SteadyTimer monitors_timer;
 
-    // TODO (ioan): does this have to be persisted in case of a reboot?
+    // To->CSMS message unique ID
     int32_t unique_id;
 
     notify_events notify_csms_events;

--- a/include/ocpp/v201/monitoring_updater.hpp
+++ b/include/ocpp/v201/monitoring_updater.hpp
@@ -77,13 +77,12 @@ private:
     std::shared_ptr<DeviceModel> device_model;
     Everest::SteadyTimer monitors_timer;
 
-    // To->CSMS message unique ID
+    // Charger to CSMS message unique ID for EventData
     int32_t unique_id;
 
     notify_events notify_csms_events;
     is_offline is_chargepoint_offline;
 
-    // TODO (ioan): not entirely clear, but according to N07.FR.13 these seem to be persistent across reboots?
     std::unordered_map<int32_t, TriggeredMonitorData> triggered_monitors;
     std::unordered_map<int32_t, PeriodicMonitorData> periodic_monitors;
 };

--- a/include/ocpp/v201/monitoring_updater.hpp
+++ b/include/ocpp/v201/monitoring_updater.hpp
@@ -55,22 +55,45 @@ class MonitoringUpdater {
 
 public:
     MonitoringUpdater() = delete;
+
+    /// \brief Constructs a new variable monitor updater
+    /// \param device_model Currently used variable device model
+    /// \param notify_csms_events Function that can be invoked with a number of alert events
+    /// \param is_chargepoint_offline Function that can be invoked in order to retrieve the
+    /// status of the charging station connection to the CSMS
     MonitoringUpdater(std::shared_ptr<DeviceModel> device_model, notify_events notify_csms_events,
                       is_offline is_chargepoint_offline);
     ~MonitoringUpdater();
 
 public:
+    /// \brief Starts monitoring the variables, kicking the timer
     void start_monitoring();
+    /// \brief Stops monitoring the variables, canceling the timer
     void stop_monitoring();
 
+    /// \brief Processes the variable triggered monitors. Will be called
+    /// after relevant variable modification operations or will be called
+    /// periodically in case that processing can not be done at the current
+    /// moment, for example in the case of an internal variable modification
     void process_triggered_monitors();
 
 private:
+    /// \brief Callback that is registered to the 'device_model' that determines if any of
+    /// the monitors are triggered for a certain variable when the internal value is used. Will
+    /// delay the sending of the monitors to the CSMS until the charging station has
+    /// finished any current operation. The reason is that a variable can change during an
+    /// operation where the CSMS does NOT expect a message of type 'EventData' therefore
+    /// the processing is delayed either until a manual call to 'process_triggered_monitors'
+    /// or when the periodic monitoring timer is hit
     void on_variable_changed(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,
                              const Component& component, const Variable& variable,
                              const VariableCharacteristics& characteristics, const VariableAttribute& attribute,
                              const std::string& value_old, const std::string& value_current);
 
+    /// \brief Processes the periodic monitors. Since this can be somewhat of a costly
+    /// operation (DB query of each triggered monitor's actual value) the processing time
+    /// can be configured using the 'VariableMonitoringProcessTime' internal variable. If
+    // there are also any pending alert triggered monitors, those will be processed too
     void process_periodic_monitors();
 
 private:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -69,6 +69,7 @@ if(LIBOCPP_ENABLE_V201)
             ocpp/v201/message_queue.cpp
             ocpp/v201/ocpp_types.cpp
             ocpp/v201/ocsp_updater.cpp
+            ocpp/v201/monitoring_updater.cpp
             ocpp/v201/transaction.cpp
             ocpp/v201/types.cpp
             ocpp/v201/utils.cpp

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -84,9 +84,12 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
     firmware_status(FirmwareStatusEnum::Idle),
     upload_log_status(UploadLogStatusEnum::Idle),
     bootreason(BootReasonEnum::PowerUp),
-    ocsp_updater(
-        OcspUpdater(this->evse_security, this->send_callback<GetCertificateStatusRequest, GetCertificateStatusResponse>(
-                                             MessageType::GetCertificateStatusResponse))),
+    ocsp_updater(this->evse_security, this->send_callback<GetCertificateStatusRequest, GetCertificateStatusResponse>(
+                                          MessageType::GetCertificateStatusResponse)),
+    device_model(std::make_shared<DeviceModel>(std::move(device_model_storage))),
+    monitoring_updater(
+        device_model, [this](const std::vector<EventData>& events) { this->notify_event_req(events); },
+        [this]() { return this->is_offline(); }),
     csr_attempt(1),
     client_certificate_expiration_check_timer([this]() { this->scheduled_check_client_certificate_expiration(); }),
     v2g_certificate_expiration_check_timer([this]() { this->scheduled_check_v2g_certificate_expiration(); }),
@@ -97,7 +100,6 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
         EVLOG_AND_THROW(std::invalid_argument("All non-optional callbacks must be supplied"));
     }
 
-    this->device_model = std::make_shared<DeviceModel>(std::move(device_model_storage));
     this->device_model->check_integrity(evse_connector_structure);
 
     auto database_connection = std::make_unique<common::DatabaseConnection>(fs::path(core_database_path) / "cp.db");
@@ -163,7 +165,9 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
     // configure logging
     this->configure_message_logging_format(message_log_path);
 
-    // TODO - this should this be dependency injected.
+    // start monitoring
+    this->monitoring_updater.start_monitoring();
+
     this->message_queue = std::make_unique<ocpp::MessageQueue<v201::MessageType>>(
         [this](json message) -> bool { return this->websocket->send(message.dump()); },
         MessageQueueConfig{
@@ -238,6 +242,7 @@ void ChargePoint::stop() {
     this->websocket_timer.stop();
     this->client_certificate_expiration_check_timer.stop();
     this->v2g_certificate_expiration_check_timer.stop();
+    // this->monitoring_updater.stop_monitoring();
     this->disconnect_websocket(WebsocketCloseReason::Normal);
     this->message_queue->stop();
 }
@@ -1278,6 +1283,21 @@ void ChargePoint::handle_message(const EnhancedMessage<v201::MessageType>& messa
         break;
     case MessageType::CustomerInformation:
         this->handle_customer_information_req(json_message);
+        break;
+    case MessageType::SetMonitoringBase:
+        this->handle_set_monitoring_base_req(json_message);
+        break;
+    case MessageType::SetMonitoringLevel:
+        this->handle_set_monitoring_level_req(json_message);
+        break;
+    case MessageType::SetVariableMonitoring:
+        this->handle_set_variable_monitoring_req(message);
+        break;
+    case MessageType::GetMonitoringReport:
+        this->handle_get_monitoring_report_req(json_message);
+        break;
+    case MessageType::ClearVariableMonitoring:
+        this->handle_clear_variable_monitoring_req(json_message);
         break;
     default:
         if (message.messageTypeId == MessageTypeId::CALL) {

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -240,6 +240,13 @@ const ComponentVariable& WebsocketPongTimeout = {
         "WebsocketPongTimeout",
     }),
 };
+const ComponentVariable& VariableMonitoringProcessTime = {
+    ControllerComponents::InternalCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "VariableMonitoringProcessTime",
+    }),
+};
 const ComponentVariable& MaxCustomerInformationDataLength = {
     ControllerComponents::InternalCtrlr,
     std::nullopt,

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -240,11 +240,11 @@ const ComponentVariable& WebsocketPongTimeout = {
         "WebsocketPongTimeout",
     }),
 };
-const ComponentVariable& VariableMonitoringProcessTime = {
+const ComponentVariable& MonitorsProcessingInterval = {
     ControllerComponents::InternalCtrlr,
     std::nullopt,
     std::optional<Variable>({
-        "VariableMonitoringProcessTime",
+        "MonitorsProcessingInterval",
     }),
 };
 const ComponentVariable& MaxCustomerInformationDataLength = {

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -534,8 +534,8 @@ std::vector<SetMonitoringResult> DeviceModel::set_monitors(const std::vector<Set
 
         if (characteristics.supportsMonitoring) {
             EVLOG_debug << "Validating monitor request of type: [" << request << "] and characteristics: ["
-                       << characteristics << "]"
-                       << " and value: " << request.value;
+                        << characteristics << "]"
+                        << " and value: " << request.value;
 
             // If the monitor is of type 'delta' (or periodic) and it is of a non-numeric
             // type the value is ignored since all values will be reported

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -573,7 +573,7 @@ std::vector<SetMonitoringResult> DeviceModel::set_monitors(const std::vector<Set
         bool duplicate_value = false;
 
         // Only test for duplicates if we do not receive an explicit monitor ID
-        if(!request.id.has_value()) {
+        if (!request.id.has_value()) {
             for (const auto& [id, monitor_meta] : variable_it->second.monitors) {
                 if (monitor_meta.monitor.type == request.type && monitor_meta.monitor.severity == request.severity) {
                     duplicate_value = true;

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -448,6 +448,8 @@ bool DeviceModel::update_monitor_reference(int32_t monitor_id, const std::string
 
     // See if this is a trivial delta monitor and that it exists
     for (auto& [component, variable_map] : this->device_model) {
+        bool found_monitor_id = false;
+
         for (auto& [variable, variable_meta_data] : variable_map) {
             auto it = variable_meta_data.monitors.find(monitor_id);
             if (it != std::end(variable_meta_data.monitors)) {
@@ -465,11 +467,15 @@ bool DeviceModel::update_monitor_reference(int32_t monitor_id, const std::string
                     found_monitor = false;
                 }
 
-                goto loop_end;
+                found_monitor_id = true;
+                break; // Break inner loop
             }
         }
+
+        if (found_monitor_id) {
+            break; // Break outer loop
+        }
     }
-loop_end:
 
     if (found_monitor) {
         try {

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -533,7 +533,7 @@ std::vector<SetMonitoringResult> DeviceModel::set_monitors(const std::vector<Set
         bool valid_value = true;
 
         if (characteristics.supportsMonitoring) {
-            EVLOG_info << "Validating monitor request of type: [" << request << "] and characteristics: ["
+            EVLOG_debug << "Validating monitor request of type: [" << request << "] and characteristics: ["
                        << characteristics << "]"
                        << " and value: " << request.value;
 

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -277,8 +277,9 @@ SetVariableStatusEnum DeviceModel::set_value(const Component& component, const V
 
         // If we had a variable value change, trigger the listener
         if (!monitors.empty()) {
-            // TODO (ioan): Are we in danger of an empty value problem here?
-            const std::string& value_previous = attribute.value().value.value();
+            static const std::string EMPTY_VALUE{};
+
+            const std::string& value_previous = attribute.value().value.value_or(EMPTY_VALUE);
             const std::string& value_current = value;
 
             if (value_previous != value_current) {

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -544,7 +544,7 @@ std::vector<SetMonitoringResult> DeviceModel::set_monitors(const std::vector<Set
                 valid_value = true;
             } else if (request.type == MonitorEnum::Delta && (characteristics.dataType == DataEnum::decimal ||
                                                               characteristics.dataType == DataEnum::integer)) {
-                // Seem that TC_N_43_CS, sees a negative delta as an error, I certainly do not
+                // N04.FR.14 - negative delta is an error
                 if (request.value < 0.0f) {
                     valid_value = false;
                 }
@@ -580,6 +580,17 @@ std::vector<SetMonitoringResult> DeviceModel::set_monitors(const std::vector<Set
                     duplicate_value = true;
                     break;
                 }
+            }
+        } else {
+            // N04.FR.13 - If we receive an ID but we can't find a monitor
+            // with this ID send a rejected result
+            bool id_missing =
+                (variable_it->second.monitors.find(request.id.value()) == std::end(variable_it->second.monitors));
+
+            if (id_missing) {
+                result.status = SetMonitoringStatusEnum::Rejected;
+                set_monitors_res.push_back(result);
+                continue;
             }
         }
 

--- a/lib/ocpp/v201/device_model_storage_sqlite.cpp
+++ b/lib/ocpp/v201/device_model_storage_sqlite.cpp
@@ -285,6 +285,8 @@ std::optional<VariableMonitoringMeta> DeviceModelStorageSqlite::set_monitoring_d
 
     auto insert_stmt = this->db->new_statement(insert_query);
 
+    EVLOG_info << "Inserting new monitor with query: " << insert_query;
+
     insert_stmt->bind_int(1, _variable_id);
     insert_stmt->bind_int(2, data.severity);
     insert_stmt->bind_int(3, data.transaction.value_or(false));
@@ -302,6 +304,11 @@ std::optional<VariableMonitoringMeta> DeviceModelStorageSqlite::set_monitoring_d
     if (data.id.has_value()) {
         insert_stmt->bind_int(8, data.id.value());
     }
+
+    EVLOG_info << "Insert data: " << _variable_id << " severity: " 
+               << data.severity << " value: " << data.value 
+               << " actual value: " << actual_value.value_or("NULL")
+               << " id: " << data.id.value_or(-1000);
 
     if (insert_stmt->step() != SQLITE_DONE) {
         EVLOG_error << this->db->get_error_message();

--- a/lib/ocpp/v201/device_model_storage_sqlite.cpp
+++ b/lib/ocpp/v201/device_model_storage_sqlite.cpp
@@ -252,7 +252,6 @@ bool DeviceModelStorageSqlite::update_monitoring_reference(int32_t monitor_id, c
 
     std::string update_query = "UPDATE VARIABLE_MONITORING SET REFERENCE_VALUE = ? WHERE ID = ?";
     auto update_stmt = this->db->new_statement(update_query);
-    EVLOG_info << "Updating monitor reference with query: " << update_query;
 
     update_stmt->bind_text(1, reference_value, SQLiteString::Transient);
     update_stmt->bind_int(2, monitor_id);
@@ -265,7 +264,6 @@ bool DeviceModelStorageSqlite::update_monitoring_reference(int32_t monitor_id, c
     transaction->commit();
 
     int changes = update_stmt->changes();
-    EVLOG_info << "Updated rows: " << changes;
 
     return (changes == 1);
 }
@@ -307,7 +305,6 @@ std::optional<VariableMonitoringMeta> DeviceModelStorageSqlite::set_monitoring_d
     }
 
     auto insert_stmt = this->db->new_statement(insert_query);
-    EVLOG_info << "Inserting new monitor with query: " << insert_query;
 
     insert_stmt->bind_int(1, _variable_id);
     insert_stmt->bind_int(2, data.severity);
@@ -326,9 +323,6 @@ std::optional<VariableMonitoringMeta> DeviceModelStorageSqlite::set_monitoring_d
     if (data.id.has_value()) {
         insert_stmt->bind_int(8, data.id.value());
     }
-
-    EVLOG_info << "Insert data: " << _variable_id << " severity: " << data.severity << " value: " << data.value
-               << " actual value: " << actual_value.value_or("NULL") << " id: " << data.id.value_or(-1000);
 
     if (insert_stmt->step() != SQLITE_DONE) {
         EVLOG_error << this->db->get_error_message();

--- a/lib/ocpp/v201/device_model_storage_sqlite.cpp
+++ b/lib/ocpp/v201/device_model_storage_sqlite.cpp
@@ -298,12 +298,12 @@ std::optional<VariableMonitoringMeta> DeviceModelStorageSqlite::set_monitoring_d
 
     if (data.id.has_value()) {
         insert_query = "INSERT OR REPLACE INTO VARIABLE_MONITORING (VARIABLE_ID, SEVERITY, 'TRANSACTION', TYPE_ID, "
-                       "CONFIG_TYPE_ID, VALUE, REFERENCE_VALUE) "
-                       "VALUES (?, ?, ?, ?, ?, ?, ?)";
-    } else {
-        insert_query = "INSERT OR REPLACE INTO VARIABLE_MONITORING (VARIABLE_ID, SEVERITY, 'TRANSACTION', TYPE_ID, "
                        "CONFIG_TYPE_ID, VALUE, REFERENCE_VALUE, ID) "
                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+    } else {
+        insert_query = "INSERT OR REPLACE INTO VARIABLE_MONITORING (VARIABLE_ID, SEVERITY, 'TRANSACTION', TYPE_ID, "
+                       "CONFIG_TYPE_ID, VALUE, REFERENCE_VALUE) "
+                       "VALUES (?, ?, ?, ?, ?, ?, ?)";
     }
 
     auto insert_stmt = this->db->new_statement(insert_query);

--- a/lib/ocpp/v201/device_model_storage_sqlite.cpp
+++ b/lib/ocpp/v201/device_model_storage_sqlite.cpp
@@ -247,7 +247,8 @@ bool DeviceModelStorageSqlite::set_variable_attribute_value(const Component& com
     return true;
 }
 
-bool DeviceModelStorageSqlite::update_monitoring_reference(int32_t monitor_id, const std::string& reference_value) {
+bool DeviceModelStorageSqlite::update_monitoring_reference(const int32_t monitor_id,
+                                                           const std::string& reference_value) {
     auto transaction = this->db->begin_transaction();
 
     std::string update_query = "UPDATE VARIABLE_MONITORING SET REFERENCE_VALUE = ? WHERE ID = ?";

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -487,6 +487,10 @@ void MonitoringUpdater::process_triggered_monitors() {
 
                 EventData notify_event = std::move(create_notify_event(unique_id++, reported_value, trigger.component,
                                                                        trigger.variable, trigger.monitor_meta));
+                // Mark if the event is cleared (returned to normal)
+                if (trigger.cleared) {
+                    notify_event.cleared = trigger.cleared;
+                }
 
                 // Mark the triggers as CSMS sent
                 trigger.csms_sent = true;

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -151,7 +151,7 @@ void MonitoringUpdater::start_monitoring() {
     device_model->register_variable_listener(std::move(fn));
 
     int process_interval_seconds =
-        this->device_model->get_optional_value<int>(ControllerComponentVariables::VariableMonitoringProcessTime)
+        this->device_model->get_optional_value<int>(ControllerComponentVariables::MonitorsProcessingInterval)
             .value_or(1);
 
     monitors_timer.interval(std::chrono::seconds(process_interval_seconds));

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -139,13 +139,15 @@ void MonitoringUpdater::on_variable_changed(const std::unordered_map<int64_t, Va
                                             const VariableCharacteristics& characteristics,
                                             const VariableAttribute& attribute, const std::string& value_previous,
                                             const std::string& value_current) {
-    EVLOG_info << "Variable: " << variable.name.get() << " changed value from: " << value_previous
-               << " to: " << value_current;
+    EVLOG_info << "Variable: " << variable.name.get() << " changed value from: [" << value_previous
+               << "] to: [" << value_current << "]";
 
     // Ignore non-actual values
     if (attribute.type.has_value() && attribute.type.value() != AttributeEnum::Actual) {
         return;
     }
+
+    EVLOG_info << "Processing variable: [" << variable.name.get() << "] with monitors: " << monitors.size();
 
     // Iterate monitors and search for a triggered monitor
     for (const auto& [monitor_id, monitor_meta] : monitors) {
@@ -174,6 +176,8 @@ void MonitoringUpdater::on_variable_changed(const std::unordered_map<int64_t, Va
         } else {
             EVLOG_AND_THROW(std::runtime_error("Requested unsupported 'DataEnum' type"));
         }
+
+        EVLOG_info << "Monitor: [" << monitor_meta.monitor << "] triggered: " << monitor_triggered;
 
         auto it = triggered_monitors.find(monitor_id);
 

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v201/monitoring_updater.hpp>
+
+#include <chrono>
+
+#include <ocpp/v201/ctrlr_component_variables.hpp>
+#include <ocpp/v201/device_model.hpp>
+#include <ocpp/v201/utils.hpp>
+
+namespace ocpp::v201 {
+
+template <DataEnum T>
+bool triggers_monitor(const VariableMonitoringMeta& monitor_meta, const std::string& value_old,
+                      const std::string& value_new) {
+    if constexpr (T == DataEnum::boolean) {
+        return (value_old != value_new);
+    } else {
+        auto raw_val_current = to_specific_type_auto<T>(value_old);
+
+        if (monitor_meta.monitor.type == MonitorEnum::Delta) {
+            // TODO (ioan): the reference value should never be null but see for ref access except
+            auto raw_val_reference = to_specific_type_auto<T>(monitor_meta.reference_value.value());
+            auto raw_val_new = to_specific_type_auto<T>(value_new);
+
+            auto delta = std::abs(raw_val_reference - raw_val_new);
+
+            return (delta > monitor_meta.monitor.value);
+        } else if (monitor_meta.monitor.type == MonitorEnum::LowerThreshold) {
+            return (raw_val_current < monitor_meta.monitor.value);
+        } else if (monitor_meta.monitor.type == MonitorEnum::UpperThreshold) {
+            return (raw_val_current > monitor_meta.monitor.value);
+        } else {
+            EVLOG_AND_THROW(std::runtime_error("Requested unsupported trigger monitor"));
+        }
+    }
+
+    return false;
+}
+
+std::chrono::time_point<std::chrono::system_clock> get_next_clock_aligned_point(float monitor_interval) {
+    auto monitor_seconds =
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<float>(monitor_interval));
+
+    auto sys_time_now = std::chrono::system_clock::now();
+    auto hours_now = std::chrono::floor<std::chrono::hours>(sys_time_now);
+    auto seconds_now = std::chrono::duration_cast<std::chrono::seconds>(sys_time_now - hours_now);
+
+    // Round next seconds, for ex at a interval of 900 while we are at second 2700 will yield
+    // the result is 3600, and that is a roll-over, we will call the next monitor at the precise hour
+    auto next_seconds =
+        (std::ceil((double)seconds_now.count() / (double)monitor_seconds.count()) * monitor_seconds).count();
+
+    std::chrono::time_point<std::chrono::system_clock> aligned_timepoint;
+
+    if (next_seconds >= static_cast<decltype(next_seconds)>(3600)) {
+        // If we rolled over, move to the next hour
+        aligned_timepoint = (hours_now + std::chrono::hours(1));
+    } else {
+        aligned_timepoint = (hours_now + std::chrono::duration_cast<std::chrono::seconds>(
+                                             std::chrono::duration<decltype(next_seconds)>(next_seconds)));
+    }
+
+    auto dbg_time_now = std::chrono::system_clock::to_time_t(sys_time_now);
+    auto dbg_time_aligned = std::chrono::system_clock::to_time_t(aligned_timepoint);
+    EVLOG_info << "Aligned time: " << std::ctime(&dbg_time_now) << " with interval: " << monitor_seconds.count()
+               << " to next timepoint: " << std::ctime(&dbg_time_aligned);
+
+    return aligned_timepoint;
+}
+
+EventData create_notify_event(int32_t unique_id, const std::string& reported_value, const Component& component,
+                              const Variable& variable, const VariableMonitoringMeta& monitor_meta) {
+    EventData notify_event;
+
+    notify_event.component = component;
+    notify_event.variable = variable;
+    notify_event.variableMonitoringId = monitor_meta.monitor.id;
+
+    notify_event.eventId = unique_id;
+    notify_event.timestamp = ocpp::DateTime();
+    notify_event.actualValue = reported_value;
+
+    if (monitor_meta.monitor.type == MonitorEnum::Periodic ||
+        monitor_meta.monitor.type == MonitorEnum::PeriodicClockAligned) {
+        notify_event.trigger = EventTriggerEnum::Periodic;
+    } else if (monitor_meta.monitor.type == MonitorEnum::Delta) {
+        notify_event.trigger = EventTriggerEnum::Delta;
+    } else if (monitor_meta.monitor.type == MonitorEnum::UpperThreshold ||
+               monitor_meta.monitor.type == MonitorEnum::LowerThreshold) {
+        notify_event.trigger = EventTriggerEnum::Alerting;
+    } else {
+        EVLOG_AND_THROW(std::runtime_error("Invalid monitor type"));
+    }
+
+    if (monitor_meta.type == VariableMonitorType::HardWiredMonitor) {
+        notify_event.eventNotificationType = EventNotificationEnum::HardWiredMonitor;
+    } else if (monitor_meta.type == VariableMonitorType::PreconfiguredMonitor) {
+        notify_event.eventNotificationType = EventNotificationEnum::PreconfiguredMonitor;
+    } else if (monitor_meta.type == VariableMonitorType::CustomMonitor) {
+        notify_event.eventNotificationType = EventNotificationEnum::CustomMonitor;
+    } else {
+        EVLOG_AND_THROW(std::runtime_error("Invalid monitor meta type"));
+    }
+
+    return notify_event;
+}
+
+MonitoringUpdater::MonitoringUpdater(std::shared_ptr<DeviceModel> device_model, notify_events notify_csms_events,
+                                     is_offline is_chargepoint_offline) :
+    device_model(std::move(device_model)),
+    notify_csms_events(std::move(notify_csms_events)),
+    is_chargepoint_offline(std::move(is_chargepoint_offline)),
+    monitors_timer([this]() { this->process_periodic_monitors(); }),
+    unique_id(0) {
+}
+
+MonitoringUpdater::~MonitoringUpdater() {
+    stop_monitoring();
+}
+
+void MonitoringUpdater::start_monitoring() {
+    // Bind function to this instance
+    auto fn = std::bind(&MonitoringUpdater::on_variable_changed, this, std::placeholders::_1, std::placeholders::_2,
+                        std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6);
+    device_model->register_variable_listener(std::move(fn));
+
+    monitors_timer.interval(std::chrono::seconds(1));
+}
+
+void MonitoringUpdater::stop_monitoring() {
+    monitors_timer.stop();
+}
+
+void MonitoringUpdater::on_variable_changed(const std::unordered_map<int64_t, VariableMonitoringMeta>& monitors,
+                                            const Component& component, const Variable& variable,
+                                            const VariableCharacteristics& characteristics,
+                                            const std::string& value_previous, const std::string& value_current) {
+    EVLOG_info << "Variable: " << variable.name.get() << " changed value from: " << value_previous
+               << " to: " << value_current;
+
+    // Iterate monitors and search for a triggered monitor
+    for (const auto& [monitor_id, monitor_meta] : monitors) {
+        // Don't care about periodic
+        switch (monitor_meta.monitor.type) {
+        case MonitorEnum::Periodic:
+        case MonitorEnum::PeriodicClockAligned:
+            continue;
+        }
+
+        bool monitor_triggered = false;
+
+        // N07.FR.19 - Based on this it seems that OptionList, SequenceList, MemberList will
+        // cause a trigger if the value is changed regardless of the content (or monitor delta)
+        if ((characteristics.dataType == DataEnum::boolean) || (characteristics.dataType == DataEnum::string) ||
+            (characteristics.dataType == DataEnum::dateTime) || (characteristics.dataType == DataEnum::OptionList) ||
+            (characteristics.dataType == DataEnum::MemberList) ||
+            (characteristics.dataType == DataEnum::SequenceList)) {
+            monitor_triggered = triggers_monitor<DataEnum::boolean>(monitor_meta, value_previous, value_current);
+        } else if (characteristics.dataType == DataEnum::decimal) {
+            monitor_triggered = triggers_monitor<DataEnum::decimal>(monitor_meta, value_previous, value_current);
+        } else if (characteristics.dataType == DataEnum::integer) {
+            monitor_triggered = triggers_monitor<DataEnum::integer>(monitor_meta, value_previous, value_current);
+        } else {
+            EVLOG_AND_THROW(std::runtime_error("Requested unsupported 'DataEnum' type"));
+        }
+
+        auto it = triggered_monitors.find(monitor_id);
+
+        if (monitor_triggered) {
+            if (it == std::end(triggered_monitors)) {
+                TriggeredMonitorData triggered;
+
+                triggered.component = component;
+                triggered.variable = variable;
+                triggered.monitor_meta = monitor_meta;
+                triggered.csms_sent = false;
+                triggered.cleared = false;
+
+                auto res = triggered_monitors.insert(std::pair{monitor_meta.monitor.id, std::move(triggered)});
+                if (!res.second) {
+                    EVLOG_warning << "Could not insert monitor to triggered monitor map!";
+                    continue;
+                }
+                it = res.first;
+
+                EVLOG_info << "Variable: " << variable.name.get() << " triggered monitor: " << monitor_id;
+            }
+
+            TriggeredMonitorData& triggered_data = it->second;
+
+            // Make it not cleared, that is in a 'dangerous' state
+            triggered_data.cleared = false;
+
+            // Update relevant values
+            triggered_data.value_previous = value_previous;
+            triggered_data.value_current = value_current;
+        } else {
+            // If the monitor is not triggered and we already have the data
+            // in our triggered list it means that we have returned to normal
+            if (it != std::end(triggered_monitors)) {
+                if (!it->second.cleared) {
+
+                    // Mark as cleared (a.k.a normal)
+                    it->second.cleared = true;
+
+                    // If it was previously sent to the CSMS, mark it as not sent
+                    // so that we can allow the CSMS to know that we had a return to normal
+                    it->second.csms_sent = false;
+
+                    EVLOG_info << "Variable: " << variable.name.get() << " cleared monitor: " << monitor_id;
+                }
+            }
+        }
+    }
+}
+
+void MonitoringUpdater::process_periodic_monitors() {
+    bool monitoring_enabled =
+        this->device_model->get_optional_value<bool>(ControllerComponentVariables::MonitoringCtrlrEnabled)
+            .value_or(false);
+
+    if (!monitoring_enabled) {
+        EVLOG_info << "Monitoring not enabled, not processing periodic monitors";
+        return;
+    }
+
+    // We don't persist the messages here, base on the  'OfflineQueuingSeverity'
+    // since the periodic monitors do not imply an alert
+    if (is_chargepoint_offline()) {
+        return;
+    }
+
+    int active_monitoring_level =
+        this->device_model->get_optional_value<int>(ControllerComponentVariables::ActiveMonitoringLevel)
+            .value_or(MontoringLevelSeverity::MAX);
+
+    EVLOG_info << "Processing periodic monitors";
+
+    std::vector<EventData> monitor_events;
+    auto monitors = this->device_model->get_periodic_monitors();
+
+    for (auto& component_variable_monitors : monitors) {
+        for (auto& periodic_monitor_meta : component_variable_monitors.monitors) {
+
+            // Skip monitors that have a severity > than our active monitoring level
+            if (periodic_monitor_meta.monitor.severity > active_monitoring_level) {
+                continue;
+            }
+
+            // Monitor secodns interval
+            auto monitor_seconds = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::duration<float>(periodic_monitor_meta.monitor.value));
+
+            // See if we already have the local monitor
+            auto it = this->periodic_monitors.find(periodic_monitor_meta.monitor.id);
+
+            if (it == std::end(this->periodic_monitors)) {
+                PeriodicMonitorData periodic_monitor_data;
+
+                periodic_monitor_data.component = component_variable_monitors.component;
+                periodic_monitor_data.variable = component_variable_monitors.variable;
+                periodic_monitor_data.monitor_meta = periodic_monitor_meta;
+
+                if (periodic_monitor_meta.monitor.type == MonitorEnum::Periodic) {
+                    // Set the trigger to the current time
+                    periodic_monitor_data.last_trigger_steady = std::chrono::steady_clock::now();
+                } else if (periodic_monitor_meta.monitor.type == MonitorEnum::PeriodicClockAligned) {
+                    // Snap to the closest monitor multiple
+                    periodic_monitor_data.next_trigger_clock_aligned =
+                        get_next_clock_aligned_point(periodic_monitor_data.monitor_meta.monitor.value);
+                    EVLOG_info << "First aligned timepoint for monitor ID: " << periodic_monitor_meta.monitor.id;
+                }
+
+                auto res = this->periodic_monitors.insert(
+                    std::pair{periodic_monitor_meta.monitor.id, std::move(periodic_monitor_data)});
+
+                if (!res.second) {
+                    EVLOG_warning << "Could not insert monitor to periodic monitor map!";
+                    continue;
+                }
+
+                it = res.first;
+            }
+
+            PeriodicMonitorData& periodic_monitor = it->second;
+            bool matches_time = false;
+
+            if (periodic_monitor.monitor_meta.monitor.type == MonitorEnum::Periodic) {
+                auto current_time = std::chrono::steady_clock::now();
+                auto delta = current_time - periodic_monitor.last_trigger_steady;
+
+                if (delta > monitor_seconds) {
+                    // Update last time
+                    periodic_monitor.last_trigger_steady = current_time;
+                    matches_time = true;
+                }
+            } else if (periodic_monitor.monitor_meta.monitor.type == MonitorEnum::PeriodicClockAligned) {
+                // 3.55
+                // PeriodicClockAligned Triggers an event notice every monitorValue
+                // seconds interval, starting from the nearest clock-aligned interval
+                // after this monitor was set. For example, a monitorValue of 900 will
+                // trigger event notices at 0, 15, 30 and 45 minutes after the hour, every hour.
+                auto current_time = std::chrono::system_clock::now();
+
+                if (current_time > periodic_monitor.next_trigger_clock_aligned) {
+                    auto distance = std::chrono::duration_cast<std::chrono::seconds>(
+                                        current_time - periodic_monitor.next_trigger_clock_aligned)
+                                        .count();
+
+                    // TODO (ioan): if we missed an interval, for example 15 minute mark see how large
+                    // is the distance in which we will not send the notification any more. If we miss
+                    // it with > 1 minute maybe we should not trigger it any more?
+                    if (distance > static_cast<decltype(distance)>(60)) {
+                        EVLOG_warning << "Missed scheduled monitor time by: " << distance;
+                    }
+                    matches_time = true;
+                    EVLOG_info << "Reporting periodic monitor: " << periodic_monitor_meta.monitor.id;
+
+                    periodic_monitor.next_trigger_clock_aligned =
+                        get_next_clock_aligned_point(periodic_monitor.monitor_meta.monitor.value);
+                }
+            } else {
+                EVLOG_AND_THROW(std::runtime_error("Invalid monitor type from: 'get_periodic_monitors'"));
+            }
+
+            if (matches_time) {
+                RequiredComponentVariable comp_var;
+                comp_var.component = component_variable_monitors.component;
+                comp_var.variable = component_variable_monitors.variable;
+
+                std::string current_value = this->device_model->get_value<std::string>(comp_var);
+
+                EventData notify_event = std::move(
+                    create_notify_event(this->unique_id++, current_value, component_variable_monitors.component,
+                                        component_variable_monitors.variable, periodic_monitor.monitor_meta));
+
+                monitor_events.push_back(std::move(notify_event));
+            }
+        }
+    }
+
+    if (!monitor_events.empty()) {
+        notify_csms_events(monitor_events);
+    }
+}
+
+void MonitoringUpdater::process_triggered_monitors() {
+    bool monitoring_enabled =
+        this->device_model->get_optional_value<bool>(ControllerComponentVariables::MonitoringCtrlrEnabled)
+            .value_or(false);
+
+    if (!monitoring_enabled) {
+        EVLOG_info << "Monitoring not enabled, not processing triggers";
+        return;
+    }
+
+    EVLOG_info << "Processing alert monitors";
+
+    // Persist OfflineMonitoringEventQueuingSeverity even when offline if we have a problem
+    bool is_offline = is_chargepoint_offline();
+    // By default (if the comp is missing we are reporting up to 'Warning')
+    int offline_severity =
+        this->device_model->get_optional_value<int>(ControllerComponentVariables::OfflineQueuingSeverity)
+            .value_or(MontoringLevelSeverity::Warning);
+
+    int active_monitoring_level =
+        this->device_model->get_optional_value<int>(ControllerComponentVariables::ActiveMonitoringLevel)
+            .value_or(MontoringLevelSeverity::MAX);
+
+    for (auto it = triggered_monitors.begin(); it != triggered_monitors.end();) {
+        bool should_clear = false;
+
+        if (is_offline) {
+            // If we are offline, just discard triggers that have a severity > than 'offline_severity'
+            if (it->second.monitor_meta.monitor.severity > offline_severity) {
+                should_clear = true;
+            }
+        } else {
+            // If we are online, discard the triggers that have a severity > than 'active_monitoring_level'
+            if (it->second.monitor_meta.monitor.severity > active_monitoring_level) {
+                should_clear = true;
+            }
+        }
+
+        if (should_clear) {
+            it = triggered_monitors.erase(it);
+        } else {
+            ++it;
+        }
+    }
+
+    if (!is_offline) {
+        std::vector<EventData> monitor_events;
+        for (auto& [id, trigger] : triggered_monitors) {
+            EventData notify_event = std::move(create_notify_event(
+                unique_id++, trigger.value_current, trigger.component, trigger.variable, trigger.monitor_meta));
+
+            // Mark the triggers as CSMS sent
+            trigger.csms_sent = true;
+
+            monitor_events.push_back(std::move(notify_event));
+        }
+
+        if (!monitor_events.empty()) {
+            notify_csms_events(monitor_events);
+        }
+    }
+
+    for (auto it = triggered_monitors.begin(); it != triggered_monitors.end();) {
+        bool should_clear = false;
+
+        if (it->second.csms_sent == false && it->second.cleared == true) {
+            // Based on spec comments, if a variable returns to normal and we're offline and
+            // it was not sent to the CSMS it can safely be discarded:
+            // "Only those monitoring events that were triggered & cleared during the offline period will remain
+            // invisible to CSMS."
+            should_clear = true;
+        } else if (it->second.csms_sent && it->second.cleared == true) {
+            // Also discard monitors that were sent to the CSMS and are cleared,
+            // that is, in their proper state
+            should_clear = true;
+        }
+
+        if (should_clear) {
+            it = triggered_monitors.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+} // namespace ocpp::v201

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -150,7 +150,11 @@ void MonitoringUpdater::start_monitoring() {
                         std::placeholders::_7);
     device_model->register_variable_listener(std::move(fn));
 
-    monitors_timer.interval(std::chrono::seconds(1));
+    int process_interval_seconds =
+        this->device_model->get_optional_value<int>(ControllerComponentVariables::VariableMonitoringProcessTime)
+            .value_or(1);
+
+    monitors_timer.interval(std::chrono::seconds(process_interval_seconds));
 }
 
 void MonitoringUpdater::stop_monitoring() {


### PR DESCRIPTION
## Describe your changes

This PR takes care of spec-based N test-cases and builds on top of two previous PR.

Passes OCTT N Test Cases:
TC_N_01_CS
TC_N_02_CS
TC_N_03_CS
[...]
TC_N_06_CS
[...]
TC_N_08_CS
TC_N_09_CS
TC_N_10_CS
TC_N_11_CS
TC_N_12_CS
TC_N_13_CS
TC_N_15_CS
TC_N_16_CS
TC_N_17_CS
TC_N_18_CS
TC_N_19_CS
[...]
TC_N_23_CS
TC_N_24_CS
[...]
TC_N_37_CS
TC_N_38_CS
TC_N_39_CS
[...]
TC_N_40_CS
[...]
TC_N_43_CS
[...]
TC_N_45_CS
[...]
TC_N_47_CS
TC_N_48_CS
[...]
TC_N_51_CS
[...]
TC_N_53_CS
TC_N_56_CS
TC_N_61_CS

Not implemented:
TC_N_21_CS - Requires DB support for hardwired monitors
TC_N_41_CS - Requires DB support for hardwired monitors
TC_N_44_CS - Requires DB support for hardwired monitors

OCTT Tool Issues:
TC_N_04_CS - Not Applicable, we support everything
TC_N_07_CS - Not Applicable, we support everything
TC_N_20_CS - Tool bug
TC_N_22_CS - Tool bug
TC_N_52_CS - Tool bug

This PR does not handle test cases related to Log/Customer Information (TC_N_25_CS - TC_N_36_CS)

Updated ocpp201 document:
https://github.com/EVerest/libocpp/blob/feature/variable-monitoring-triggers/doc/ocpp_201_status.md

## Issue ticket number and link

Issue:
https://github.com/EVerest/libocpp/issues/640

Build upon:
https://github.com/EVerest/libocpp/pull/665
https://github.com/EVerest/libocpp/pull/653

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

