### PR TITLE
Fixed bug that used evse_id 0 in set_evse_operative_status

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3117,7 +3117,7 @@ void ChargePoint::handle_change_availability_req(Call<ChangeAvailabilityRequest>
             for (auto const& evse : *this->evse_manager) {
                 if (!evse.has_active_transaction()) {
                     // FIXME: This will linger after the update too! We probably need another mechanism...
-                    this->set_evse_operative_status(evse_id, OperationalStatusEnum::Inoperative, false);
+                    this->set_evse_operative_status(evse.get_id(), OperationalStatusEnum::Inoperative, false);
                 }
             }
         } else {


### PR DESCRIPTION
## Describe your changes
fixed bug that accessed evse id 0 as parameter in set_evse_operative_status

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

