### PR TITLE
Loading ChargingProfiles into memory when ChargePoint is constructed

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -125,6 +125,7 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
     this->smart_charging_handler = std::make_unique<SmartChargingHandler>(
         this->connectors, this->database_handler,
         this->configuration->getAllowChargingProfileWithoutStartSchedule().value_or(false));
+    this->load_charging_profiles();
 
     // ISO15118 PnC handlers
     if (this->configuration->getSupportedFeatureProfilesSet().count(SupportedFeatureProfiles::PnC)) {
@@ -874,7 +875,6 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->message_queue->get_persisted_messages_from_db(this->configuration->getDisableSecurityEventNotifications());
     this->boot_notification();
     this->try_resume_transactions(resuming_session_ids);
-    this->load_charging_profiles();
     this->call_set_connection_timeout();
 
     switch (bootreason) {


### PR DESCRIPTION
## Describe your changes
Moved loading of charging profiles from database into memory into constructor. Before that, this function was inside the start() function of the ChargePoint. If the libocpp consumer requested the composite schedule before the start() function is called, existing profiles were not used.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

