### PR TITLE
Only log missing variables on debug

### DIFF
--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -203,7 +203,7 @@ GetVariableStatusEnum DeviceModel::request_value_internal(const Component& compo
                                                           bool allow_write_only) {
     const auto component_it = this->device_model.find(component_id);
     if (component_it == this->device_model.end()) {
-        EVLOG_warning << "unknown component in " << component_id.name << "." << variable_id.name;
+        EVLOG_debug << "unknown component in " << component_id.name << "." << variable_id.name;
         return GetVariableStatusEnum::UnknownComponent;
     }
 
@@ -211,7 +211,7 @@ GetVariableStatusEnum DeviceModel::request_value_internal(const Component& compo
     const auto& variable_it = component.find(variable_id);
 
     if (variable_it == component.end()) {
-        EVLOG_warning << "unknown variable in " << component_id.name << "." << variable_id.name;
+        EVLOG_debug << "unknown variable in " << component_id.name << "." << variable_id.name;
         return GetVariableStatusEnum::UnknownVariable;
     }
 

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -150,11 +150,15 @@ void MonitoringUpdater::start_monitoring() {
                         std::placeholders::_7);
     device_model->register_variable_listener(std::move(fn));
 
-    int process_interval_seconds =
-        this->device_model->get_optional_value<int>(ControllerComponentVariables::MonitorsProcessingInterval)
-            .value_or(60);
+    // No point in starting the monitor if this variable does not exist. It will never start to exist later on.
+    if (this->device_model->get_optional_value<bool>(ControllerComponentVariables::MonitoringCtrlrEnabled)
+            .has_value()) {
+        int process_interval_seconds =
+            this->device_model->get_optional_value<int>(ControllerComponentVariables::MonitorsProcessingInterval)
+                .value_or(1);
 
-    monitors_timer.interval(std::chrono::seconds(process_interval_seconds));
+        monitors_timer.interval(std::chrono::seconds(process_interval_seconds));
+    }
 }
 
 void MonitoringUpdater::stop_monitoring() {

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -152,7 +152,7 @@ void MonitoringUpdater::start_monitoring() {
 
     int process_interval_seconds =
         this->device_model->get_optional_value<int>(ControllerComponentVariables::MonitorsProcessingInterval)
-            .value_or(1);
+            .value_or(60);
 
     monitors_timer.interval(std::chrono::seconds(process_interval_seconds));
 }


### PR DESCRIPTION
## Describe your changes

When we request an optional variable and the variable is not present we currently print a warning which is strange since the variable is optional with a reason. Changing this to debug still allows to check the logs but by default will not print it. If `get_value` is used on a variable that is not present we will still log and throw anyway.

Also I changed the default for the monitoring rate to 60 seconds to reduce spam (in debug mode) of missing monitoring vairables. Ideally it should not perform monitoring at all when `MonitoringCtrlrEnabled` is false but that is too big of a change for this PR.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

