### PR TITLE
Update generators and move custom enums to new file

### DIFF
--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -18,8 +18,8 @@
 
 #include <ocpp/common/cistring.hpp>
 #include <ocpp/common/support_older_cpp_versions.hpp>
-#include <ocpp/v16/enums.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 
 using json = nlohmann::json;
 

--- a/include/ocpp/v16/charge_point_state_machine.hpp
+++ b/include/ocpp/v16/charge_point_state_machine.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 
 namespace ocpp {
 namespace v16 {

--- a/include/ocpp/v16/messages/Authorize.hpp
+++ b/include/ocpp/v16/messages/Authorize.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_AUTHORIZE_HPP
 #define OCPP_V16_AUTHORIZE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/BootNotification.hpp
+++ b/include/ocpp/v16/messages/BootNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_BOOTNOTIFICATION_HPP
 #define OCPP_V16_BOOTNOTIFICATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/CancelReservation.hpp
+++ b/include/ocpp/v16/messages/CancelReservation.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_CANCELRESERVATION_HPP
 #define OCPP_V16_CANCELRESERVATION_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/CertificateSigned.hpp
+++ b/include/ocpp/v16/messages/CertificateSigned.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_CERTIFICATESIGNED_HPP
 #define OCPP_V16_CERTIFICATESIGNED_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/ChangeAvailability.hpp
+++ b/include/ocpp/v16/messages/ChangeAvailability.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_CHANGEAVAILABILITY_HPP
 #define OCPP_V16_CHANGEAVAILABILITY_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/ChangeConfiguration.hpp
+++ b/include/ocpp/v16/messages/ChangeConfiguration.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_CHANGECONFIGURATION_HPP
 #define OCPP_V16_CHANGECONFIGURATION_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/ClearCache.hpp
+++ b/include/ocpp/v16/messages/ClearCache.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_CLEARCACHE_HPP
 #define OCPP_V16_CLEARCACHE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/ClearChargingProfile.hpp
+++ b/include/ocpp/v16/messages/ClearChargingProfile.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_CLEARCHARGINGPROFILE_HPP
 #define OCPP_V16_CLEARCHARGINGPROFILE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/DataTransfer.hpp
+++ b/include/ocpp/v16/messages/DataTransfer.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_DATATRANSFER_HPP
 #define OCPP_V16_DATATRANSFER_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/DeleteCertificate.hpp
+++ b/include/ocpp/v16/messages/DeleteCertificate.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_DELETECERTIFICATE_HPP
 #define OCPP_V16_DELETECERTIFICATE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/DiagnosticsStatusNotification.hpp
+++ b/include/ocpp/v16/messages/DiagnosticsStatusNotification.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_DIAGNOSTICSSTATUSNOTIFICATION_HPP
 #define OCPP_V16_DIAGNOSTICSSTATUSNOTIFICATION_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/ExtendedTriggerMessage.hpp
+++ b/include/ocpp/v16/messages/ExtendedTriggerMessage.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_EXTENDEDTRIGGERMESSAGE_HPP
 #define OCPP_V16_EXTENDEDTRIGGERMESSAGE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/FirmwareStatusNotification.hpp
+++ b/include/ocpp/v16/messages/FirmwareStatusNotification.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_FIRMWARESTATUSNOTIFICATION_HPP
 #define OCPP_V16_FIRMWARESTATUSNOTIFICATION_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/GetCompositeSchedule.hpp
+++ b/include/ocpp/v16/messages/GetCompositeSchedule.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_GETCOMPOSITESCHEDULE_HPP
 #define OCPP_V16_GETCOMPOSITESCHEDULE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/GetConfiguration.hpp
+++ b/include/ocpp/v16/messages/GetConfiguration.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_GETCONFIGURATION_HPP
 #define OCPP_V16_GETCONFIGURATION_HPP
 

--- a/include/ocpp/v16/messages/GetDiagnostics.hpp
+++ b/include/ocpp/v16/messages/GetDiagnostics.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_GETDIAGNOSTICS_HPP
 #define OCPP_V16_GETDIAGNOSTICS_HPP
 

--- a/include/ocpp/v16/messages/GetInstalledCertificateIds.hpp
+++ b/include/ocpp/v16/messages/GetInstalledCertificateIds.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_GETINSTALLEDCERTIFICATEIDS_HPP
 #define OCPP_V16_GETINSTALLEDCERTIFICATEIDS_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/GetLocalListVersion.hpp
+++ b/include/ocpp/v16/messages/GetLocalListVersion.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_GETLOCALLISTVERSION_HPP
 #define OCPP_V16_GETLOCALLISTVERSION_HPP
 

--- a/include/ocpp/v16/messages/GetLog.hpp
+++ b/include/ocpp/v16/messages/GetLog.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_GETLOG_HPP
 #define OCPP_V16_GETLOG_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/Heartbeat.hpp
+++ b/include/ocpp/v16/messages/Heartbeat.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_HEARTBEAT_HPP
 #define OCPP_V16_HEARTBEAT_HPP
 

--- a/include/ocpp/v16/messages/InstallCertificate.hpp
+++ b/include/ocpp/v16/messages/InstallCertificate.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_INSTALLCERTIFICATE_HPP
 #define OCPP_V16_INSTALLCERTIFICATE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/LogStatusNotification.hpp
+++ b/include/ocpp/v16/messages/LogStatusNotification.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_LOGSTATUSNOTIFICATION_HPP
 #define OCPP_V16_LOGSTATUSNOTIFICATION_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/MeterValues.hpp
+++ b/include/ocpp/v16/messages/MeterValues.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_METERVALUES_HPP
 #define OCPP_V16_METERVALUES_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/RemoteStartTransaction.hpp
+++ b/include/ocpp/v16/messages/RemoteStartTransaction.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_REMOTESTARTTRANSACTION_HPP
 #define OCPP_V16_REMOTESTARTTRANSACTION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/RemoteStopTransaction.hpp
+++ b/include/ocpp/v16/messages/RemoteStopTransaction.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_REMOTESTOPTRANSACTION_HPP
 #define OCPP_V16_REMOTESTOPTRANSACTION_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/ReserveNow.hpp
+++ b/include/ocpp/v16/messages/ReserveNow.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_RESERVENOW_HPP
 #define OCPP_V16_RESERVENOW_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/Reset.hpp
+++ b/include/ocpp/v16/messages/Reset.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_RESET_HPP
 #define OCPP_V16_RESET_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/SecurityEventNotification.hpp
+++ b/include/ocpp/v16/messages/SecurityEventNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_SECURITYEVENTNOTIFICATION_HPP
 #define OCPP_V16_SECURITYEVENTNOTIFICATION_HPP
 

--- a/include/ocpp/v16/messages/SendLocalList.hpp
+++ b/include/ocpp/v16/messages/SendLocalList.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_SENDLOCALLIST_HPP
 #define OCPP_V16_SENDLOCALLIST_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/SetChargingProfile.hpp
+++ b/include/ocpp/v16/messages/SetChargingProfile.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_SETCHARGINGPROFILE_HPP
 #define OCPP_V16_SETCHARGINGPROFILE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/SignCertificate.hpp
+++ b/include/ocpp/v16/messages/SignCertificate.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_SIGNCERTIFICATE_HPP
 #define OCPP_V16_SIGNCERTIFICATE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/SignedFirmwareStatusNotification.hpp
+++ b/include/ocpp/v16/messages/SignedFirmwareStatusNotification.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_SIGNEDFIRMWARESTATUSNOTIFICATION_HPP
 #define OCPP_V16_SIGNEDFIRMWARESTATUSNOTIFICATION_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/SignedUpdateFirmware.hpp
+++ b/include/ocpp/v16/messages/SignedUpdateFirmware.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_SIGNEDUPDATEFIRMWARE_HPP
 #define OCPP_V16_SIGNEDUPDATEFIRMWARE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/StartTransaction.hpp
+++ b/include/ocpp/v16/messages/StartTransaction.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_STARTTRANSACTION_HPP
 #define OCPP_V16_STARTTRANSACTION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/StatusNotification.hpp
+++ b/include/ocpp/v16/messages/StatusNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_STATUSNOTIFICATION_HPP
 #define OCPP_V16_STATUSNOTIFICATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/StopTransaction.hpp
+++ b/include/ocpp/v16/messages/StopTransaction.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_STOPTRANSACTION_HPP
 #define OCPP_V16_STOPTRANSACTION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/TriggerMessage.hpp
+++ b/include/ocpp/v16/messages/TriggerMessage.hpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_TRIGGERMESSAGE_HPP
 #define OCPP_V16_TRIGGERMESSAGE_HPP
 
 #include <nlohmann/json_fwd.hpp>
 #include <optional>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/UnlockConnector.hpp
+++ b/include/ocpp/v16/messages/UnlockConnector.hpp
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_UNLOCKCONNECTOR_HPP
 #define OCPP_V16_UNLOCKCONNECTOR_HPP
 
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v16/messages/UpdateFirmware.hpp
+++ b/include/ocpp/v16/messages/UpdateFirmware.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_UPDATEFIRMWARE_HPP
 #define OCPP_V16_UPDATEFIRMWARE_HPP
 

--- a/include/ocpp/v16/ocpp_enums.hpp
+++ b/include/ocpp/v16/ocpp_enums.hpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-#ifndef OCPP_V16_ENUMS_HPP
-#define OCPP_V16_ENUMS_HPP
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#ifndef OCPP_V16_OCPP_ENUMS_HPP
+#define OCPP_V16_OCPP_ENUMS_HPP
 
 #include <iosfwd>
 #include <string>
@@ -704,7 +706,6 @@ enum class UnitOfMeasure {
     Celsius,
     Fahrenheit,
     Percent,
-    RevolutionsPerMinute,
 };
 
 namespace conversions {
@@ -1143,4 +1144,4 @@ std::ostream& operator<<(std::ostream& os, const UnlockStatus& unlock_status);
 } // namespace v16
 } // namespace ocpp
 
-#endif // OCPP_V16_ENUMS_HPP
+#endif // OCPP_V16_OCPP_ENUMS_HPP

--- a/include/ocpp/v16/ocpp_types.hpp
+++ b/include/ocpp/v16/ocpp_types.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V16_OCPP_TYPES_HPP
 #define OCPP_V16_OCPP_TYPES_HPP
 
@@ -9,7 +11,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/types.hpp>
 
 namespace ocpp {
@@ -178,9 +180,9 @@ std::ostream& operator<<(std::ostream& os, const LocalAuthorizationList& k);
 
 struct FirmwareType {
     CiString<512> location;
-    ocpp::DateTime retrieveDateTime;
     CiString<5500> signingCertificate;
     CiString<800> signature;
+    std::optional<ocpp::DateTime> retrieveDateTime;
     std::optional<ocpp::DateTime> installDateTime;
 };
 /// \brief Conversion from a given FirmwareType \p k to a given json object \p j

--- a/include/ocpp/v16/types.hpp
+++ b/include/ocpp/v16/types.hpp
@@ -11,7 +11,7 @@
 #include <everest/logging.hpp>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 
 using json = nlohmann::json;
 

--- a/include/ocpp/v201/average_meter_values.hpp
+++ b/include/ocpp/v201/average_meter_values.hpp
@@ -6,7 +6,7 @@
 #include <everest/logging.hpp>
 #include <everest/timer.hpp>
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/types.hpp>
 #include <ocpp/v201/utils.hpp>

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -14,7 +14,7 @@
 #include <ocpp/v201/database_handler.hpp>
 #include <ocpp/v201/device_model.hpp>
 #include <ocpp/v201/device_model_storage.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/monitoring_updater.hpp>
 #include <ocpp/v201/ocpp_types.hpp>

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -14,9 +14,9 @@
 #include <ocpp/v201/database_handler.hpp>
 #include <ocpp/v201/device_model.hpp>
 #include <ocpp/v201/device_model_storage.hpp>
-#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/monitoring_updater.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/ocsp_updater.hpp>
 #include <ocpp/v201/types.hpp>

--- a/include/ocpp/v201/component_state_manager.hpp
+++ b/include/ocpp/v201/component_state_manager.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "database_handler.hpp"
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 
 namespace ocpp::v201 {
 

--- a/include/ocpp/v201/connector.hpp
+++ b/include/ocpp/v201/connector.hpp
@@ -8,7 +8,7 @@
 
 #include "component_state_manager.hpp"
 #include "database_handler.hpp"
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <optional>
 
 namespace ocpp {

--- a/include/ocpp/v201/device_model_storage.hpp
+++ b/include/ocpp/v201/device_model_storage.hpp
@@ -10,8 +10,8 @@
 #include <ocpp/v201/comparators.hpp>
 #include <optional>
 
-#include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {
 namespace v201 {

--- a/include/ocpp/v201/device_model_storage.hpp
+++ b/include/ocpp/v201/device_model_storage.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 
 #include <ocpp/v201/ocpp_types.hpp>
+#include <ocpp/v201/enums.hpp>
 
 namespace ocpp {
 namespace v201 {

--- a/include/ocpp/v201/enums.hpp
+++ b/include/ocpp/v201/enums.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+
+#ifndef OCPP_V201_ENUMS_HPP
+#define OCPP_V201_ENUMS_HPP
+
+namespace ocpp {
+namespace v201 {
+
+enum class VariableMonitorType {
+    HardWiredMonitor,
+    PreconfiguredMonitor,
+    CustomMonitor,
+};
+
+namespace MonitoringLevelSeverity {
+constexpr int32_t Danger = 0;
+constexpr int32_t HardwareFailure = 1;
+constexpr int32_t SystemFailure = 2;
+constexpr int32_t Critical = 3;
+constexpr int32_t Error = 4;
+constexpr int32_t Alert = 5;
+constexpr int32_t Warning = 6;
+constexpr int32_t Notice = 7;
+constexpr int32_t Informational = 8;
+constexpr int32_t Debug = 9;
+
+constexpr int32_t MIN = Danger;
+constexpr int32_t MAX = Debug;
+} // namespace MonitoringLevelSeverity
+
+} // namespace v201
+} // namespace ocpp
+
+#endif // OCPP_V201_ENUMS_HPP

--- a/include/ocpp/v201/messages/Authorize.hpp
+++ b/include/ocpp/v201/messages/Authorize.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_AUTHORIZE_HPP
 #define OCPP_V201_AUTHORIZE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/BootNotification.hpp
+++ b/include/ocpp/v201/messages/BootNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_BOOTNOTIFICATION_HPP
 #define OCPP_V201_BOOTNOTIFICATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/CancelReservation.hpp
+++ b/include/ocpp/v201/messages/CancelReservation.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CANCELRESERVATION_HPP
 #define OCPP_V201_CANCELRESERVATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/CertificateSigned.hpp
+++ b/include/ocpp/v201/messages/CertificateSigned.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CERTIFICATESIGNED_HPP
 #define OCPP_V201_CERTIFICATESIGNED_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ChangeAvailability.hpp
+++ b/include/ocpp/v201/messages/ChangeAvailability.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CHANGEAVAILABILITY_HPP
 #define OCPP_V201_CHANGEAVAILABILITY_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ClearCache.hpp
+++ b/include/ocpp/v201/messages/ClearCache.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CLEARCACHE_HPP
 #define OCPP_V201_CLEARCACHE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ClearChargingProfile.hpp
+++ b/include/ocpp/v201/messages/ClearChargingProfile.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CLEARCHARGINGPROFILE_HPP
 #define OCPP_V201_CLEARCHARGINGPROFILE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ClearDisplayMessage.hpp
+++ b/include/ocpp/v201/messages/ClearDisplayMessage.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CLEARDISPLAYMESSAGE_HPP
 #define OCPP_V201_CLEARDISPLAYMESSAGE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ClearVariableMonitoring.hpp
+++ b/include/ocpp/v201/messages/ClearVariableMonitoring.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CLEARVARIABLEMONITORING_HPP
 #define OCPP_V201_CLEARVARIABLEMONITORING_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ClearedChargingLimit.hpp
+++ b/include/ocpp/v201/messages/ClearedChargingLimit.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CLEAREDCHARGINGLIMIT_HPP
 #define OCPP_V201_CLEAREDCHARGINGLIMIT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/CostUpdated.hpp
+++ b/include/ocpp/v201/messages/CostUpdated.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_COSTUPDATED_HPP
 #define OCPP_V201_COSTUPDATED_HPP
 

--- a/include/ocpp/v201/messages/CustomerInformation.hpp
+++ b/include/ocpp/v201/messages/CustomerInformation.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_CUSTOMERINFORMATION_HPP
 #define OCPP_V201_CUSTOMERINFORMATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/DataTransfer.hpp
+++ b/include/ocpp/v201/messages/DataTransfer.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_DATATRANSFER_HPP
 #define OCPP_V201_DATATRANSFER_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/DeleteCertificate.hpp
+++ b/include/ocpp/v201/messages/DeleteCertificate.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_DELETECERTIFICATE_HPP
 #define OCPP_V201_DELETECERTIFICATE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/FirmwareStatusNotification.hpp
+++ b/include/ocpp/v201/messages/FirmwareStatusNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_FIRMWARESTATUSNOTIFICATION_HPP
 #define OCPP_V201_FIRMWARESTATUSNOTIFICATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/Get15118EVCertificate.hpp
+++ b/include/ocpp/v201/messages/Get15118EVCertificate.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GET15118EVCERTIFICATE_HPP
 #define OCPP_V201_GET15118EVCERTIFICATE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {
@@ -17,7 +19,7 @@ namespace v201 {
 struct Get15118EVCertificateRequest : public ocpp::Message {
     CiString<50> iso15118SchemaVersion;
     CertificateActionEnum action;
-    CiString<7500> exiRequest;
+    CiString<5600> exiRequest;
     std::optional<CustomData> customData;
 
     /// \brief Provides the type of this Get15118EVCertificate message as a human readable string
@@ -38,7 +40,7 @@ std::ostream& operator<<(std::ostream& os, const Get15118EVCertificateRequest& k
 /// \brief Contains a OCPP Get15118EVCertificateResponse message
 struct Get15118EVCertificateResponse : public ocpp::Message {
     Iso15118EVCertificateStatusEnum status;
-    CiString<7500> exiResponse;
+    CiString<5600> exiResponse;
     std::optional<CustomData> customData;
     std::optional<StatusInfo> statusInfo;
 

--- a/include/ocpp/v201/messages/GetBaseReport.hpp
+++ b/include/ocpp/v201/messages/GetBaseReport.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETBASEREPORT_HPP
 #define OCPP_V201_GETBASEREPORT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetCertificateStatus.hpp
+++ b/include/ocpp/v201/messages/GetCertificateStatus.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETCERTIFICATESTATUS_HPP
 #define OCPP_V201_GETCERTIFICATESTATUS_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetChargingProfiles.hpp
+++ b/include/ocpp/v201/messages/GetChargingProfiles.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETCHARGINGPROFILES_HPP
 #define OCPP_V201_GETCHARGINGPROFILES_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetCompositeSchedule.hpp
+++ b/include/ocpp/v201/messages/GetCompositeSchedule.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETCOMPOSITESCHEDULE_HPP
 #define OCPP_V201_GETCOMPOSITESCHEDULE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetDisplayMessages.hpp
+++ b/include/ocpp/v201/messages/GetDisplayMessages.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETDISPLAYMESSAGES_HPP
 #define OCPP_V201_GETDISPLAYMESSAGES_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetInstalledCertificateIds.hpp
+++ b/include/ocpp/v201/messages/GetInstalledCertificateIds.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETINSTALLEDCERTIFICATEIDS_HPP
 #define OCPP_V201_GETINSTALLEDCERTIFICATEIDS_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetLocalListVersion.hpp
+++ b/include/ocpp/v201/messages/GetLocalListVersion.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETLOCALLISTVERSION_HPP
 #define OCPP_V201_GETLOCALLISTVERSION_HPP
 

--- a/include/ocpp/v201/messages/GetLog.hpp
+++ b/include/ocpp/v201/messages/GetLog.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETLOG_HPP
 #define OCPP_V201_GETLOG_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetMonitoringReport.hpp
+++ b/include/ocpp/v201/messages/GetMonitoringReport.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETMONITORINGREPORT_HPP
 #define OCPP_V201_GETMONITORINGREPORT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetReport.hpp
+++ b/include/ocpp/v201/messages/GetReport.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETREPORT_HPP
 #define OCPP_V201_GETREPORT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/GetTransactionStatus.hpp
+++ b/include/ocpp/v201/messages/GetTransactionStatus.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETTRANSACTIONSTATUS_HPP
 #define OCPP_V201_GETTRANSACTIONSTATUS_HPP
 

--- a/include/ocpp/v201/messages/GetVariables.hpp
+++ b/include/ocpp/v201/messages/GetVariables.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_GETVARIABLES_HPP
 #define OCPP_V201_GETVARIABLES_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/Heartbeat.hpp
+++ b/include/ocpp/v201/messages/Heartbeat.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_HEARTBEAT_HPP
 #define OCPP_V201_HEARTBEAT_HPP
 

--- a/include/ocpp/v201/messages/InstallCertificate.hpp
+++ b/include/ocpp/v201/messages/InstallCertificate.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_INSTALLCERTIFICATE_HPP
 #define OCPP_V201_INSTALLCERTIFICATE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/LogStatusNotification.hpp
+++ b/include/ocpp/v201/messages/LogStatusNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_LOGSTATUSNOTIFICATION_HPP
 #define OCPP_V201_LOGSTATUSNOTIFICATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/MeterValues.hpp
+++ b/include/ocpp/v201/messages/MeterValues.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_METERVALUES_HPP
 #define OCPP_V201_METERVALUES_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/NotifyChargingLimit.hpp
+++ b/include/ocpp/v201/messages/NotifyChargingLimit.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYCHARGINGLIMIT_HPP
 #define OCPP_V201_NOTIFYCHARGINGLIMIT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/NotifyCustomerInformation.hpp
+++ b/include/ocpp/v201/messages/NotifyCustomerInformation.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYCUSTOMERINFORMATION_HPP
 #define OCPP_V201_NOTIFYCUSTOMERINFORMATION_HPP
 

--- a/include/ocpp/v201/messages/NotifyDisplayMessages.hpp
+++ b/include/ocpp/v201/messages/NotifyDisplayMessages.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYDISPLAYMESSAGES_HPP
 #define OCPP_V201_NOTIFYDISPLAYMESSAGES_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/NotifyEVChargingNeeds.hpp
+++ b/include/ocpp/v201/messages/NotifyEVChargingNeeds.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYEVCHARGINGNEEDS_HPP
 #define OCPP_V201_NOTIFYEVCHARGINGNEEDS_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/NotifyEVChargingSchedule.hpp
+++ b/include/ocpp/v201/messages/NotifyEVChargingSchedule.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYEVCHARGINGSCHEDULE_HPP
 #define OCPP_V201_NOTIFYEVCHARGINGSCHEDULE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/NotifyEvent.hpp
+++ b/include/ocpp/v201/messages/NotifyEvent.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYEVENT_HPP
 #define OCPP_V201_NOTIFYEVENT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/NotifyMonitoringReport.hpp
+++ b/include/ocpp/v201/messages/NotifyMonitoringReport.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYMONITORINGREPORT_HPP
 #define OCPP_V201_NOTIFYMONITORINGREPORT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/NotifyReport.hpp
+++ b/include/ocpp/v201/messages/NotifyReport.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_NOTIFYREPORT_HPP
 #define OCPP_V201_NOTIFYREPORT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/PublishFirmware.hpp
+++ b/include/ocpp/v201/messages/PublishFirmware.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_PUBLISHFIRMWARE_HPP
 #define OCPP_V201_PUBLISHFIRMWARE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/PublishFirmwareStatusNotification.hpp
+++ b/include/ocpp/v201/messages/PublishFirmwareStatusNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_PUBLISHFIRMWARESTATUSNOTIFICATION_HPP
 #define OCPP_V201_PUBLISHFIRMWARESTATUSNOTIFICATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ReportChargingProfiles.hpp
+++ b/include/ocpp/v201/messages/ReportChargingProfiles.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_REPORTCHARGINGPROFILES_HPP
 #define OCPP_V201_REPORTCHARGINGPROFILES_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/RequestStartTransaction.hpp
+++ b/include/ocpp/v201/messages/RequestStartTransaction.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_REQUESTSTARTTRANSACTION_HPP
 #define OCPP_V201_REQUESTSTARTTRANSACTION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/RequestStopTransaction.hpp
+++ b/include/ocpp/v201/messages/RequestStopTransaction.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_REQUESTSTOPTRANSACTION_HPP
 #define OCPP_V201_REQUESTSTOPTRANSACTION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ReservationStatusUpdate.hpp
+++ b/include/ocpp/v201/messages/ReservationStatusUpdate.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_RESERVATIONSTATUSUPDATE_HPP
 #define OCPP_V201_RESERVATIONSTATUSUPDATE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/ReserveNow.hpp
+++ b/include/ocpp/v201/messages/ReserveNow.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_RESERVENOW_HPP
 #define OCPP_V201_RESERVENOW_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/Reset.hpp
+++ b/include/ocpp/v201/messages/Reset.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_RESET_HPP
 #define OCPP_V201_RESET_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SecurityEventNotification.hpp
+++ b/include/ocpp/v201/messages/SecurityEventNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SECURITYEVENTNOTIFICATION_HPP
 #define OCPP_V201_SECURITYEVENTNOTIFICATION_HPP
 

--- a/include/ocpp/v201/messages/SendLocalList.hpp
+++ b/include/ocpp/v201/messages/SendLocalList.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SENDLOCALLIST_HPP
 #define OCPP_V201_SENDLOCALLIST_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SetChargingProfile.hpp
+++ b/include/ocpp/v201/messages/SetChargingProfile.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SETCHARGINGPROFILE_HPP
 #define OCPP_V201_SETCHARGINGPROFILE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SetDisplayMessage.hpp
+++ b/include/ocpp/v201/messages/SetDisplayMessage.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SETDISPLAYMESSAGE_HPP
 #define OCPP_V201_SETDISPLAYMESSAGE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SetMonitoringBase.hpp
+++ b/include/ocpp/v201/messages/SetMonitoringBase.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SETMONITORINGBASE_HPP
 #define OCPP_V201_SETMONITORINGBASE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SetMonitoringLevel.hpp
+++ b/include/ocpp/v201/messages/SetMonitoringLevel.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SETMONITORINGLEVEL_HPP
 #define OCPP_V201_SETMONITORINGLEVEL_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SetNetworkProfile.hpp
+++ b/include/ocpp/v201/messages/SetNetworkProfile.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SETNETWORKPROFILE_HPP
 #define OCPP_V201_SETNETWORKPROFILE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SetVariableMonitoring.hpp
+++ b/include/ocpp/v201/messages/SetVariableMonitoring.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SETVARIABLEMONITORING_HPP
 #define OCPP_V201_SETVARIABLEMONITORING_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SetVariables.hpp
+++ b/include/ocpp/v201/messages/SetVariables.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SETVARIABLES_HPP
 #define OCPP_V201_SETVARIABLES_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/SignCertificate.hpp
+++ b/include/ocpp/v201/messages/SignCertificate.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_SIGNCERTIFICATE_HPP
 #define OCPP_V201_SIGNCERTIFICATE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/StatusNotification.hpp
+++ b/include/ocpp/v201/messages/StatusNotification.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_STATUSNOTIFICATION_HPP
 #define OCPP_V201_STATUSNOTIFICATION_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/TransactionEvent.hpp
+++ b/include/ocpp/v201/messages/TransactionEvent.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_TRANSACTIONEVENT_HPP
 #define OCPP_V201_TRANSACTIONEVENT_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/TriggerMessage.hpp
+++ b/include/ocpp/v201/messages/TriggerMessage.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_TRIGGERMESSAGE_HPP
 #define OCPP_V201_TRIGGERMESSAGE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/UnlockConnector.hpp
+++ b/include/ocpp/v201/messages/UnlockConnector.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_UNLOCKCONNECTOR_HPP
 #define OCPP_V201_UNLOCKCONNECTOR_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/UnpublishFirmware.hpp
+++ b/include/ocpp/v201/messages/UnpublishFirmware.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_UNPUBLISHFIRMWARE_HPP
 #define OCPP_V201_UNPUBLISHFIRMWARE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/messages/UpdateFirmware.hpp
+++ b/include/ocpp/v201/messages/UpdateFirmware.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_UPDATEFIRMWARE_HPP
 #define OCPP_V201_UPDATEFIRMWARE_HPP
 
@@ -7,7 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 namespace ocpp {

--- a/include/ocpp/v201/monitoring_updater.hpp
+++ b/include/ocpp/v201/monitoring_updater.hpp
@@ -7,7 +7,7 @@
 
 #include <everest/timer.hpp>
 
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
 #include <ocpp/v201/device_model_storage.hpp>

--- a/include/ocpp/v201/ocpp_enums.hpp
+++ b/include/ocpp/v201/ocpp_enums.hpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-#ifndef OCPP_V201_ENUMS_HPP
-#define OCPP_V201_ENUMS_HPP
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
-#include <cstdint>
+#ifndef OCPP_V201_OCPP_ENUMS_HPP
+#define OCPP_V201_OCPP_ENUMS_HPP
+
 #include <iosfwd>
 #include <string>
 
@@ -1184,19 +1185,12 @@ EventTriggerEnum string_to_event_trigger_enum(const std::string& s);
 /// stream \p os \returns an output stream with the EventTriggerEnum written to
 std::ostream& operator<<(std::ostream& os, const EventTriggerEnum& event_trigger_enum);
 
-enum class VariableMonitorType {
+// from: NotifyEventRequest
+enum class EventNotificationEnum {
+    HardWiredNotification,
     HardWiredMonitor,
     PreconfiguredMonitor,
     CustomMonitor,
-};
-
-// from: NotifyEventRequest
-enum class EventNotificationEnum {
-    HardWiredNotification, // The software implemented by the manufacturer triggered a hardwired notification.
-    HardWiredMonitor,      // Triggered by a monitor, which is hardwired by the manufacturer.
-    PreconfiguredMonitor,  // Triggered by a monitor, which is preconfigured by the manufacturer.
-    CustomMonitor, // Triggered by a monitor, which is set with the setvariablemonitoringrequest message by the Charging
-                   // Station Operator.
 };
 
 namespace conversions {
@@ -1581,28 +1575,11 @@ DisplayMessageStatusEnum string_to_display_message_status_enum(const std::string
 /// given output stream \p os \returns an output stream with the DisplayMessageStatusEnum written to
 std::ostream& operator<<(std::ostream& os, const DisplayMessageStatusEnum& display_message_status_enum);
 
-namespace MontoringLevelSeverity {
-constexpr int32_t Danger = 0;
-constexpr int32_t HardwareFailure = 1;
-constexpr int32_t SystemFailure = 2;
-constexpr int32_t Critical = 3;
-constexpr int32_t Error = 4;
-constexpr int32_t Alert = 5;
-constexpr int32_t Warning = 6;
-constexpr int32_t Notice = 7;
-constexpr int32_t Informational = 8;
-constexpr int32_t Debug = 9;
-
-constexpr int32_t MIN = Danger;
-constexpr int32_t MAX = Debug;
-} // namespace MontoringLevelSeverity
-
 // from: SetMonitoringBaseRequest
 enum class MonitoringBaseEnum {
     All,
-    FactoryDefault, // < Activate the default monitoring settings as recommended by the
-                    // manufacturer. This is a subset of all pre-configured monitors.
-    HardWiredOnly,  //< Clears all custom monitors and disables all pre-configured monitors.
+    FactoryDefault,
+    HardWiredOnly,
 };
 
 namespace conversions {
@@ -2062,4 +2039,4 @@ std::ostream& operator<<(std::ostream& os, const UpdateFirmwareStatusEnum& updat
 } // namespace v201
 } // namespace ocpp
 
-#endif // OCPP_V201_ENUMS_HPP
+#endif // OCPP_V201_OCPP_ENUMS_HPP

--- a/include/ocpp/v201/ocpp_types.hpp
+++ b/include/ocpp/v201/ocpp_types.hpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_V201_OCPP_TYPES_HPP
 #define OCPP_V201_OCPP_TYPES_HPP
 
@@ -9,7 +11,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 
 namespace ocpp {
 namespace v201 {

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -5,7 +5,7 @@
 #define OCPP_V201_SMART_CHARGING_HPP
 
 #include "ocpp/v201/device_model.hpp"
-#include "ocpp/v201/enums.hpp"
+#include "ocpp/v201/ocpp_enums.hpp"
 #include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include <limits>
 

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -4,14 +4,14 @@
 #ifndef OCPP_V201_SMART_CHARGING_HPP
 #define OCPP_V201_SMART_CHARGING_HPP
 
-#include "ocpp/v201/device_model.hpp"
-#include "ocpp/v201/ocpp_enums.hpp"
-#include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include <limits>
-
 #include <memory>
+
 #include <ocpp/v201/database_handler.hpp>
+#include <ocpp/v201/device_model.hpp>
 #include <ocpp/v201/evse_manager.hpp>
+#include <ocpp/v201/messages/SetChargingProfile.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/transaction.hpp>
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,7 +43,6 @@ if(LIBOCPP_ENABLE_V16)
             ocpp/v16/message_queue.cpp
             ocpp/v16/profile.cpp
             ocpp/v16/transaction.cpp
-            ocpp/v16/enums.cpp
             ocpp/v16/ocpp_enums.cpp
             ocpp/v16/ocpp_types.cpp
             ocpp/v16/types.cpp
@@ -62,7 +61,6 @@ if(LIBOCPP_ENABLE_V201)
             ocpp/v201/database_handler.cpp
             ocpp/v201/device_model.cpp
             ocpp/v201/device_model_storage_sqlite.cpp
-            ocpp/v201/enums.cpp
             ocpp/v201/evse.cpp
             ocpp/v201/evse_manager.cpp
             ocpp/v201/init_device_model_db.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -44,6 +44,7 @@ if(LIBOCPP_ENABLE_V16)
             ocpp/v16/profile.cpp
             ocpp/v16/transaction.cpp
             ocpp/v16/enums.cpp
+            ocpp/v16/ocpp_enums.cpp
             ocpp/v16/ocpp_types.cpp
             ocpp/v16/types.cpp
     )
@@ -67,6 +68,7 @@ if(LIBOCPP_ENABLE_V201)
             ocpp/v201/init_device_model_db.cpp
             ocpp/v201/notify_report_requests_splitter.cpp
             ocpp/v201/message_queue.cpp
+            ocpp/v201/ocpp_enums.cpp
             ocpp/v201/ocpp_types.cpp
             ocpp/v201/ocsp_updater.cpp
             ocpp/v201/monitoring_updater.cpp

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -791,7 +791,6 @@ std::optional<MeterValue> ChargePointImpl::get_latest_meter_value(int32_t connec
                 // RPM
                 const auto rpm = measurement.rpm;
                 if (rpm) {
-                    sample.unit.emplace(UnitOfMeasure::RevolutionsPerMinute);
                     if (rpm.value().location.has_value()) {
                         sample.location.emplace(conversions::string_to_location(rpm.value().location.value()));
                     } else {

--- a/lib/ocpp/v16/charge_point_state_machine.cpp
+++ b/lib/ocpp/v16/charge_point_state_machine.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 #include <ocpp/v16/charge_point_state_machine.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 
 #include <everest/logging.hpp>
 #include <stddef.h>

--- a/lib/ocpp/v16/messages/Authorize.cpp
+++ b/lib/ocpp/v16/messages/Authorize.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/Authorize.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/BootNotification.cpp
+++ b/lib/ocpp/v16/messages/BootNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/BootNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/CancelReservation.cpp
+++ b/lib/ocpp/v16/messages/CancelReservation.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/CancelReservation.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/CancelReservation.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/CertificateSigned.cpp
+++ b/lib/ocpp/v16/messages/CertificateSigned.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/CertificateSigned.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/CertificateSigned.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/ChangeAvailability.cpp
+++ b/lib/ocpp/v16/messages/ChangeAvailability.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/ChangeAvailability.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/ChangeAvailability.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/ChangeConfiguration.cpp
+++ b/lib/ocpp/v16/messages/ChangeConfiguration.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/ChangeConfiguration.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/ChangeConfiguration.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/ClearCache.cpp
+++ b/lib/ocpp/v16/messages/ClearCache.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/ClearCache.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/ClearCache.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/ClearChargingProfile.cpp
+++ b/lib/ocpp/v16/messages/ClearChargingProfile.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/ClearChargingProfile.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/DataTransfer.cpp
+++ b/lib/ocpp/v16/messages/DataTransfer.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/DataTransfer.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/DeleteCertificate.cpp
+++ b/lib/ocpp/v16/messages/DeleteCertificate.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/DeleteCertificate.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/DeleteCertificate.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/DiagnosticsStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/DiagnosticsStatusNotification.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/DiagnosticsStatusNotification.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/DiagnosticsStatusNotification.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/ExtendedTriggerMessage.cpp
+++ b/lib/ocpp/v16/messages/ExtendedTriggerMessage.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/ExtendedTriggerMessage.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/FirmwareStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/FirmwareStatusNotification.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/FirmwareStatusNotification.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/FirmwareStatusNotification.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/GetCompositeSchedule.cpp
+++ b/lib/ocpp/v16/messages/GetCompositeSchedule.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/GetCompositeSchedule.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/GetConfiguration.cpp
+++ b/lib/ocpp/v16/messages/GetConfiguration.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/GetConfiguration.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/GetDiagnostics.cpp
+++ b/lib/ocpp/v16/messages/GetDiagnostics.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/GetDiagnostics.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/GetInstalledCertificateIds.cpp
+++ b/lib/ocpp/v16/messages/GetInstalledCertificateIds.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/GetInstalledCertificateIds.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/GetLocalListVersion.cpp
+++ b/lib/ocpp/v16/messages/GetLocalListVersion.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/GetLocalListVersion.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/GetLocalListVersion.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/GetLog.cpp
+++ b/lib/ocpp/v16/messages/GetLog.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/GetLog.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/Heartbeat.cpp
+++ b/lib/ocpp/v16/messages/Heartbeat.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/Heartbeat.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/Heartbeat.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/InstallCertificate.cpp
+++ b/lib/ocpp/v16/messages/InstallCertificate.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/InstallCertificate.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/InstallCertificate.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/LogStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/LogStatusNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/LogStatusNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/MeterValues.cpp
+++ b/lib/ocpp/v16/messages/MeterValues.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/MeterValues.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/RemoteStartTransaction.cpp
+++ b/lib/ocpp/v16/messages/RemoteStartTransaction.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/RemoteStartTransaction.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/RemoteStopTransaction.cpp
+++ b/lib/ocpp/v16/messages/RemoteStopTransaction.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/RemoteStopTransaction.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/RemoteStopTransaction.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/ReserveNow.cpp
+++ b/lib/ocpp/v16/messages/ReserveNow.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/ReserveNow.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/Reset.cpp
+++ b/lib/ocpp/v16/messages/Reset.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/Reset.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/Reset.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/SecurityEventNotification.cpp
+++ b/lib/ocpp/v16/messages/SecurityEventNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/SecurityEventNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/SendLocalList.cpp
+++ b/lib/ocpp/v16/messages/SendLocalList.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/SendLocalList.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/SetChargingProfile.cpp
+++ b/lib/ocpp/v16/messages/SetChargingProfile.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/SetChargingProfile.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/SignCertificate.cpp
+++ b/lib/ocpp/v16/messages/SignCertificate.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/SignCertificate.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/SignCertificate.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/SignedFirmwareStatusNotification.cpp
+++ b/lib/ocpp/v16/messages/SignedFirmwareStatusNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/SignedFirmwareStatusNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/SignedUpdateFirmware.cpp
+++ b/lib/ocpp/v16/messages/SignedUpdateFirmware.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/SignedUpdateFirmware.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/StartTransaction.cpp
+++ b/lib/ocpp/v16/messages/StartTransaction.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/StartTransaction.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/StatusNotification.cpp
+++ b/lib/ocpp/v16/messages/StatusNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/StatusNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/StopTransaction.cpp
+++ b/lib/ocpp/v16/messages/StopTransaction.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/StopTransaction.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/TriggerMessage.cpp
+++ b/lib/ocpp/v16/messages/TriggerMessage.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/TriggerMessage.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/UnlockConnector.cpp
+++ b/lib/ocpp/v16/messages/UnlockConnector.cpp
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/messages/UnlockConnector.hpp>
 
 #include <ostream>
 #include <string>
-
-#include <ocpp/v16/messages/UnlockConnector.hpp>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/messages/UpdateFirmware.cpp
+++ b/lib/ocpp/v16/messages/UpdateFirmware.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v16/messages/UpdateFirmware.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v16/ocpp_enums.cpp
+++ b/lib/ocpp/v16/ocpp_enums.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
-#include <ocpp/v16/enums.hpp>
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/ocpp_enums.hpp>
+
 #include <stdexcept>
 #include <string>
 
@@ -1301,8 +1304,6 @@ std::string unit_of_measure_to_string(UnitOfMeasure e) {
         return "Fahrenheit";
     case UnitOfMeasure::Percent:
         return "Percent";
-    case UnitOfMeasure::RevolutionsPerMinute:
-        return "RevolutionsPerMinute";
     }
 
     throw std::out_of_range("No known string conversion for provided enum of type UnitOfMeasure");
@@ -1359,9 +1360,6 @@ UnitOfMeasure string_to_unit_of_measure(const std::string& s) {
     }
     if (s == "Percent") {
         return UnitOfMeasure::Percent;
-    }
-    if (s == "RevolutionsPerMinute") {
-        return UnitOfMeasure::RevolutionsPerMinute;
     }
 
     throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UnitOfMeasure");

--- a/lib/ocpp/v16/ocpp_types.cpp
+++ b/lib/ocpp/v16/ocpp_types.cpp
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v16/ocpp_types.hpp>
+
+#include <optional>
 #include <string>
 
 #include <nlohmann/json.hpp>
-#include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
-
-#include <ocpp/v16/ocpp_types.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 
 namespace ocpp {
 namespace v16 {
@@ -405,11 +407,13 @@ void to_json(json& j, const FirmwareType& k) {
     // the required parts of the message
     j = json{
         {"location", k.location},
-        {"retrieveDateTime", k.retrieveDateTime.to_rfc3339()},
         {"signingCertificate", k.signingCertificate},
         {"signature", k.signature},
     };
     // the optional parts of the message
+    if (k.retrieveDateTime) {
+        j["retrieveDateTime"] = k.retrieveDateTime.value().to_rfc3339();
+    }
     if (k.installDateTime) {
         j["installDateTime"] = k.installDateTime.value().to_rfc3339();
     }
@@ -419,12 +423,13 @@ void to_json(json& j, const FirmwareType& k) {
 void from_json(const json& j, FirmwareType& k) {
     // the required parts of the message
     k.location = j.at("location");
-    k.retrieveDateTime = ocpp::DateTime(std::string(j.at("retrieveDateTime")));
-    ;
     k.signingCertificate = j.at("signingCertificate");
     k.signature = j.at("signature");
 
     // the optional parts of the message
+    if (j.contains("retrieveDateTime")) {
+        k.retrieveDateTime.emplace(j.at("retrieveDateTime").get<std::string>());
+    }
     if (j.contains("installDateTime")) {
         k.installDateTime.emplace(j.at("installDateTime").get<std::string>());
     }

--- a/lib/ocpp/v16/profile.cpp
+++ b/lib/ocpp/v16/profile.cpp
@@ -6,7 +6,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/profile.hpp>
 #include <ocpp/v16/smart_charging.hpp>

--- a/lib/ocpp/v16/smart_charging.cpp
+++ b/lib/ocpp/v16/smart_charging.cpp
@@ -2,7 +2,7 @@
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
 #include "ocpp/common/types.hpp"
-#include "ocpp/v16/enums.hpp"
+#include "ocpp/v16/ocpp_enums.hpp"
 #include <ocpp/v16/profile.hpp>
 #include <ocpp/v16/smart_charging.hpp>
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3321,7 +3321,7 @@ void ChargePoint::handle_set_monitoring_level_req(Call<SetMonitoringLevelRequest
     SetMonitoringLevelResponse response;
     const auto& msg = call.msg;
 
-    if (msg.severity < MontoringLevelSeverity::MIN || msg.severity > MontoringLevelSeverity::MAX) {
+    if (msg.severity < MonitoringLevelSeverity::MIN || msg.severity > MonitoringLevelSeverity::MAX) {
         response.status = GenericStatusEnum::Rejected;
     } else {
         auto result = this->device_model->set_value(

--- a/lib/ocpp/v201/messages/Authorize.cpp
+++ b/lib/ocpp/v201/messages/Authorize.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/Authorize.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/BootNotification.cpp
+++ b/lib/ocpp/v201/messages/BootNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/BootNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/CancelReservation.cpp
+++ b/lib/ocpp/v201/messages/CancelReservation.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/CancelReservation.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/CertificateSigned.cpp
+++ b/lib/ocpp/v201/messages/CertificateSigned.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/CertificateSigned.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ChangeAvailability.cpp
+++ b/lib/ocpp/v201/messages/ChangeAvailability.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ChangeAvailability.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ClearCache.cpp
+++ b/lib/ocpp/v201/messages/ClearCache.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ClearCache.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ClearChargingProfile.cpp
+++ b/lib/ocpp/v201/messages/ClearChargingProfile.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ClearChargingProfile.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ClearDisplayMessage.cpp
+++ b/lib/ocpp/v201/messages/ClearDisplayMessage.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ClearDisplayMessage.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ClearVariableMonitoring.cpp
+++ b/lib/ocpp/v201/messages/ClearVariableMonitoring.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ClearVariableMonitoring.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ClearedChargingLimit.cpp
+++ b/lib/ocpp/v201/messages/ClearedChargingLimit.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ClearedChargingLimit.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/CostUpdated.cpp
+++ b/lib/ocpp/v201/messages/CostUpdated.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/CostUpdated.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/CustomerInformation.cpp
+++ b/lib/ocpp/v201/messages/CustomerInformation.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/CustomerInformation.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/DataTransfer.cpp
+++ b/lib/ocpp/v201/messages/DataTransfer.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/DataTransfer.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/DeleteCertificate.cpp
+++ b/lib/ocpp/v201/messages/DeleteCertificate.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/DeleteCertificate.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/FirmwareStatusNotification.cpp
+++ b/lib/ocpp/v201/messages/FirmwareStatusNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/FirmwareStatusNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/Get15118EVCertificate.cpp
+++ b/lib/ocpp/v201/messages/Get15118EVCertificate.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/Get15118EVCertificate.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetBaseReport.cpp
+++ b/lib/ocpp/v201/messages/GetBaseReport.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetBaseReport.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetCertificateStatus.cpp
+++ b/lib/ocpp/v201/messages/GetCertificateStatus.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetCertificateStatus.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetChargingProfiles.cpp
+++ b/lib/ocpp/v201/messages/GetChargingProfiles.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetChargingProfiles.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetCompositeSchedule.cpp
+++ b/lib/ocpp/v201/messages/GetCompositeSchedule.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetCompositeSchedule.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetDisplayMessages.cpp
+++ b/lib/ocpp/v201/messages/GetDisplayMessages.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetDisplayMessages.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetInstalledCertificateIds.cpp
+++ b/lib/ocpp/v201/messages/GetInstalledCertificateIds.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetInstalledCertificateIds.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetLocalListVersion.cpp
+++ b/lib/ocpp/v201/messages/GetLocalListVersion.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetLocalListVersion.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetLog.cpp
+++ b/lib/ocpp/v201/messages/GetLog.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetLog.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetMonitoringReport.cpp
+++ b/lib/ocpp/v201/messages/GetMonitoringReport.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetMonitoringReport.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetReport.cpp
+++ b/lib/ocpp/v201/messages/GetReport.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetReport.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetTransactionStatus.cpp
+++ b/lib/ocpp/v201/messages/GetTransactionStatus.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetTransactionStatus.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/GetVariables.cpp
+++ b/lib/ocpp/v201/messages/GetVariables.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/GetVariables.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/Heartbeat.cpp
+++ b/lib/ocpp/v201/messages/Heartbeat.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/Heartbeat.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/InstallCertificate.cpp
+++ b/lib/ocpp/v201/messages/InstallCertificate.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/InstallCertificate.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/LogStatusNotification.cpp
+++ b/lib/ocpp/v201/messages/LogStatusNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/LogStatusNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/MeterValues.cpp
+++ b/lib/ocpp/v201/messages/MeterValues.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/MeterValues.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyChargingLimit.cpp
+++ b/lib/ocpp/v201/messages/NotifyChargingLimit.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyChargingLimit.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyCustomerInformation.cpp
+++ b/lib/ocpp/v201/messages/NotifyCustomerInformation.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyCustomerInformation.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyDisplayMessages.cpp
+++ b/lib/ocpp/v201/messages/NotifyDisplayMessages.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyDisplayMessages.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyEVChargingNeeds.cpp
+++ b/lib/ocpp/v201/messages/NotifyEVChargingNeeds.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyEVChargingNeeds.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyEVChargingSchedule.cpp
+++ b/lib/ocpp/v201/messages/NotifyEVChargingSchedule.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyEVChargingSchedule.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyEvent.cpp
+++ b/lib/ocpp/v201/messages/NotifyEvent.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyEvent.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyMonitoringReport.cpp
+++ b/lib/ocpp/v201/messages/NotifyMonitoringReport.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyMonitoringReport.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/NotifyReport.cpp
+++ b/lib/ocpp/v201/messages/NotifyReport.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/NotifyReport.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/PublishFirmware.cpp
+++ b/lib/ocpp/v201/messages/PublishFirmware.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/PublishFirmware.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/PublishFirmwareStatusNotification.cpp
+++ b/lib/ocpp/v201/messages/PublishFirmwareStatusNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/PublishFirmwareStatusNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ReportChargingProfiles.cpp
+++ b/lib/ocpp/v201/messages/ReportChargingProfiles.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ReportChargingProfiles.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/RequestStartTransaction.cpp
+++ b/lib/ocpp/v201/messages/RequestStartTransaction.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/RequestStartTransaction.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/RequestStopTransaction.cpp
+++ b/lib/ocpp/v201/messages/RequestStopTransaction.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/RequestStopTransaction.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ReservationStatusUpdate.cpp
+++ b/lib/ocpp/v201/messages/ReservationStatusUpdate.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ReservationStatusUpdate.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/ReserveNow.cpp
+++ b/lib/ocpp/v201/messages/ReserveNow.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/ReserveNow.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/Reset.cpp
+++ b/lib/ocpp/v201/messages/Reset.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/Reset.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SecurityEventNotification.cpp
+++ b/lib/ocpp/v201/messages/SecurityEventNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SecurityEventNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SendLocalList.cpp
+++ b/lib/ocpp/v201/messages/SendLocalList.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SendLocalList.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SetChargingProfile.cpp
+++ b/lib/ocpp/v201/messages/SetChargingProfile.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SetChargingProfile.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SetDisplayMessage.cpp
+++ b/lib/ocpp/v201/messages/SetDisplayMessage.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SetDisplayMessage.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SetMonitoringBase.cpp
+++ b/lib/ocpp/v201/messages/SetMonitoringBase.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SetMonitoringBase.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SetMonitoringLevel.cpp
+++ b/lib/ocpp/v201/messages/SetMonitoringLevel.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SetMonitoringLevel.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SetNetworkProfile.cpp
+++ b/lib/ocpp/v201/messages/SetNetworkProfile.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SetNetworkProfile.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SetVariableMonitoring.cpp
+++ b/lib/ocpp/v201/messages/SetVariableMonitoring.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SetVariableMonitoring.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SetVariables.cpp
+++ b/lib/ocpp/v201/messages/SetVariables.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SetVariables.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/SignCertificate.cpp
+++ b/lib/ocpp/v201/messages/SignCertificate.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/SignCertificate.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/StatusNotification.cpp
+++ b/lib/ocpp/v201/messages/StatusNotification.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/StatusNotification.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/TransactionEvent.cpp
+++ b/lib/ocpp/v201/messages/TransactionEvent.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/TransactionEvent.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/TriggerMessage.cpp
+++ b/lib/ocpp/v201/messages/TriggerMessage.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/TriggerMessage.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/UnlockConnector.cpp
+++ b/lib/ocpp/v201/messages/UnlockConnector.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/UnlockConnector.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/UnpublishFirmware.cpp
+++ b/lib/ocpp/v201/messages/UnpublishFirmware.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/UnpublishFirmware.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/messages/UpdateFirmware.cpp
+++ b/lib/ocpp/v201/messages/UpdateFirmware.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-
-#include <ostream>
-#include <string>
-
-#include <optional>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/v201/messages/UpdateFirmware.hpp>
+
+#include <optional>
+#include <ostream>
+#include <string>
 
 using json = nlohmann::json;
 

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -303,7 +303,7 @@ void MonitoringUpdater::process_periodic_monitors() {
 
     int active_monitoring_level =
         this->device_model->get_optional_value<int>(ControllerComponentVariables::ActiveMonitoringLevel)
-            .value_or(MontoringLevelSeverity::MAX);
+            .value_or(MonitoringLevelSeverity::MAX);
 
     std::string active_monitoring_base_string =
         this->device_model->get_optional_value<std::string>(ControllerComponentVariables::ActiveMonitoringBase)
@@ -443,11 +443,11 @@ void MonitoringUpdater::process_triggered_monitors() {
     // By default (if the comp is missing we are reporting up to 'Warning')
     int offline_severity =
         this->device_model->get_optional_value<int>(ControllerComponentVariables::OfflineQueuingSeverity)
-            .value_or(MontoringLevelSeverity::Warning);
+            .value_or(MonitoringLevelSeverity::Warning);
 
     int active_monitoring_level =
         this->device_model->get_optional_value<int>(ControllerComponentVariables::ActiveMonitoringLevel)
-            .value_or(MontoringLevelSeverity::MAX);
+            .value_or(MonitoringLevelSeverity::MAX);
 
     std::string active_monitoring_base_string =
         this->device_model->get_optional_value<std::string>(ControllerComponentVariables::ActiveMonitoringBase)

--- a/lib/ocpp/v201/ocpp_enums.cpp
+++ b/lib/ocpp/v201/ocpp_enums.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-#include <ocpp/v201/enums.hpp>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v201/ocpp_enums.hpp>
+
 #include <stdexcept>
 #include <string>
 

--- a/lib/ocpp/v201/ocpp_types.cpp
+++ b/lib/ocpp/v201/ocpp_types.cpp
@@ -1,14 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/v201/ocpp_types.hpp>
+
+#include <optional>
 #include <string>
 
 #include <nlohmann/json.hpp>
-#include <optional>
 
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/enums.hpp>
-
-#include <ocpp/v201/ocpp_types.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 
 namespace ocpp {
 namespace v201 {

--- a/lib/ocpp/v201/ocpp_types.cpp
+++ b/lib/ocpp/v201/ocpp_types.cpp
@@ -563,7 +563,7 @@ void to_json(json& j, const ChargingProfileCriterion& k) {
             j["chargingLimitSource"] = json::array();
         }
         for (auto val : k.chargingLimitSource.value()) {
-            j["chargingLimitSource"].push_back(val);
+            j["chargingLimitSource"].push_back(conversions::charging_limit_source_enum_to_string(val));
         }
     }
 }
@@ -595,7 +595,7 @@ void from_json(const json& j, ChargingProfileCriterion& k) {
         json arr = j.at("chargingLimitSource");
         std::vector<ChargingLimitSourceEnum> vec;
         for (auto val : arr) {
-            vec.push_back(val);
+            vec.push_back(conversions::string_to_charging_limit_source_enum(val));
         }
         k.chargingLimitSource.emplace(vec);
     }

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -6,9 +6,9 @@
 #include "ocpp/common/types.hpp"
 #include "ocpp/v201/ctrlr_component_variables.hpp"
 #include "ocpp/v201/device_model.hpp"
-#include "ocpp/v201/ocpp_enums.hpp"
 #include "ocpp/v201/evse.hpp"
 #include "ocpp/v201/messages/SetChargingProfile.hpp"
+#include "ocpp/v201/ocpp_enums.hpp"
 #include "ocpp/v201/ocpp_types.hpp"
 #include "ocpp/v201/transaction.hpp"
 #include <algorithm>

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -6,7 +6,7 @@
 #include "ocpp/common/types.hpp"
 #include "ocpp/v201/ctrlr_component_variables.hpp"
 #include "ocpp/v201/device_model.hpp"
-#include "ocpp/v201/enums.hpp"
+#include "ocpp/v201/ocpp_enums.hpp"
 #include "ocpp/v201/evse.hpp"
 #include "ocpp/v201/messages/SetChargingProfile.hpp"
 #include "ocpp/v201/ocpp_types.hpp"

--- a/src/code_generator/common/generate_cpp.py
+++ b/src/code_generator/common/generate_cpp.py
@@ -95,8 +95,8 @@ message_hpp_template = env.get_template('message.hpp.jinja')
 message_cpp_template = env.get_template('message.cpp.jinja')
 messages_cmakelists_txt_template = env.get_template(
     'messages.cmakelists.txt.jinja')
-enums_hpp_template = env.get_template('enums.hpp.jinja')
-enums_cpp_template = env.get_template('enums.cpp.jinja')
+enums_hpp_template = env.get_template('ocpp_enums.hpp.jinja')
+enums_cpp_template = env.get_template('ocpp_enums.cpp.jinja')
 ocpp_types_hpp_template = env.get_template('ocpp_types.hpp.jinja')
 ocpp_types_cpp_template = env.get_template('ocpp_types.cpp.jinja')
 
@@ -384,8 +384,8 @@ def parse_schemas(version: str, schema_dir: Path = Path('schemas/json/'),
     if not generated_source_dir.exists():
         generated_source_dir.mkdir(parents=True)
 
-    enums_hpp_fn = Path(generated_header_dir, 'enums.hpp')
-    enums_cpp_fn = Path(generated_source_dir, 'enums.cpp')
+    enums_hpp_fn = Path(generated_header_dir, 'ocpp_enums.hpp')
+    enums_cpp_fn = Path(generated_source_dir, 'ocpp_enums.cpp')
     ocpp_types_hpp_fn = Path(generated_header_dir, 'ocpp_types.hpp')
     ocpp_types_cpp_fn = Path(generated_source_dir, 'ocpp_types.cpp')
     messages_header_dir = generated_header_dir / 'messages'

--- a/src/code_generator/common/templates/message.cpp.jinja
+++ b/src/code_generator/common/templates/message.cpp.jinja
@@ -1,15 +1,15 @@
 {% if action.is_request %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/{{namespace}}/messages/{{action.name}}.hpp>
 
 #include <ostream>
 #include <string>
-
 {% if uses_optional %}
 #include <optional>
 {% endif %}
-
-#include <ocpp/{{namespace}}/messages/{{action.name}}.hpp>
 
 using json = nlohmann::json;
 

--- a/src/code_generator/common/templates/message.hpp.jinja
+++ b/src/code_generator/common/templates/message.hpp.jinja
@@ -1,6 +1,8 @@
 {% if action.is_request %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_{{namespace | upper}}_{{ action.name|upper }}_HPP
 #define OCPP_{{namespace | upper}}_{{ action.name|upper }}_HPP
 
@@ -10,7 +12,7 @@
 #include <nlohmann/json_fwd.hpp>
 
 {% if needs_enums %}
-#include <ocpp/{{namespace}}/enums.hpp>
+#include <ocpp/{{namespace}}/ocpp_enums.hpp>
 {% endif %}
 #include <ocpp/{{namespace}}/ocpp_types.hpp>
 {% if needs_types %}

--- a/src/code_generator/common/templates/ocpp_enums.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_enums.cpp.jinja
@@ -1,9 +1,12 @@
 {% if first %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
-#include <stdexcept>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#include <ocpp/{{namespace}}/ocpp_enums.hpp>
+
 #include <string>
-#include <ocpp/{{namespace}}/enums.hpp>
+#include <stdexcept>
 
 namespace ocpp {
 namespace {{namespace}} {

--- a/src/code_generator/common/templates/ocpp_enums.hpp.jinja
+++ b/src/code_generator/common/templates/ocpp_enums.hpp.jinja
@@ -1,8 +1,10 @@
 {% if first %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
-#ifndef OCPP_{{namespace | upper}}_ENUMS_HPP
-#define OCPP_{{namespace | upper}}_ENUMS_HPP
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
+#ifndef OCPP_{{namespace | upper}}_OCPP_ENUMS_HPP
+#define OCPP_{{namespace | upper}}_OCPP_ENUMS_HPP
 
 #include <iosfwd>
 #include <string>
@@ -41,5 +43,5 @@ std::ostream& operator<<(std::ostream& os, const {{ enum_type.name }}& {{ enum_t
 } // namespace {{namespace}}
 } // namespace ocpp
 
-#endif // OCPP_{{namespace | upper}}_ENUMS_HPP
+#endif // OCPP_{{namespace | upper}}_OCPP_ENUMS_HPP
 {% endif %}

--- a/src/code_generator/common/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.cpp.jinja
@@ -1,15 +1,17 @@
 {% if first %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
-#include <string>
-
-#include <optional>
-#include <nlohmann/json.hpp>
-
-#include <ocpp/{{namespace}}/enums.hpp>
-#include <ocpp/common/types.hpp>
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
 
 #include <ocpp/{{namespace}}/ocpp_types.hpp>
+
+#include <string>
+#include <optional>
+
+#include <nlohmann/json.hpp>
+
+#include <ocpp/{{namespace}}/ocpp_enums.hpp>
+#include <ocpp/common/types.hpp>
 
 namespace ocpp {
 namespace {{namespace}} {

--- a/src/code_generator/common/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.cpp.jinja
@@ -62,7 +62,11 @@ if (j.size() == 0) {
             }
 {% endif %}
             for (auto val : k.{{property.name}}.value()) {
+                {%- if property.type.endswith('Enum>') %}
+                j["{{property.name}}"].push_back(conversions::{{- property.type.replace('std::vector<','').replace('>','') | snake_case}}_to_string(val));
+                {%- else%}
                 j["{{property.name}}"].push_back(val);
+                {%- endif%}
             }
 {% else %}
 {%- if property.enum %}
@@ -113,7 +117,11 @@ j["{{property.name}}"] = k.{{property.name}}.value();
             json arr = j.at("{{property.name}}");
             {{property.type}} vec;
             for (auto val : arr) {
+                {%- if property.type.endswith('Enum>') %}
+                vec.push_back(conversions::string_to_{{- property.type.replace('std::vector<','').replace('>','') | snake_case}}(val));
+                {%- else %}
                 vec.push_back(val);
+                {%- endif %}
             }
             k.{{property.name}}.emplace(vec);
 {% else %}

--- a/src/code_generator/common/templates/ocpp_types.hpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.hpp.jinja
@@ -1,6 +1,8 @@
 {% if first %}
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - {{year}} Pionix GmbH and Contributors to EVerest
+// This code is generated using the generator in 'src/code_generator/common`, please do not edit manually
+
 #ifndef OCPP_{{namespace | upper}}_OCPP_TYPES_HPP
 #define OCPP_{{namespace | upper}}_OCPP_TYPES_HPP
 
@@ -9,7 +11,7 @@
 #include <optional>
 #include <nlohmann/json_fwd.hpp>
 
-#include <ocpp/{{namespace}}/enums.hpp>
+#include <ocpp/{{namespace}}/ocpp_enums.hpp>
 {% if namespace == "v16" %}
     #include <ocpp/v16/types.hpp>
 {% endif %}

--- a/tests/lib/ocpp/v16/profile_testsA.cpp
+++ b/tests/lib/ocpp/v16/profile_testsA.cpp
@@ -6,7 +6,7 @@
 #include <chrono>
 
 #include "ocpp/common/types.hpp"
-#include "ocpp/v16/enums.hpp"
+#include "ocpp/v16/ocpp_enums.hpp"
 #include "ocpp/v16/profile.hpp"
 #include "profile_tests_common.hpp"
 #include <gtest/gtest.h>

--- a/tests/lib/ocpp/v16/profile_testsC.cpp
+++ b/tests/lib/ocpp/v16/profile_testsC.cpp
@@ -11,7 +11,7 @@
 
 #include "database_stub.hpp"
 #include "ocpp/common/types.hpp"
-#include "ocpp/v16/enums.hpp"
+#include "ocpp/v16/ocpp_enums.hpp"
 #include "ocpp/v16/smart_charging.hpp"
 #include "profile_tests_common.hpp"
 

--- a/tests/lib/ocpp/v16/profile_tests_common.cpp
+++ b/tests/lib/ocpp/v16/profile_tests_common.cpp
@@ -3,7 +3,7 @@
 
 #include "profile_tests_common.hpp"
 #include "ocpp/common/types.hpp"
-#include "ocpp/v16/enums.hpp"
+#include "ocpp/v16/ocpp_enums.hpp"
 
 // ----------------------------------------------------------------------------
 // helper functions

--- a/tests/lib/ocpp/v16/test_charge_point_state_machine.cpp
+++ b/tests/lib/ocpp/v16/test_charge_point_state_machine.cpp
@@ -4,7 +4,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <ocpp/v16/charge_point_state_machine.hpp>
-#include <ocpp/v16/enums.hpp>
+#include <ocpp/v16/ocpp_enums.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 
 using namespace ocpp::v16;

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -23,7 +23,7 @@
 #include <evse_mock.hpp>
 #include <evse_security_mock.hpp>
 #include <ocpp/common/call_types.hpp>
-#include <ocpp/v201/enums.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/evse.hpp>
 #include <ocpp/v201/smart_charging.hpp>
 #include <optional>

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -23,8 +23,8 @@
 #include <evse_mock.hpp>
 #include <evse_security_mock.hpp>
 #include <ocpp/common/call_types.hpp>
-#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/evse.hpp>
+#include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/smart_charging.hpp>
 #include <optional>
 


### PR DESCRIPTION
## Describe your changes

When making changes to the generators I encountered some changes made in the generated `enums.hpp`. To better differentiate between generated code and custom code I renamed the generated files to `ocpp_enums.hpp` so that leaves room for custom enums in `enums.hpp`

I also changed some minor details:
* Added a line in each generated file stating that it is generated and should not be touched
* Fixed order of include files so we always include the sources header file first
* Removed unit RevolutionsPerMinute since that is not a unit defined in the schemas

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

