### PR TITLE
OCPP1.6: Fix transaction handling in case of StartTransaction.req retries

### DIFF
--- a/include/ocpp/v16/database_handler.hpp
+++ b/include/ocpp/v16/database_handler.hpp
@@ -72,6 +72,11 @@ public:
     /// table
     void update_transaction_csms_ack(const int32_t transaction_id);
 
+    /// \brief Updates the START_TRANSACTION_MESSAGE_ID column for the transaction with the given \p session_id in the
+    /// TRANSACTIONS table
+    void update_start_transaction_message_id(const std::string& session_id,
+                                             const std::string& start_transaction_message_id);
+
     /// \brief Updates the METER_LAST and METER_LAST_TIME column for the transaction with the given \p session_id in the
     /// TRANSACTIONS table
     void update_transaction_meter_value(const std::string& session_id, const int32_t value,

--- a/lib/ocpp/v16/database_handler.cpp
+++ b/lib/ocpp/v16/database_handler.cpp
@@ -136,6 +136,20 @@ void DatabaseHandler::update_transaction_csms_ack(const int32_t transaction_id) 
     }
 }
 
+void DatabaseHandler::update_start_transaction_message_id(const std::string& session_id,
+                                                          const std::string& start_transaction_message_id) {
+    std::string sql = "UPDATE TRANSACTIONS SET START_TRANSACTION_MESSAGE_ID=@start_transaction_message_id, "
+                      "LAST_UPDATE=@last_update WHERE ID==@session_id";
+    auto stmt = this->database->new_statement(sql);
+
+    stmt->bind_text("@last_update", ocpp::DateTime().to_rfc3339(), SQLiteString::Transient);
+    stmt->bind_text("@start_transaction_message_id", start_transaction_message_id);
+
+    if (stmt->step() != SQLITE_DONE) {
+        throw QueryExecutionException(this->database->get_error_message());
+    }
+}
+
 void DatabaseHandler::update_transaction_meter_value(const std::string& session_id, const int32_t value,
                                                      const std::string& last_meter_time) {
     std::string sql = "UPDATE TRANSACTIONS SET METER_LAST=@meter_last, METER_LAST_TIME=@meter_last_time, "

--- a/lib/ocpp/v16/message_queue.cpp
+++ b/lib/ocpp/v16/message_queue.cpp
@@ -22,6 +22,10 @@ bool is_transaction_message(const ocpp::v16::MessageType message_type) {
            (message_type == v16::MessageType::SecurityEventNotification);
 }
 
+bool is_start_transaction_message(const ocpp::v16::MessageType message_type) {
+    return message_type == v16::MessageType::StartTransaction;
+}
+
 bool is_boot_notification_message(const ocpp::v16::MessageType message_type) {
     return message_type == ocpp::v16::MessageType::BootNotification;
 }

--- a/lib/ocpp/v201/message_queue.cpp
+++ b/lib/ocpp/v201/message_queue.cpp
@@ -12,6 +12,10 @@ bool is_transaction_message(const ocpp::v201::MessageType message_type) {
            (message_type == v201::MessageType::SecurityEventNotification);
 }
 
+bool is_start_transaction_message(const ocpp::v201::MessageType message_type) {
+    return false;
+}
+
 bool is_boot_notification_message(const ocpp::v201::MessageType message_type) {
     return message_type == ocpp::v201::MessageType::BootNotification;
 }

--- a/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/tests/lib/ocpp/common/test_message_queue.cpp
@@ -124,6 +124,10 @@ bool is_transaction_message(const TestMessageType message_type) {
     return (message_type == TestMessageType::TRANSACTIONAL) || (message_type == TestMessageType::TRANSACTIONAL_UPDATE);
 }
 
+bool is_start_transaction_message(const TestMessageType message_type) {
+    return false;
+}
+
 template <> bool ControlMessage<TestMessageType>::is_transaction_update_message() const {
     return this->messageType == TestMessageType::TRANSACTIONAL_UPDATE;
 }


### PR DESCRIPTION
## Describe your changes
Fixed bug that lead to incorrect transaction handling in case StartTransaction.req could not be delivered:

* StartTransaction.conf handler retrieves a transaction based on the message id of the StartTransaction.req. In case this message is retried, the reference is updated in the message queue but not in the transaction handler
* This change updates the start_transaction_message_id of the transaction of the transaction_handler and in the database in case of a retry

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

