### PR TITLE
Feature/add trigger reason to transaction finished

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.14.0
+    VERSION 0.14.1
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -264,7 +264,7 @@ public:
     /// \param signed_meter_value
     /// \param charging_state
     virtual void on_transaction_finished(const int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop,
-                                         const ReasonEnum reason, const std::optional<TriggerReasonEnum> trigger_reason,
+                                         const ReasonEnum reason, const TriggerReasonEnum trigger_reason,
                                          const std::optional<IdToken>& id_token,
                                          const std::optional<std::string>& signed_meter_value,
                                          const ChargingStateEnum charging_state) = 0;
@@ -860,7 +860,7 @@ public:
                                 const ChargingStateEnum charging_state) override;
 
     void on_transaction_finished(const int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop,
-                                 const ReasonEnum reason, const std::optional<TriggerReasonEnum> trigger_reason,
+                                 const ReasonEnum reason, const TriggerReasonEnum trigger_reason,
                                  const std::optional<IdToken>& id_token,
                                  const std::optional<std::string>& signed_meter_value,
                                  const ChargingStateEnum charging_state) override;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -264,7 +264,8 @@ public:
     /// \param signed_meter_value
     /// \param charging_state
     virtual void on_transaction_finished(const int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop,
-                                         const ReasonEnum reason, const std::optional<IdToken>& id_token,
+                                         const ReasonEnum reason, const std::optional<TriggerReasonEnum> trigger_reason,
+                                         const std::optional<IdToken>& id_token,
                                          const std::optional<std::string>& signed_meter_value,
                                          const ChargingStateEnum charging_state) = 0;
 
@@ -859,7 +860,8 @@ public:
                                 const ChargingStateEnum charging_state) override;
 
     void on_transaction_finished(const int32_t evse_id, const DateTime& timestamp, const MeterValue& meter_stop,
-                                 const ReasonEnum reason, const std::optional<IdToken>& id_token,
+                                 const ReasonEnum reason, const std::optional<TriggerReasonEnum> trigger_reason,
+                                 const std::optional<IdToken>& id_token,
                                  const std::optional<std::string>& signed_meter_value,
                                  const ChargingStateEnum charging_state) override;
 

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -41,11 +41,6 @@ std::vector<MeterValue> get_meter_values_with_measurands_applied(
     const std::vector<MeasurandEnum>& aligned_tx_ended_measurands, ocpp::DateTime max_timestamp,
     bool include_sampled_signed = true, bool include_aligned_signed = true);
 
-/// \brief Converts the given \p stop_reason to a TriggerReasonEnum
-/// \param stop_reason
-/// \return
-TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ReasonEnum& stop_reason);
-
 /// \brief Returns the given \p str hashed using SHA256
 /// \param str
 /// \return

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -397,7 +397,7 @@ void ChargePoint::on_transaction_started(const int32_t evse_id, const int32_t co
 
 void ChargePoint::on_transaction_finished(const int32_t evse_id, const DateTime& timestamp,
                                           const MeterValue& meter_stop, const ReasonEnum reason,
-                                          const std::optional<TriggerReasonEnum> trigger_reason,
+                                          const TriggerReasonEnum trigger_reason,
                                           const std::optional<IdToken>& id_token,
                                           const std::optional<std::string>& signed_meter_value,
                                           const ChargingStateEnum charging_state) {
@@ -434,15 +434,12 @@ void ChargePoint::on_transaction_finished(const int32_t evse_id, const DateTime&
         EVLOG_warning << "Could not get metervalues of transaction: " << e.what();
     }
 
-    const auto _trigger_reason =
-        trigger_reason.has_value() ? trigger_reason.value() : utils::stop_reason_to_trigger_reason_enum(reason);
-
     // E07.FR.02 The field idToken is provided when the authorization of the transaction has been ended
     const std::optional<IdToken> transaction_id_token =
         trigger_reason == ocpp::v201::TriggerReasonEnum::StopAuthorized ? id_token : std::nullopt;
 
     this->transaction_event_req(TransactionEventEnum::Ended, timestamp, enhanced_transaction->get_transaction(),
-                                _trigger_reason, enhanced_transaction->get_seq_no(), std::nullopt, std::nullopt,
+                                trigger_reason, enhanced_transaction->get_seq_no(), std::nullopt, std::nullopt,
                                 transaction_id_token, meter_values, std::nullopt, this->is_offline(), std::nullopt);
 
     evse_handle.release_transaction();

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -102,51 +102,6 @@ std::vector<MeterValue> get_meter_values_with_measurands_applied(
     return meter_values_result;
 }
 
-TriggerReasonEnum stop_reason_to_trigger_reason_enum(const ReasonEnum& stop_reason) {
-    switch (stop_reason) {
-    case ReasonEnum::DeAuthorized:
-        return TriggerReasonEnum::Deauthorized;
-    case ReasonEnum::EmergencyStop:
-        return TriggerReasonEnum::AbnormalCondition;
-    case ReasonEnum::EnergyLimitReached:
-        return TriggerReasonEnum::EnergyLimitReached;
-    case ReasonEnum::EVDisconnected:
-        return TriggerReasonEnum::EVCommunicationLost;
-    case ReasonEnum::GroundFault:
-        return TriggerReasonEnum::AbnormalCondition;
-    case ReasonEnum::ImmediateReset:
-        return TriggerReasonEnum::ResetCommand;
-    case ReasonEnum::Local:
-        return TriggerReasonEnum::StopAuthorized;
-    case ReasonEnum::LocalOutOfCredit:
-        return TriggerReasonEnum::ChargingStateChanged;
-    case ReasonEnum::MasterPass:
-        return TriggerReasonEnum::StopAuthorized;
-    case ReasonEnum::Other:
-        return TriggerReasonEnum::AbnormalCondition;
-    case ReasonEnum::OvercurrentFault:
-        return TriggerReasonEnum::AbnormalCondition;
-    case ReasonEnum::PowerLoss:
-        return TriggerReasonEnum::AbnormalCondition;
-    case ReasonEnum::PowerQuality:
-        return TriggerReasonEnum::AbnormalCondition;
-    case ReasonEnum::Reboot:
-        return TriggerReasonEnum::ResetCommand;
-    case ReasonEnum::Remote:
-        return TriggerReasonEnum::RemoteStop;
-    case ReasonEnum::SOCLimitReached:
-        return TriggerReasonEnum::EnergyLimitReached;
-    case ReasonEnum::StoppedByEV:
-        return TriggerReasonEnum::StopAuthorized;
-    case ReasonEnum::TimeLimitReached:
-        return TriggerReasonEnum::TimeLimitReached;
-    case ReasonEnum::Timeout:
-        return TriggerReasonEnum::EVConnectTimeout;
-    default:
-        return TriggerReasonEnum::AbnormalCondition;
-    }
-}
-
 std::string sha256(const std::string& str) {
     unsigned char hash[SHA256_DIGEST_LENGTH];
     EVP_Digest(str.c_str(), str.size(), hash, NULL, EVP_sha256(), NULL);


### PR DESCRIPTION
## Describe your changes
Moved TriggerReason as an argument to on_transaction_finished to allow the libocpp consumer to set this value. This change is required, since the (Stopped)ReasoEnum cannot be used to derive the TriggerReason, because in some situations the same ReasonEnum requires different TriggerReasonEnum.

Removed `stop_reason_to_trigger_reason_enum` since its not required anymore with these changes.

## Issue ticket number and link
Companion PR in everest-core: https://github.com/EVerest/everest-core/pull/787

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

