### PR TITLE
Added connection_state_changed callback

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -182,6 +182,9 @@ struct Callbacks {
     std::optional<std::function<void(const TransactionEventRequest& transaction_event,
                                      const TransactionEventResponse& transaction_event_response)>>
         transaction_event_response_callback;
+
+    /// \brief Callback function is called when the websocket connection status changes
+    std::optional<std::function<void(const bool is_connected)>> connection_state_changed_callback;
 };
 
 /// \brief Combines ChangeAvailabilityRequest with persist flag for scheduled Availability changes

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1002,6 +1002,10 @@ void ChargePoint::init_websocket() {
 
         // We have a connection again so next time it fails we should send the notification again
         this->skip_invalid_csms_certificate_notifications = false;
+
+        if (this->callbacks.connection_state_changed_callback.has_value()) {
+            this->callbacks.connection_state_changed_callback.value()(true);
+        }
     });
 
     this->websocket->register_disconnected_callback([this]() {
@@ -1015,6 +1019,9 @@ void ChargePoint::init_websocket() {
 
         this->client_certificate_expiration_check_timer.stop();
         this->v2g_certificate_expiration_check_timer.stop();
+        if (this->callbacks.connection_state_changed_callback.has_value()) {
+            this->callbacks.connection_state_changed_callback.value()(false);
+        }
     });
 
     this->websocket->register_closed_callback(


### PR DESCRIPTION
## Describe your changes
Added callback connection_state_changed_callback to be able to notify libocpp consumer if the websocket connection status has been changed

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

