### PR TITLE
Fix issue with signed meter values for resumed transactions in OCPP1.6

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -384,7 +384,6 @@ void ChargePointImpl::try_resume_transactions(const std::set<std::string>& resum
         }
 
         const auto stop_energy_wh = std::make_shared<StampedEnergyWh>(timestamp, meter_stop);
-        transaction->add_stop_energy_wh(stop_energy_wh);
         transaction->set_transaction_id(transaction_entry.transaction_id);
         // we need this in order to handle a StartTransaction.conf
         transaction->set_start_transaction_message_id(transaction_entry.start_transaction_message_id);
@@ -409,6 +408,7 @@ void ChargePointImpl::try_resume_transactions(const std::set<std::string>& resum
                 EVLOG_info << "Queuing StopTransaction.req for transaction with id: "
                            << transaction_entry.transaction_id
                            << " because it hasn't been acknowledged by CSMS and shall not be resumed.";
+                transaction->add_stop_energy_wh(stop_energy_wh);
                 this->stop_transaction(transaction_entry.connector, Reason::PowerLoss, std::nullopt);
             } else {
                 EVLOG_info << "Resuming transaction with transaction id: " << transaction_entry.transaction_id;


### PR DESCRIPTION
## Describe your changes
Moved `add_stop_energy_wh` in `try_resume_transactions` since this shall only be executed in case the StopTransaction.req shall be queued by executing `stop_transaction`.

This fixes an issue that signed meter values cannot be added anymore for resumed transactions.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

