### PR TITLE
Add missing start of message queue for OCPP1.6

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -855,6 +855,7 @@ void ChargePointImpl::send_meter_value(int32_t connector, MeterValue meter_value
 }
 
 bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason) {
+    this->message_queue->start();
     this->bootreason = bootreason;
     this->init_state_machine(connector_status_map);
     this->init_websocket();


### PR DESCRIPTION
## Describe your changes
Add missing start of message queue for OCPP1.6. Required since https://github.com/EVerest/libocpp/pull/685

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

