### PR TITLE
Allow persisting messages initiated with send_async

### DIFF
--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -705,7 +705,8 @@ public:
         } else {
             // all other messages are allowed to "jump the queue" to improve user experience
             // TODO: decide if we only want to allow this for a subset of messages
-            if (this->paused && !this->resuming && message->messageType != M::BootNotification) {
+            if (this->paused && !this->config.queue_all_messages && !this->resuming &&
+                message->messageType != M::BootNotification) {
                 // do not add a normal message to the queue if the queue is paused/offline
                 auto enhanced_message = EnhancedMessage<M>();
                 enhanced_message.offline = true;


### PR DESCRIPTION
## Describe your changes
Adding async messages to queue and therefore persisting these messages when queue all messages is set.

Without this change, messages intitated by send_async are not persisted when the message queue is paused / or when offline.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

