### PR TITLE
Change return type of DataTransfer to std::optional

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -145,9 +145,11 @@ public:
     /// \param vendorId
     /// \param messageId
     /// \param data
-    /// \return
-    DataTransferResponse data_transfer(const CiString<255>& vendorId, const std::optional<CiString<50>>& messageId,
-                                       const std::optional<std::string>& data);
+    /// \return the DataTransferResponse from the CSMS. In case no response is received from the CSMS because the
+    /// message timed out or the charging station is offline, std::nullopt is returned
+    std::optional<DataTransferResponse> data_transfer(const CiString<255>& vendorId,
+                                                      const std::optional<CiString<50>>& messageId,
+                                                      const std::optional<std::string>& data);
 
     /// \brief Calculates ChargingProfiles configured by the CSMS of all connectors from now until now + given \p
     /// duration_s

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -450,8 +450,9 @@ public:
     /// \param vendorId
     /// \param messageId
     /// \param data
-    /// \return
-    DataTransferResponse data_transfer(const CiString<255>& vendorId, const std::optional<CiString<50>>& messageId,
+    /// \return the DataTransferResponse from the CSMS. In case no response is received from the CSMS because the
+    /// message timed out or the charging station is offline, std::nullopt is returned
+    std::optional<DataTransferResponse> data_transfer(const CiString<255>& vendorId, const std::optional<CiString<50>>& messageId,
                                        const std::optional<std::string>& data);
 
     /// \brief Calculates ChargingProfiles configured by the CSMS of all connectors from now until now + given \p

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -352,14 +352,15 @@ public:
     /// \param messageId
     /// \param data
     /// \return DataTransferResponse containing the result from CSMS
-    virtual DataTransferResponse data_transfer_req(const CiString<255>& vendorId,
-                                                   const std::optional<CiString<50>>& messageId,
-                                                   const std::optional<json>& data) = 0;
+    virtual std::optional<DataTransferResponse> data_transfer_req(const CiString<255>& vendorId,
+                                                                  const std::optional<CiString<50>>& messageId,
+                                                                  const std::optional<json>& data) = 0;
 
     /// \brief Data transfer mechanism initiated by charger
     /// \param request
-    /// \return DataTransferResponse containing the result from CSMS
-    virtual DataTransferResponse data_transfer_req(const DataTransferRequest& request) = 0;
+    /// \return DataTransferResponse containing the result from CSMS. In case no response is received from the CSMS because the
+    /// message timed out or the charging station is offline, std::nullopt is returned
+    virtual std::optional<DataTransferResponse> data_transfer_req(const DataTransferRequest& request) = 0;
 
     /// \brief Switches the operative status of the CS
     /// \param new_status: The new operative status to switch to
@@ -893,10 +894,11 @@ public:
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
 
-    DataTransferResponse data_transfer_req(const CiString<255>& vendorId, const std::optional<CiString<50>>& messageId,
-                                           const std::optional<json>& data) override;
+    std::optional<DataTransferResponse> data_transfer_req(const CiString<255>& vendorId,
+                                                          const std::optional<CiString<50>>& messageId,
+                                                          const std::optional<json>& data) override;
 
-    DataTransferResponse data_transfer_req(const DataTransferRequest& request) override;
+    std::optional<DataTransferResponse> data_transfer_req(const DataTransferRequest& request) override;
 
     void set_cs_operative_status(OperationalStatusEnum new_status, bool persist) override;
 

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -64,7 +64,7 @@ void ChargePoint::data_transfer_pnc_get_15118_ev_certificate(
                                                                    certificate_action);
 }
 
-DataTransferResponse ChargePoint::data_transfer(const CiString<255>& vendorId,
+std::optional<DataTransferResponse> ChargePoint::data_transfer(const CiString<255>& vendorId,
                                                 const std::optional<CiString<50>>& messageId,
                                                 const std::optional<std::string>& data) {
     return this->charge_point->data_transfer(vendorId, messageId, data);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3489,7 +3489,7 @@ template <class T> bool ChargePoint::send(ocpp::CallResult<T> call_result) {
     return true;
 }
 
-DataTransferResponse ChargePoint::data_transfer_req(const CiString<255>& vendorId,
+std::optional<DataTransferResponse> ChargePoint::data_transfer_req(const CiString<255>& vendorId,
                                                     const std::optional<CiString<50>>& messageId,
                                                     const std::optional<json>& data) {
     DataTransferRequest req;
@@ -3500,15 +3500,20 @@ DataTransferResponse ChargePoint::data_transfer_req(const CiString<255>& vendorI
     return this->data_transfer_req(req);
 }
 
-DataTransferResponse ChargePoint::data_transfer_req(const DataTransferRequest& request) {
+std::optional<DataTransferResponse> ChargePoint::data_transfer_req(const DataTransferRequest& request) {
     DataTransferResponse response;
+    response.status = DataTransferStatusEnum::Rejected;
+
     ocpp::Call<DataTransferRequest> call(request, this->message_queue->createMessageId());
     auto data_transfer_future = this->send_async<DataTransferRequest>(call);
 
+    if (!this->websocket->is_connected()) {
+        return std::nullopt;
+    }
+
     if (data_transfer_future.wait_for(DEFAULT_WAIT_FOR_FUTURE_TIMEOUT) == std::future_status::timeout) {
         EVLOG_warning << "Waiting for DataTransfer.conf future timed out";
-        response.status = ocpp::v201::DataTransferStatusEnum::Rejected;
-        return response;
+        return std::nullopt;
     }
 
     auto enhanced_message = data_transfer_future.get();
@@ -3517,7 +3522,7 @@ DataTransferResponse ChargePoint::data_transfer_req(const DataTransferRequest& r
         response = call_result.msg;
     }
     if (enhanced_message.offline) {
-        response.status = ocpp::v201::DataTransferStatusEnum::Rejected;
+        return std::nullopt;
     }
 
     return response;


### PR DESCRIPTION

## Describe your changes
Change return value of public data_transfer in 1.6 and 2.0.1 to optional. This allows the functions to return immediately if the charge point is currently offline.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

