### PR TITLE
Mark methods as override

### DIFF
--- a/include/ocpp/common/database/database_exceptions.hpp
+++ b/include/ocpp/common/database/database_exceptions.hpp
@@ -16,7 +16,7 @@ public:
     virtual ~DatabaseException() noexcept {
     }
 
-    virtual const char* what() const noexcept {
+    virtual const char* what() const noexcept override {
         return msg.c_str();
     }
 

--- a/include/ocpp/v16/messages/Authorize.hpp
+++ b/include/ocpp/v16/messages/Authorize.hpp
@@ -19,7 +19,7 @@ struct AuthorizeRequest : public ocpp::Message {
 
     /// \brief Provides the type of this Authorize message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given AuthorizeRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct AuthorizeResponse : public ocpp::Message {
 
     /// \brief Provides the type of this AuthorizeResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given AuthorizeResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/BootNotification.hpp
+++ b/include/ocpp/v16/messages/BootNotification.hpp
@@ -27,7 +27,7 @@ struct BootNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this BootNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given BootNotificationRequest \p k to a given json object \p j
@@ -48,7 +48,7 @@ struct BootNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this BootNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given BootNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/CancelReservation.hpp
+++ b/include/ocpp/v16/messages/CancelReservation.hpp
@@ -17,7 +17,7 @@ struct CancelReservationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this CancelReservation message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CancelReservationRequest \p k to a given json object \p j
@@ -36,7 +36,7 @@ struct CancelReservationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this CancelReservationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CancelReservationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/CertificateSigned.hpp
+++ b/include/ocpp/v16/messages/CertificateSigned.hpp
@@ -17,7 +17,7 @@ struct CertificateSignedRequest : public ocpp::Message {
 
     /// \brief Provides the type of this CertificateSigned message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CertificateSignedRequest \p k to a given json object \p j
@@ -36,7 +36,7 @@ struct CertificateSignedResponse : public ocpp::Message {
 
     /// \brief Provides the type of this CertificateSignedResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CertificateSignedResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/ChangeAvailability.hpp
+++ b/include/ocpp/v16/messages/ChangeAvailability.hpp
@@ -18,7 +18,7 @@ struct ChangeAvailabilityRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ChangeAvailability message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ChangeAvailabilityRequest \p k to a given json object \p j
@@ -37,7 +37,7 @@ struct ChangeAvailabilityResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ChangeAvailabilityResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ChangeAvailabilityResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/ChangeConfiguration.hpp
+++ b/include/ocpp/v16/messages/ChangeConfiguration.hpp
@@ -19,7 +19,7 @@ struct ChangeConfigurationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ChangeConfiguration message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ChangeConfigurationRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct ChangeConfigurationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ChangeConfigurationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ChangeConfigurationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/ClearCache.hpp
+++ b/include/ocpp/v16/messages/ClearCache.hpp
@@ -16,7 +16,7 @@ struct ClearCacheRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ClearCache message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearCacheRequest \p k to a given json object \p j
@@ -35,7 +35,7 @@ struct ClearCacheResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ClearCacheResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearCacheResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/ClearChargingProfile.hpp
+++ b/include/ocpp/v16/messages/ClearChargingProfile.hpp
@@ -21,7 +21,7 @@ struct ClearChargingProfileRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ClearChargingProfile message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearChargingProfileRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct ClearChargingProfileResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ClearChargingProfileResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearChargingProfileResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/DataTransfer.hpp
+++ b/include/ocpp/v16/messages/DataTransfer.hpp
@@ -21,7 +21,7 @@ struct DataTransferRequest : public ocpp::Message {
 
     /// \brief Provides the type of this DataTransfer message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DataTransferRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct DataTransferResponse : public ocpp::Message {
 
     /// \brief Provides the type of this DataTransferResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DataTransferResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/DeleteCertificate.hpp
+++ b/include/ocpp/v16/messages/DeleteCertificate.hpp
@@ -17,7 +17,7 @@ struct DeleteCertificateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this DeleteCertificate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DeleteCertificateRequest \p k to a given json object \p j
@@ -36,7 +36,7 @@ struct DeleteCertificateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this DeleteCertificateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DeleteCertificateResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/DiagnosticsStatusNotification.hpp
+++ b/include/ocpp/v16/messages/DiagnosticsStatusNotification.hpp
@@ -17,7 +17,7 @@ struct DiagnosticsStatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this DiagnosticsStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DiagnosticsStatusNotificationRequest \p k to a given json object \p j
@@ -35,7 +35,7 @@ struct DiagnosticsStatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this DiagnosticsStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DiagnosticsStatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/ExtendedTriggerMessage.hpp
+++ b/include/ocpp/v16/messages/ExtendedTriggerMessage.hpp
@@ -19,7 +19,7 @@ struct ExtendedTriggerMessageRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ExtendedTriggerMessage message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ExtendedTriggerMessageRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct ExtendedTriggerMessageResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ExtendedTriggerMessageResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ExtendedTriggerMessageResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/FirmwareStatusNotification.hpp
+++ b/include/ocpp/v16/messages/FirmwareStatusNotification.hpp
@@ -17,7 +17,7 @@ struct FirmwareStatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this FirmwareStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given FirmwareStatusNotificationRequest \p k to a given json object \p j
@@ -35,7 +35,7 @@ struct FirmwareStatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this FirmwareStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given FirmwareStatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/GetCompositeSchedule.hpp
+++ b/include/ocpp/v16/messages/GetCompositeSchedule.hpp
@@ -20,7 +20,7 @@ struct GetCompositeScheduleRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetCompositeSchedule message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetCompositeScheduleRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct GetCompositeScheduleResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetCompositeScheduleResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetCompositeScheduleResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/GetConfiguration.hpp
+++ b/include/ocpp/v16/messages/GetConfiguration.hpp
@@ -18,7 +18,7 @@ struct GetConfigurationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetConfiguration message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetConfigurationRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct GetConfigurationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetConfigurationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetConfigurationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/GetDiagnostics.hpp
+++ b/include/ocpp/v16/messages/GetDiagnostics.hpp
@@ -22,7 +22,7 @@ struct GetDiagnosticsRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetDiagnostics message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetDiagnosticsRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct GetDiagnosticsResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetDiagnosticsResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetDiagnosticsResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/GetInstalledCertificateIds.hpp
+++ b/include/ocpp/v16/messages/GetInstalledCertificateIds.hpp
@@ -18,7 +18,7 @@ struct GetInstalledCertificateIdsRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetInstalledCertificateIds message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetInstalledCertificateIdsRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct GetInstalledCertificateIdsResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetInstalledCertificateIdsResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetInstalledCertificateIdsResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/GetLocalListVersion.hpp
+++ b/include/ocpp/v16/messages/GetLocalListVersion.hpp
@@ -15,7 +15,7 @@ struct GetLocalListVersionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetLocalListVersion message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLocalListVersionRequest \p k to a given json object \p j
@@ -34,7 +34,7 @@ struct GetLocalListVersionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetLocalListVersionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLocalListVersionResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/GetLog.hpp
+++ b/include/ocpp/v16/messages/GetLog.hpp
@@ -23,7 +23,7 @@ struct GetLogRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetLog message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLogRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct GetLogResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetLogResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLogResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/Heartbeat.hpp
+++ b/include/ocpp/v16/messages/Heartbeat.hpp
@@ -15,7 +15,7 @@ struct HeartbeatRequest : public ocpp::Message {
 
     /// \brief Provides the type of this Heartbeat message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given HeartbeatRequest \p k to a given json object \p j
@@ -34,7 +34,7 @@ struct HeartbeatResponse : public ocpp::Message {
 
     /// \brief Provides the type of this HeartbeatResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given HeartbeatResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/InstallCertificate.hpp
+++ b/include/ocpp/v16/messages/InstallCertificate.hpp
@@ -18,7 +18,7 @@ struct InstallCertificateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this InstallCertificate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given InstallCertificateRequest \p k to a given json object \p j
@@ -37,7 +37,7 @@ struct InstallCertificateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this InstallCertificateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given InstallCertificateResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/LogStatusNotification.hpp
+++ b/include/ocpp/v16/messages/LogStatusNotification.hpp
@@ -19,7 +19,7 @@ struct LogStatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this LogStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given LogStatusNotificationRequest \p k to a given json object \p j
@@ -37,7 +37,7 @@ struct LogStatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this LogStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given LogStatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/MeterValues.hpp
+++ b/include/ocpp/v16/messages/MeterValues.hpp
@@ -20,7 +20,7 @@ struct MeterValuesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this MeterValues message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given MeterValuesRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct MeterValuesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this MeterValuesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given MeterValuesResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/RemoteStartTransaction.hpp
+++ b/include/ocpp/v16/messages/RemoteStartTransaction.hpp
@@ -21,7 +21,7 @@ struct RemoteStartTransactionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this RemoteStartTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RemoteStartTransactionRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct RemoteStartTransactionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this RemoteStartTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RemoteStartTransactionResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/RemoteStopTransaction.hpp
+++ b/include/ocpp/v16/messages/RemoteStopTransaction.hpp
@@ -17,7 +17,7 @@ struct RemoteStopTransactionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this RemoteStopTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RemoteStopTransactionRequest \p k to a given json object \p j
@@ -36,7 +36,7 @@ struct RemoteStopTransactionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this RemoteStopTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RemoteStopTransactionResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/ReserveNow.hpp
+++ b/include/ocpp/v16/messages/ReserveNow.hpp
@@ -23,7 +23,7 @@ struct ReserveNowRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ReserveNow message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReserveNowRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct ReserveNowResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ReserveNowResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReserveNowResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/Reset.hpp
+++ b/include/ocpp/v16/messages/Reset.hpp
@@ -17,7 +17,7 @@ struct ResetRequest : public ocpp::Message {
 
     /// \brief Provides the type of this Reset message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ResetRequest \p k to a given json object \p j
@@ -36,7 +36,7 @@ struct ResetResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ResetResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ResetResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/SecurityEventNotification.hpp
+++ b/include/ocpp/v16/messages/SecurityEventNotification.hpp
@@ -20,7 +20,7 @@ struct SecurityEventNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SecurityEventNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SecurityEventNotificationRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct SecurityEventNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SecurityEventNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SecurityEventNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/SendLocalList.hpp
+++ b/include/ocpp/v16/messages/SendLocalList.hpp
@@ -21,7 +21,7 @@ struct SendLocalListRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SendLocalList message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SendLocalListRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct SendLocalListResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SendLocalListResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SendLocalListResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/SetChargingProfile.hpp
+++ b/include/ocpp/v16/messages/SetChargingProfile.hpp
@@ -19,7 +19,7 @@ struct SetChargingProfileRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetChargingProfile message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetChargingProfileRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct SetChargingProfileResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetChargingProfileResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetChargingProfileResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/SignCertificate.hpp
+++ b/include/ocpp/v16/messages/SignCertificate.hpp
@@ -17,7 +17,7 @@ struct SignCertificateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SignCertificate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignCertificateRequest \p k to a given json object \p j
@@ -36,7 +36,7 @@ struct SignCertificateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SignCertificateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignCertificateResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/SignedFirmwareStatusNotification.hpp
+++ b/include/ocpp/v16/messages/SignedFirmwareStatusNotification.hpp
@@ -19,7 +19,7 @@ struct SignedFirmwareStatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SignedFirmwareStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignedFirmwareStatusNotificationRequest \p k to a given json object \p j
@@ -37,7 +37,7 @@ struct SignedFirmwareStatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SignedFirmwareStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignedFirmwareStatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/SignedUpdateFirmware.hpp
+++ b/include/ocpp/v16/messages/SignedUpdateFirmware.hpp
@@ -21,7 +21,7 @@ struct SignedUpdateFirmwareRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SignedUpdateFirmware message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignedUpdateFirmwareRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct SignedUpdateFirmwareResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SignedUpdateFirmwareResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignedUpdateFirmwareResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/StartTransaction.hpp
+++ b/include/ocpp/v16/messages/StartTransaction.hpp
@@ -23,7 +23,7 @@ struct StartTransactionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this StartTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StartTransactionRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct StartTransactionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this StartTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StartTransactionResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/StatusNotification.hpp
+++ b/include/ocpp/v16/messages/StatusNotification.hpp
@@ -25,7 +25,7 @@ struct StatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this StatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StatusNotificationRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct StatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this StatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/StopTransaction.hpp
+++ b/include/ocpp/v16/messages/StopTransaction.hpp
@@ -24,7 +24,7 @@ struct StopTransactionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this StopTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StopTransactionRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct StopTransactionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this StopTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StopTransactionResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/TriggerMessage.hpp
+++ b/include/ocpp/v16/messages/TriggerMessage.hpp
@@ -19,7 +19,7 @@ struct TriggerMessageRequest : public ocpp::Message {
 
     /// \brief Provides the type of this TriggerMessage message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given TriggerMessageRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct TriggerMessageResponse : public ocpp::Message {
 
     /// \brief Provides the type of this TriggerMessageResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given TriggerMessageResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/UnlockConnector.hpp
+++ b/include/ocpp/v16/messages/UnlockConnector.hpp
@@ -17,7 +17,7 @@ struct UnlockConnectorRequest : public ocpp::Message {
 
     /// \brief Provides the type of this UnlockConnector message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UnlockConnectorRequest \p k to a given json object \p j
@@ -36,7 +36,7 @@ struct UnlockConnectorResponse : public ocpp::Message {
 
     /// \brief Provides the type of this UnlockConnectorResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UnlockConnectorResponse \p k to a given json object \p j

--- a/include/ocpp/v16/messages/UpdateFirmware.hpp
+++ b/include/ocpp/v16/messages/UpdateFirmware.hpp
@@ -20,7 +20,7 @@ struct UpdateFirmwareRequest : public ocpp::Message {
 
     /// \brief Provides the type of this UpdateFirmware message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UpdateFirmwareRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct UpdateFirmwareResponse : public ocpp::Message {
 
     /// \brief Provides the type of this UpdateFirmwareResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UpdateFirmwareResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/Authorize.hpp
+++ b/include/ocpp/v201/messages/Authorize.hpp
@@ -22,7 +22,7 @@ struct AuthorizeRequest : public ocpp::Message {
 
     /// \brief Provides the type of this Authorize message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given AuthorizeRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct AuthorizeResponse : public ocpp::Message {
 
     /// \brief Provides the type of this AuthorizeResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given AuthorizeResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/BootNotification.hpp
+++ b/include/ocpp/v201/messages/BootNotification.hpp
@@ -21,7 +21,7 @@ struct BootNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this BootNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given BootNotificationRequest \p k to a given json object \p j
@@ -44,7 +44,7 @@ struct BootNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this BootNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given BootNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/CancelReservation.hpp
+++ b/include/ocpp/v201/messages/CancelReservation.hpp
@@ -20,7 +20,7 @@ struct CancelReservationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this CancelReservation message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CancelReservationRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct CancelReservationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this CancelReservationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CancelReservationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/CertificateSigned.hpp
+++ b/include/ocpp/v201/messages/CertificateSigned.hpp
@@ -21,7 +21,7 @@ struct CertificateSignedRequest : public ocpp::Message {
 
     /// \brief Provides the type of this CertificateSigned message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CertificateSignedRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct CertificateSignedResponse : public ocpp::Message {
 
     /// \brief Provides the type of this CertificateSignedResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CertificateSignedResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ChangeAvailability.hpp
+++ b/include/ocpp/v201/messages/ChangeAvailability.hpp
@@ -21,7 +21,7 @@ struct ChangeAvailabilityRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ChangeAvailability message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ChangeAvailabilityRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct ChangeAvailabilityResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ChangeAvailabilityResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ChangeAvailabilityResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ClearCache.hpp
+++ b/include/ocpp/v201/messages/ClearCache.hpp
@@ -19,7 +19,7 @@ struct ClearCacheRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ClearCache message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearCacheRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct ClearCacheResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ClearCacheResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearCacheResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ClearChargingProfile.hpp
+++ b/include/ocpp/v201/messages/ClearChargingProfile.hpp
@@ -21,7 +21,7 @@ struct ClearChargingProfileRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ClearChargingProfile message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearChargingProfileRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct ClearChargingProfileResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ClearChargingProfileResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearChargingProfileResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ClearDisplayMessage.hpp
+++ b/include/ocpp/v201/messages/ClearDisplayMessage.hpp
@@ -20,7 +20,7 @@ struct ClearDisplayMessageRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ClearDisplayMessage message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearDisplayMessageRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct ClearDisplayMessageResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ClearDisplayMessageResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearDisplayMessageResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ClearVariableMonitoring.hpp
+++ b/include/ocpp/v201/messages/ClearVariableMonitoring.hpp
@@ -20,7 +20,7 @@ struct ClearVariableMonitoringRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ClearVariableMonitoring message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearVariableMonitoringRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct ClearVariableMonitoringResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ClearVariableMonitoringResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearVariableMonitoringResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ClearedChargingLimit.hpp
+++ b/include/ocpp/v201/messages/ClearedChargingLimit.hpp
@@ -21,7 +21,7 @@ struct ClearedChargingLimitRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ClearedChargingLimit message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearedChargingLimitRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct ClearedChargingLimitResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ClearedChargingLimitResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ClearedChargingLimitResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/CostUpdated.hpp
+++ b/include/ocpp/v201/messages/CostUpdated.hpp
@@ -20,7 +20,7 @@ struct CostUpdatedRequest : public ocpp::Message {
 
     /// \brief Provides the type of this CostUpdated message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CostUpdatedRequest \p k to a given json object \p j
@@ -39,7 +39,7 @@ struct CostUpdatedResponse : public ocpp::Message {
 
     /// \brief Provides the type of this CostUpdatedResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CostUpdatedResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/CustomerInformation.hpp
+++ b/include/ocpp/v201/messages/CustomerInformation.hpp
@@ -25,7 +25,7 @@ struct CustomerInformationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this CustomerInformation message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CustomerInformationRequest \p k to a given json object \p j
@@ -46,7 +46,7 @@ struct CustomerInformationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this CustomerInformationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given CustomerInformationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/DataTransfer.hpp
+++ b/include/ocpp/v201/messages/DataTransfer.hpp
@@ -22,7 +22,7 @@ struct DataTransferRequest : public ocpp::Message {
 
     /// \brief Provides the type of this DataTransfer message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DataTransferRequest \p k to a given json object \p j
@@ -44,7 +44,7 @@ struct DataTransferResponse : public ocpp::Message {
 
     /// \brief Provides the type of this DataTransferResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DataTransferResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/DeleteCertificate.hpp
+++ b/include/ocpp/v201/messages/DeleteCertificate.hpp
@@ -20,7 +20,7 @@ struct DeleteCertificateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this DeleteCertificate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DeleteCertificateRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct DeleteCertificateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this DeleteCertificateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given DeleteCertificateResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/FirmwareStatusNotification.hpp
+++ b/include/ocpp/v201/messages/FirmwareStatusNotification.hpp
@@ -21,7 +21,7 @@ struct FirmwareStatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this FirmwareStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given FirmwareStatusNotificationRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct FirmwareStatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this FirmwareStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given FirmwareStatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/Get15118EVCertificate.hpp
+++ b/include/ocpp/v201/messages/Get15118EVCertificate.hpp
@@ -22,7 +22,7 @@ struct Get15118EVCertificateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this Get15118EVCertificate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given Get15118EVCertificateRequest \p k to a given json object \p j
@@ -44,7 +44,7 @@ struct Get15118EVCertificateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this Get15118EVCertificateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given Get15118EVCertificateResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetBaseReport.hpp
+++ b/include/ocpp/v201/messages/GetBaseReport.hpp
@@ -21,7 +21,7 @@ struct GetBaseReportRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetBaseReport message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetBaseReportRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct GetBaseReportResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetBaseReportResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetBaseReportResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetCertificateStatus.hpp
+++ b/include/ocpp/v201/messages/GetCertificateStatus.hpp
@@ -20,7 +20,7 @@ struct GetCertificateStatusRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetCertificateStatus message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetCertificateStatusRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct GetCertificateStatusResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetCertificateStatusResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetCertificateStatusResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetChargingProfiles.hpp
+++ b/include/ocpp/v201/messages/GetChargingProfiles.hpp
@@ -22,7 +22,7 @@ struct GetChargingProfilesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetChargingProfiles message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetChargingProfilesRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct GetChargingProfilesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetChargingProfilesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetChargingProfilesResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetCompositeSchedule.hpp
+++ b/include/ocpp/v201/messages/GetCompositeSchedule.hpp
@@ -22,7 +22,7 @@ struct GetCompositeScheduleRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetCompositeSchedule message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetCompositeScheduleRequest \p k to a given json object \p j
@@ -44,7 +44,7 @@ struct GetCompositeScheduleResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetCompositeScheduleResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetCompositeScheduleResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetDisplayMessages.hpp
+++ b/include/ocpp/v201/messages/GetDisplayMessages.hpp
@@ -23,7 +23,7 @@ struct GetDisplayMessagesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetDisplayMessages message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetDisplayMessagesRequest \p k to a given json object \p j
@@ -44,7 +44,7 @@ struct GetDisplayMessagesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetDisplayMessagesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetDisplayMessagesResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetInstalledCertificateIds.hpp
+++ b/include/ocpp/v201/messages/GetInstalledCertificateIds.hpp
@@ -20,7 +20,7 @@ struct GetInstalledCertificateIdsRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetInstalledCertificateIds message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetInstalledCertificateIdsRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct GetInstalledCertificateIdsResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetInstalledCertificateIdsResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetInstalledCertificateIdsResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetLocalListVersion.hpp
+++ b/include/ocpp/v201/messages/GetLocalListVersion.hpp
@@ -18,7 +18,7 @@ struct GetLocalListVersionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetLocalListVersion message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLocalListVersionRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct GetLocalListVersionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetLocalListVersionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLocalListVersionResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetLog.hpp
+++ b/include/ocpp/v201/messages/GetLog.hpp
@@ -24,7 +24,7 @@ struct GetLogRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetLog message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLogRequest \p k to a given json object \p j
@@ -46,7 +46,7 @@ struct GetLogResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetLogResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetLogResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetMonitoringReport.hpp
+++ b/include/ocpp/v201/messages/GetMonitoringReport.hpp
@@ -22,7 +22,7 @@ struct GetMonitoringReportRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetMonitoringReport message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetMonitoringReportRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct GetMonitoringReportResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetMonitoringReportResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetMonitoringReportResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetReport.hpp
+++ b/include/ocpp/v201/messages/GetReport.hpp
@@ -22,7 +22,7 @@ struct GetReportRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetReport message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetReportRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct GetReportResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetReportResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetReportResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetTransactionStatus.hpp
+++ b/include/ocpp/v201/messages/GetTransactionStatus.hpp
@@ -19,7 +19,7 @@ struct GetTransactionStatusRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetTransactionStatus message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetTransactionStatusRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct GetTransactionStatusResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetTransactionStatusResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetTransactionStatusResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/GetVariables.hpp
+++ b/include/ocpp/v201/messages/GetVariables.hpp
@@ -20,7 +20,7 @@ struct GetVariablesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this GetVariables message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetVariablesRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct GetVariablesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this GetVariablesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given GetVariablesResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/Heartbeat.hpp
+++ b/include/ocpp/v201/messages/Heartbeat.hpp
@@ -18,7 +18,7 @@ struct HeartbeatRequest : public ocpp::Message {
 
     /// \brief Provides the type of this Heartbeat message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given HeartbeatRequest \p k to a given json object \p j
@@ -38,7 +38,7 @@ struct HeartbeatResponse : public ocpp::Message {
 
     /// \brief Provides the type of this HeartbeatResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given HeartbeatResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/InstallCertificate.hpp
+++ b/include/ocpp/v201/messages/InstallCertificate.hpp
@@ -21,7 +21,7 @@ struct InstallCertificateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this InstallCertificate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given InstallCertificateRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct InstallCertificateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this InstallCertificateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given InstallCertificateResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/LogStatusNotification.hpp
+++ b/include/ocpp/v201/messages/LogStatusNotification.hpp
@@ -21,7 +21,7 @@ struct LogStatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this LogStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given LogStatusNotificationRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct LogStatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this LogStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given LogStatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/MeterValues.hpp
+++ b/include/ocpp/v201/messages/MeterValues.hpp
@@ -21,7 +21,7 @@ struct MeterValuesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this MeterValues message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given MeterValuesRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct MeterValuesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this MeterValuesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given MeterValuesResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyChargingLimit.hpp
+++ b/include/ocpp/v201/messages/NotifyChargingLimit.hpp
@@ -22,7 +22,7 @@ struct NotifyChargingLimitRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyChargingLimit message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyChargingLimitRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct NotifyChargingLimitResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyChargingLimitResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyChargingLimitResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyCustomerInformation.hpp
+++ b/include/ocpp/v201/messages/NotifyCustomerInformation.hpp
@@ -23,7 +23,7 @@ struct NotifyCustomerInformationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyCustomerInformation message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyCustomerInformationRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct NotifyCustomerInformationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyCustomerInformationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyCustomerInformationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyDisplayMessages.hpp
+++ b/include/ocpp/v201/messages/NotifyDisplayMessages.hpp
@@ -22,7 +22,7 @@ struct NotifyDisplayMessagesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyDisplayMessages message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyDisplayMessagesRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct NotifyDisplayMessagesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyDisplayMessagesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyDisplayMessagesResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyEVChargingNeeds.hpp
+++ b/include/ocpp/v201/messages/NotifyEVChargingNeeds.hpp
@@ -22,7 +22,7 @@ struct NotifyEVChargingNeedsRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyEVChargingNeeds message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyEVChargingNeedsRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct NotifyEVChargingNeedsResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyEVChargingNeedsResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyEVChargingNeedsResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyEVChargingSchedule.hpp
+++ b/include/ocpp/v201/messages/NotifyEVChargingSchedule.hpp
@@ -22,7 +22,7 @@ struct NotifyEVChargingScheduleRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyEVChargingSchedule message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyEVChargingScheduleRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct NotifyEVChargingScheduleResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyEVChargingScheduleResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyEVChargingScheduleResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyEvent.hpp
+++ b/include/ocpp/v201/messages/NotifyEvent.hpp
@@ -23,7 +23,7 @@ struct NotifyEventRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyEvent message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyEventRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct NotifyEventResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyEventResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyEventResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyMonitoringReport.hpp
+++ b/include/ocpp/v201/messages/NotifyMonitoringReport.hpp
@@ -24,7 +24,7 @@ struct NotifyMonitoringReportRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyMonitoringReport message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyMonitoringReportRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct NotifyMonitoringReportResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyMonitoringReportResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyMonitoringReportResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/NotifyReport.hpp
+++ b/include/ocpp/v201/messages/NotifyReport.hpp
@@ -24,7 +24,7 @@ struct NotifyReportRequest : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyReport message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyReportRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct NotifyReportResponse : public ocpp::Message {
 
     /// \brief Provides the type of this NotifyReportResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given NotifyReportResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/PublishFirmware.hpp
+++ b/include/ocpp/v201/messages/PublishFirmware.hpp
@@ -24,7 +24,7 @@ struct PublishFirmwareRequest : public ocpp::Message {
 
     /// \brief Provides the type of this PublishFirmware message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given PublishFirmwareRequest \p k to a given json object \p j
@@ -45,7 +45,7 @@ struct PublishFirmwareResponse : public ocpp::Message {
 
     /// \brief Provides the type of this PublishFirmwareResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given PublishFirmwareResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/PublishFirmwareStatusNotification.hpp
+++ b/include/ocpp/v201/messages/PublishFirmwareStatusNotification.hpp
@@ -22,7 +22,7 @@ struct PublishFirmwareStatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this PublishFirmwareStatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given PublishFirmwareStatusNotificationRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct PublishFirmwareStatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this PublishFirmwareStatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given PublishFirmwareStatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ReportChargingProfiles.hpp
+++ b/include/ocpp/v201/messages/ReportChargingProfiles.hpp
@@ -24,7 +24,7 @@ struct ReportChargingProfilesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ReportChargingProfiles message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReportChargingProfilesRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct ReportChargingProfilesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ReportChargingProfilesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReportChargingProfilesResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/RequestStartTransaction.hpp
+++ b/include/ocpp/v201/messages/RequestStartTransaction.hpp
@@ -24,7 +24,7 @@ struct RequestStartTransactionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this StartTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RequestStartTransactionRequest \p k to a given json object \p j
@@ -46,7 +46,7 @@ struct RequestStartTransactionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this StartTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RequestStartTransactionResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/RequestStopTransaction.hpp
+++ b/include/ocpp/v201/messages/RequestStopTransaction.hpp
@@ -20,7 +20,7 @@ struct RequestStopTransactionRequest : public ocpp::Message {
 
     /// \brief Provides the type of this StopTransaction message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RequestStopTransactionRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct RequestStopTransactionResponse : public ocpp::Message {
 
     /// \brief Provides the type of this StopTransactionResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given RequestStopTransactionResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ReservationStatusUpdate.hpp
+++ b/include/ocpp/v201/messages/ReservationStatusUpdate.hpp
@@ -21,7 +21,7 @@ struct ReservationStatusUpdateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ReservationStatusUpdate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReservationStatusUpdateRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct ReservationStatusUpdateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ReservationStatusUpdateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReservationStatusUpdateResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/ReserveNow.hpp
+++ b/include/ocpp/v201/messages/ReserveNow.hpp
@@ -25,7 +25,7 @@ struct ReserveNowRequest : public ocpp::Message {
 
     /// \brief Provides the type of this ReserveNow message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReserveNowRequest \p k to a given json object \p j
@@ -46,7 +46,7 @@ struct ReserveNowResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ReserveNowResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ReserveNowResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/Reset.hpp
+++ b/include/ocpp/v201/messages/Reset.hpp
@@ -21,7 +21,7 @@ struct ResetRequest : public ocpp::Message {
 
     /// \brief Provides the type of this Reset message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ResetRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct ResetResponse : public ocpp::Message {
 
     /// \brief Provides the type of this ResetResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given ResetResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SecurityEventNotification.hpp
+++ b/include/ocpp/v201/messages/SecurityEventNotification.hpp
@@ -21,7 +21,7 @@ struct SecurityEventNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SecurityEventNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SecurityEventNotificationRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct SecurityEventNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SecurityEventNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SecurityEventNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SendLocalList.hpp
+++ b/include/ocpp/v201/messages/SendLocalList.hpp
@@ -22,7 +22,7 @@ struct SendLocalListRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SendLocalList message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SendLocalListRequest \p k to a given json object \p j
@@ -43,7 +43,7 @@ struct SendLocalListResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SendLocalListResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SendLocalListResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SetChargingProfile.hpp
+++ b/include/ocpp/v201/messages/SetChargingProfile.hpp
@@ -21,7 +21,7 @@ struct SetChargingProfileRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetChargingProfile message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetChargingProfileRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct SetChargingProfileResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetChargingProfileResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetChargingProfileResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SetDisplayMessage.hpp
+++ b/include/ocpp/v201/messages/SetDisplayMessage.hpp
@@ -20,7 +20,7 @@ struct SetDisplayMessageRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetDisplayMessage message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetDisplayMessageRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct SetDisplayMessageResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetDisplayMessageResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetDisplayMessageResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SetMonitoringBase.hpp
+++ b/include/ocpp/v201/messages/SetMonitoringBase.hpp
@@ -20,7 +20,7 @@ struct SetMonitoringBaseRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetMonitoringBase message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetMonitoringBaseRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct SetMonitoringBaseResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetMonitoringBaseResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetMonitoringBaseResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SetMonitoringLevel.hpp
+++ b/include/ocpp/v201/messages/SetMonitoringLevel.hpp
@@ -20,7 +20,7 @@ struct SetMonitoringLevelRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetMonitoringLevel message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetMonitoringLevelRequest \p k to a given json object \p j
@@ -41,7 +41,7 @@ struct SetMonitoringLevelResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetMonitoringLevelResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetMonitoringLevelResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SetNetworkProfile.hpp
+++ b/include/ocpp/v201/messages/SetNetworkProfile.hpp
@@ -21,7 +21,7 @@ struct SetNetworkProfileRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetNetworkProfile message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetNetworkProfileRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct SetNetworkProfileResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetNetworkProfileResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetNetworkProfileResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SetVariableMonitoring.hpp
+++ b/include/ocpp/v201/messages/SetVariableMonitoring.hpp
@@ -20,7 +20,7 @@ struct SetVariableMonitoringRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetVariableMonitoring message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetVariableMonitoringRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct SetVariableMonitoringResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetVariableMonitoringResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetVariableMonitoringResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SetVariables.hpp
+++ b/include/ocpp/v201/messages/SetVariables.hpp
@@ -20,7 +20,7 @@ struct SetVariablesRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SetVariables message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetVariablesRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct SetVariablesResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SetVariablesResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SetVariablesResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/SignCertificate.hpp
+++ b/include/ocpp/v201/messages/SignCertificate.hpp
@@ -21,7 +21,7 @@ struct SignCertificateRequest : public ocpp::Message {
 
     /// \brief Provides the type of this SignCertificate message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignCertificateRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct SignCertificateResponse : public ocpp::Message {
 
     /// \brief Provides the type of this SignCertificateResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given SignCertificateResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/StatusNotification.hpp
+++ b/include/ocpp/v201/messages/StatusNotification.hpp
@@ -23,7 +23,7 @@ struct StatusNotificationRequest : public ocpp::Message {
 
     /// \brief Provides the type of this StatusNotification message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StatusNotificationRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct StatusNotificationResponse : public ocpp::Message {
 
     /// \brief Provides the type of this StatusNotificationResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given StatusNotificationResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/TransactionEvent.hpp
+++ b/include/ocpp/v201/messages/TransactionEvent.hpp
@@ -31,7 +31,7 @@ struct TransactionEventRequest : public ocpp::Message {
 
     /// \brief Provides the type of this TransactionEvent message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given TransactionEventRequest \p k to a given json object \p j
@@ -54,7 +54,7 @@ struct TransactionEventResponse : public ocpp::Message {
 
     /// \brief Provides the type of this TransactionEventResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given TransactionEventResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/TriggerMessage.hpp
+++ b/include/ocpp/v201/messages/TriggerMessage.hpp
@@ -21,7 +21,7 @@ struct TriggerMessageRequest : public ocpp::Message {
 
     /// \brief Provides the type of this TriggerMessage message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given TriggerMessageRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct TriggerMessageResponse : public ocpp::Message {
 
     /// \brief Provides the type of this TriggerMessageResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given TriggerMessageResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/UnlockConnector.hpp
+++ b/include/ocpp/v201/messages/UnlockConnector.hpp
@@ -21,7 +21,7 @@ struct UnlockConnectorRequest : public ocpp::Message {
 
     /// \brief Provides the type of this UnlockConnector message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UnlockConnectorRequest \p k to a given json object \p j
@@ -42,7 +42,7 @@ struct UnlockConnectorResponse : public ocpp::Message {
 
     /// \brief Provides the type of this UnlockConnectorResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UnlockConnectorResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/UnpublishFirmware.hpp
+++ b/include/ocpp/v201/messages/UnpublishFirmware.hpp
@@ -20,7 +20,7 @@ struct UnpublishFirmwareRequest : public ocpp::Message {
 
     /// \brief Provides the type of this UnpublishFirmware message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UnpublishFirmwareRequest \p k to a given json object \p j
@@ -40,7 +40,7 @@ struct UnpublishFirmwareResponse : public ocpp::Message {
 
     /// \brief Provides the type of this UnpublishFirmwareResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UnpublishFirmwareResponse \p k to a given json object \p j

--- a/include/ocpp/v201/messages/UpdateFirmware.hpp
+++ b/include/ocpp/v201/messages/UpdateFirmware.hpp
@@ -23,7 +23,7 @@ struct UpdateFirmwareRequest : public ocpp::Message {
 
     /// \brief Provides the type of this UpdateFirmware message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UpdateFirmwareRequest \p k to a given json object \p j
@@ -44,7 +44,7 @@ struct UpdateFirmwareResponse : public ocpp::Message {
 
     /// \brief Provides the type of this UpdateFirmwareResponse message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given UpdateFirmwareResponse \p k to a given json object \p j

--- a/src/code_generator/common/templates/message.hpp.jinja
+++ b/src/code_generator/common/templates/message.hpp.jinja
@@ -36,7 +36,7 @@ struct {{ type.name }} : public ocpp::Message {
 
     /// \brief Provides the type of this {{ type.name | replace('Request', '') }} message as a human readable string
     /// \returns the message type as a human readable string
-    std::string get_type() const;
+    std::string get_type() const override;
 };
 
 /// \brief Conversion from a given {{ type.name }} \p k to a given json object \p j


### PR DESCRIPTION
## Describe your changes
To improve code readability and maintenance, all overriding methods are marked with keyword _override_ (allows to enable warning-free the compile options "-Wsuggest-override").

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

