### PR TITLE
Fix component schemas

### DIFF
--- a/config/v201/component_schemas/standardized/DisplayMessageCtrlr.json
+++ b/config/v201/component_schemas/standardized/DisplayMessageCtrlr.json
@@ -20,7 +20,7 @@
       "type": "boolean"
     },
     "NumberOfDisplayMessages": {
-      "variable_name": "NumberOfDisplayMessages",
+      "variable_name": "DisplayMessages",
       "characteristics": {
         "supportsMonitoring": true,
         "dataType": "integer"

--- a/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
+++ b/config/v201/component_schemas/standardized/OCPPCommCtrlr.json
@@ -22,7 +22,7 @@
       "variable_name": "ActiveNetworkProfile",
       "characteristics": {
         "supportsMonitoring": true,
-        "dataType": "string"
+        "dataType": "integer"
       },
       "attributes": [
         {
@@ -31,8 +31,8 @@
         }
       ],
       "description": "Indicates the configuration profile the station uses at that moment to connect to the network.",
-      "default": "1",
-      "type": "string"
+      "default": 1,
+      "type": "integer"
     },
     "FileTransferProtocols": {
       "variable_name": "FileTransferProtocols",

--- a/config/v201/component_schemas/standardized/SampledDataCtrlr.json
+++ b/config/v201/component_schemas/standardized/SampledDataCtrlr.json
@@ -122,7 +122,7 @@
     "SampledDataTxUpdatedMeasurands": {
       "variable_name": "TxUpdatedMeasurands",
       "characteristics": {
-        "valuesList": "Current.Export,Current.Import,Current.Offered,Energy.Active.Export.Register,Energy.Active.Import.Register,Energy.Reactive.Export.Register,Energy.Reactive.Import.Register,Energy.Active.Export.Interval,Energy.Active.Import.Interval,Energy.Reactive.Export.Interval,Energy.Reactive.Import.Interval,Frequency,Power.Active.Export,Power.Active.Import,Power.Factor,Power.Offered,Power.Reactive.Export,Power.Reactive.Import,Voltage",
+        "valuesList": "Current.Export,Current.Import,Current.Offered,Energy.Active.Export.Register,Energy.Active.Import.Register,Energy.Reactive.Export.Register,Energy.Reactive.Import.Register,Energy.Active.Export.Interval,Energy.Active.Import.Interval,Energy.Reactive.Export.Interval,Energy.Reactive.Import.Interval,Frequency,Power.Active.Export,Power.Active.Import,Power.Factor,Power.Offered,Power.Reactive.Export,Power.Reactive.Import,Voltage,SoC",
         "supportsMonitoring": true,
         "dataType": "MemberList"
       },

--- a/config/v201/component_schemas/standardized/TariffCostCtrlr.json
+++ b/config/v201/component_schemas/standardized/TariffCostCtrlr.json
@@ -40,7 +40,8 @@
       "variable_name": "Currency",
       "characteristics": {
         "supportsMonitoring": true,
-        "dataType": "string"
+        "dataType": "string",
+        "maxLimit": 3
       },
       "attributes": [
         {
@@ -87,7 +88,8 @@
       "variable_name": "TariffFallbackMessage",
       "characteristics": {
         "supportsMonitoring": true,
-        "dataType": "string"
+        "dataType": "string",
+        "maxLimit": 255
       },
       "attributes": [
         {
@@ -102,7 +104,8 @@
       "variable_name": "TotalCostFallbackMessage",
       "characteristics": {
         "supportsMonitoring": true,
-        "dataType": "string"
+        "dataType": "string",
+        "maxLimit": 255
       },
       "attributes": [
         {

--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -185,7 +185,7 @@
             "NetworkConnectionProfiles": {
                 "variable_name": "NetworkConnectionProfiles",
                 "attributes": {
-                    "Actual": "[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"ws://localhost:9000/cp001\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]"
+                    "Actual": "[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"ws://7d52373cc3c58608.octt.openchargealliance.org:10756\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]"
                 }
             },
             "ChargeBoxSerialNumber": {
@@ -352,7 +352,7 @@
         "name": "DisplayMessageCtrlr",
         "variables": {
             "NumberOfDisplayMessages": {
-                "variable_name": "NumberOfDisplayMessages",
+                "variable_name": "DisplayMessages",
                 "attributes": {
                     "Actual": 42
                 }


### PR DESCRIPTION

## Describe your changes
adjust some component schmeas and configs to align with requirements of OCPP201 spec
This allows TC_B_53 to pass again with the default setup

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

