### PR TITLE
Improved handling of json and enum conversion errors

### DIFF
--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -752,8 +752,7 @@ public:
             // TODO(kai): we need to do some error handling in the CallError case
             std::unique_lock<std::recursive_mutex> lk(this->message_mutex);
             if (this->in_flight == nullptr) {
-                EVLOG_error
-                    << "Received a CALLRESULT OR CALLERROR without a message in flight, this should not happen";
+                EVLOG_error << "Received a CALLRESULT OR CALLERROR without a message in flight, this should not happen";
                 return enhanced_message;
             }
             if (this->in_flight->uniqueId() != enhanced_message.uniqueId) {

--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -721,61 +721,55 @@ public:
     /// \brief Enhances a received \p json_message with additional meta information, checks if it is a valid CallResult
     /// with a corresponding Call message on top of the queue
     /// \returns the enhanced message
-    EnhancedMessage<M> receive(const std::string& message) {
+    EnhancedMessage<M> receive(std::string_view message) {
         EnhancedMessage<M> enhanced_message;
 
-        try {
-            enhanced_message.message = json::parse(message);
-            enhanced_message.uniqueId = this->getMessageId(enhanced_message.message);
-            enhanced_message.messageTypeId = this->getMessageTypeId(enhanced_message.message);
+        enhanced_message.message = json::parse(message);
+        enhanced_message.uniqueId = this->getMessageId(enhanced_message.message);
+        enhanced_message.messageTypeId = this->getMessageTypeId(enhanced_message.message);
 
-            if (enhanced_message.messageTypeId == MessageTypeId::CALL) {
-                enhanced_message.messageType = this->string_to_messagetype(enhanced_message.message.at(CALL_ACTION));
-                enhanced_message.call_message = enhanced_message.message;
+        if (enhanced_message.messageTypeId == MessageTypeId::CALL) {
+            enhanced_message.messageType = this->string_to_messagetype(enhanced_message.message.at(CALL_ACTION));
+            enhanced_message.call_message = enhanced_message.message;
 
-                {
-                    std::lock_guard<std::recursive_mutex> lk(this->next_message_mutex);
-                    // save the uid of the message we just received to ensure the next message we send is a response to
-                    // this message
-                    next_message_to_send.emplace(enhanced_message.uniqueId);
-                }
+            {
+                std::lock_guard<std::recursive_mutex> lk(this->next_message_mutex);
+                // save the uid of the message we just received to ensure the next message we send is a response to
+                // this message
+                next_message_to_send.emplace(enhanced_message.uniqueId);
             }
+        }
 
-            // TODO(kai): what happens if we receive a CallResult or CallError out of order?
-            if (enhanced_message.messageTypeId == MessageTypeId::CALLRESULT ||
-                enhanced_message.messageTypeId == MessageTypeId::CALLERROR) {
-                {
-                    std::lock_guard<std::recursive_mutex> lk(this->next_message_mutex);
-                    next_message_to_send.reset();
-                }
-                // we need to remove Call messages from in_flight if we receive a CallResult OR a CallError
-
-                // TODO(kai): we need to do some error handling in the CallError case
-                std::unique_lock<std::recursive_mutex> lk(this->message_mutex);
-                if (this->in_flight == nullptr) {
-                    EVLOG_error
-                        << "Received a CALLRESULT OR CALLERROR without a message in flight, this should not happen";
-                    return enhanced_message;
-                }
-                if (this->in_flight->uniqueId() != enhanced_message.uniqueId) {
-                    EVLOG_error << "Received a CALLRESULT OR CALLERROR with mismatching uid: "
-                                << this->in_flight->uniqueId() << " != " << enhanced_message.uniqueId;
-                    return enhanced_message;
-                }
-                if (enhanced_message.messageTypeId == MessageTypeId::CALLERROR) {
-                    EVLOG_error << "Received a CALLERROR for message with UID: " << enhanced_message.uniqueId;
-                    // make sure the original call message is attached to the callerror
-                    enhanced_message.call_message = this->in_flight->message;
-                    lk.unlock();
-                    this->handle_timeout_or_callerror(enhanced_message);
-                } else {
-                    this->handle_call_result(enhanced_message);
-                }
+        // TODO(kai): what happens if we receive a CallResult or CallError out of order?
+        if (enhanced_message.messageTypeId == MessageTypeId::CALLRESULT ||
+            enhanced_message.messageTypeId == MessageTypeId::CALLERROR) {
+            {
+                std::lock_guard<std::recursive_mutex> lk(this->next_message_mutex);
+                next_message_to_send.reset();
             }
+            // we need to remove Call messages from in_flight if we receive a CallResult OR a CallError
 
-        } catch (const std::exception& e) {
-            EVLOG_error << "json parse failed because: "
-                        << "(" << e.what() << ")";
+            // TODO(kai): we need to do some error handling in the CallError case
+            std::unique_lock<std::recursive_mutex> lk(this->message_mutex);
+            if (this->in_flight == nullptr) {
+                EVLOG_error
+                    << "Received a CALLRESULT OR CALLERROR without a message in flight, this should not happen";
+                return enhanced_message;
+            }
+            if (this->in_flight->uniqueId() != enhanced_message.uniqueId) {
+                EVLOG_error << "Received a CALLRESULT OR CALLERROR with mismatching uid: "
+                            << this->in_flight->uniqueId() << " != " << enhanced_message.uniqueId;
+                return enhanced_message;
+            }
+            if (enhanced_message.messageTypeId == MessageTypeId::CALLERROR) {
+                EVLOG_error << "Received a CALLERROR for message with UID: " << enhanced_message.uniqueId;
+                // make sure the original call message is attached to the callerror
+                enhanced_message.call_message = this->in_flight->message;
+                lk.unlock();
+                this->handle_timeout_or_callerror(enhanced_message);
+            } else {
+                this->handle_call_result(enhanced_message);
+            }
         }
 
         return enhanced_message;

--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -110,6 +110,47 @@ public:
     DateTime& operator=(const char* c);
 };
 
+/// \brief Base exception for when a conversion from string to enum or vice versa fails
+class EnumConversionException : public std::exception {
+public:
+    explicit EnumConversionException(std::string&& msg) : msg{std::move(msg)} {
+    }
+
+    // ~EnumConversionException() noexcept override = default;
+
+    const char* what() const noexcept override {
+        return msg.c_str();
+    }
+
+private:
+    std::string msg;
+};
+
+/// \brief Exception used when conversion from enum to string fails
+class EnumToStringException : public EnumConversionException {
+public:
+    /// \brief Creates a new StringToEnumException
+    /// \param enumValue value of enum that failed to convert
+    /// \param type name of the enum trying to convert from
+    template <typename T>
+    explicit EnumToStringException(T enumValue, std::string_view type) :
+        EnumConversionException{std::string{"No known conversion from value '"} +
+                                std::to_string(static_cast<int>(enumValue)) + "' to " + type.data()} {
+    }
+};
+
+/// \brief Exception used when conversion from string to enum fails
+class StringToEnumException : public EnumConversionException {
+public:
+    /// \brief Creates a new StringToEnumException
+    /// \param str input string that failed to convert
+    /// \param type name of the enum trying to convert to
+    StringToEnumException(std::string_view str, std::string_view type) :
+        EnumConversionException{std::string{"Provided string '"} + str.data() + "' could not be converted to " +
+                                type.data()} {
+    }
+};
+
 /// \brief Contains the different connection states of the charge point
 enum SessionStartedReason {
     EVConnected,

--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -111,19 +111,9 @@ public:
 };
 
 /// \brief Base exception for when a conversion from string to enum or vice versa fails
-class EnumConversionException : public std::exception {
+class EnumConversionException : public std::out_of_range {
 public:
-    explicit EnumConversionException(std::string&& msg) : msg{std::move(msg)} {
-    }
-
-    // ~EnumConversionException() noexcept override = default;
-
-    const char* what() const noexcept override {
-        return msg.c_str();
-    }
-
-private:
-    std::string msg;
+    using std::out_of_range::out_of_range;
 };
 
 /// \brief Exception used when conversion from enum to string fails

--- a/lib/ocpp/common/types.cpp
+++ b/lib/ocpp/common/types.cpp
@@ -136,7 +136,7 @@ std::string session_started_reason_to_string(SessionStartedReason e) {
     case SessionStartedReason::EVConnected:
         return "EVConnected";
     }
-    throw std::out_of_range("No known string conversion for provided enum of type SessionStartedReason");
+    throw EnumToStringException{e, "SessionStartedReason"};
 }
 
 SessionStartedReason string_to_session_started_reason(const std::string& s) {
@@ -146,7 +146,7 @@ SessionStartedReason string_to_session_started_reason(const std::string& s) {
     if (s == "EVConnected") {
         return SessionStartedReason::EVConnected;
     }
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type SessionStartedReason");
+    throw StringToEnumException{s, "SessionStartedReason"};
 }
 } // namespace conversions
 
@@ -581,7 +581,7 @@ std::string ca_certificate_type_to_string(CaCertificateType e) {
         return "MF";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CaCertificateType");
+    throw EnumToStringException{e, "CaCertificateType"};
 }
 
 CaCertificateType string_to_ca_certificate_type(const std::string& s) {
@@ -594,7 +594,7 @@ CaCertificateType string_to_ca_certificate_type(const std::string& s) {
     } else if (s == "MF") {
         return CaCertificateType::MF;
     }
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type CertificateType");
+    throw StringToEnumException{s, "CertificateType"};
 }
 } // namespace conversions
 
@@ -622,7 +622,7 @@ std::string certificate_validation_result_to_string(CertificateValidationResult 
         return "Unknown";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateValidationResult");
+    throw EnumToStringException{e, "CertificateValidationResult"};
 }
 
 CertificateValidationResult string_to_certificate_validation_result(const std::string& s) {
@@ -647,8 +647,7 @@ CertificateValidationResult string_to_certificate_validation_result(const std::s
     if (s == "Unknown") {
         return CertificateValidationResult::Unknown;
     }
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type CertificateValidationResult");
+    throw StringToEnumException{s, "CertificateValidationResult"};
 }
 } // namespace conversions
 
@@ -680,7 +679,7 @@ std::string install_certificate_result_to_string(InstallCertificateResult e) {
         return "Accepted";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UpdateFirmwareStatusEnumType");
+    throw EnumToStringException{e, "UpdateFirmwareStatusEnumType"};
 }
 
 InstallCertificateResult string_to_install_certificate_result(const std::string& s) {
@@ -711,8 +710,7 @@ InstallCertificateResult string_to_install_certificate_result(const std::string&
     if (s == "Accepted") {
         return InstallCertificateResult::Accepted;
     }
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type InstallCertificateResult");
+    throw StringToEnumException{s, "InstallCertificateResult"};
 }
 } // namespace conversions
 
@@ -732,7 +730,7 @@ std::string delete_certificate_result_to_string(DeleteCertificateResult e) {
         return "NotFound";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DeleteCertificateResult");
+    throw EnumToStringException{e, "DeleteCertificateResult"};
 }
 
 DeleteCertificateResult string_to_delete_certificate_result(const std::string& s) {
@@ -746,7 +744,7 @@ DeleteCertificateResult string_to_delete_certificate_result(const std::string& s
         return DeleteCertificateResult::NotFound;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type DeleteCertificateResult");
+    throw StringToEnumException{s, "DeleteCertificateResult"};
 }
 } // namespace conversions
 
@@ -837,7 +835,7 @@ std::string hash_algorithm_enum_type_to_string(HashAlgorithmEnumType e) {
         return "SHA512";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type HashAlgorithmEnumType");
+    throw EnumToStringException{e, "HashAlgorithmEnumType"};
 }
 
 HashAlgorithmEnumType string_to_hash_algorithm_enum_type(const std::string& s) {
@@ -851,7 +849,7 @@ HashAlgorithmEnumType string_to_hash_algorithm_enum_type(const std::string& s) {
         return HashAlgorithmEnumType::SHA512;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type HashAlgorithmEnumType");
+    throw StringToEnumException{s, "HashAlgorithmEnumType"};
 }
 } // namespace conversions
 
@@ -869,7 +867,7 @@ std::string ocpp_protocol_version_to_string(OcppProtocolVersion e) {
         return "ocpp2.0.1";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type OcppProtocolVersion");
+    throw EnumToStringException{e, "OcppProtocolVersion"};
 }
 
 OcppProtocolVersion string_to_ocpp_protocol_version(const std::string& s) {
@@ -879,7 +877,7 @@ OcppProtocolVersion string_to_ocpp_protocol_version(const std::string& s) {
     if (s == "ocpp2.0.1") {
         return OcppProtocolVersion::v201;
     }
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type OcppProtocolVersion");
+    throw StringToEnumException{s, "OcppProtocolVersion"};
 }
 } // namespace conversions
 
@@ -899,7 +897,7 @@ std::string certificate_signing_use_enum_to_string(CertificateSigningUseEnum e) 
         return "ManufacturerCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateSigningUseEnum");
+    throw EnumToStringException{e, "CertificateSigningUseEnum"};
 }
 
 CertificateSigningUseEnum string_to_certificate_signing_use_enum(const std::string& s) {
@@ -913,8 +911,7 @@ CertificateSigningUseEnum string_to_certificate_signing_use_enum(const std::stri
         return CertificateSigningUseEnum::ManufacturerCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type CertificateSigningUseEnum");
+    throw StringToEnumException{s, "CertificateSigningUseEnum"};
 }
 } // namespace conversions
 
@@ -938,7 +935,7 @@ std::string certificate_type_to_string(CertificateType e) {
         return "MFRootCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateType");
+    throw EnumToStringException{e, "CertificateType"};
 }
 
 CertificateType string_to_certificate_type(const std::string& s) {
@@ -958,7 +955,7 @@ CertificateType string_to_certificate_type(const std::string& s) {
         return CertificateType::MFRootCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type CertificateType");
+    throw StringToEnumException{s, "CertificateType"};
 }
 } // namespace conversions
 
@@ -1008,7 +1005,7 @@ std::string generate_certificate_signing_request_status_to_string(const GetCerti
     case GetCertificateSignRequestStatus::GenerationError:
         return "GenerationError";
     default:
-        throw std::out_of_range("Could not convert GetCertificateSignRequestStatus to string");
+        throw EnumToStringException(status, "GetCertificateSignRequestStatus");
     }
 }
 } // namespace conversions

--- a/lib/ocpp/common/websocket/websocket_plain.cpp
+++ b/lib/ocpp/common/websocket/websocket_plain.cpp
@@ -26,7 +26,7 @@ websocketpp::close::status::value close_reason_to_value(WebsocketCloseReason rea
         return websocketpp::close::status::service_restart;
     }
 
-    throw std::out_of_range("No known conversion for provided enum of type WebsocketCloseReason");
+    throw EnumToStringException{e, "WebsocketCloseReason"};
 }
 
 WebsocketCloseReason value_to_close_reason(websocketpp::close::status::value value) {

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -71,7 +71,7 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
                 try {
                     this->supported_feature_profiles.insert(
                         conversions::string_to_supported_feature_profiles(component));
-                } catch (const std::out_of_range& e) {
+                } catch (const StringToEnumException& e) {
                     EVLOG_error << "Feature profile: \"" << component << "\" not recognized";
                     throw std::runtime_error("Unknown component in SupportedFeatureProfiles config option.");
                 }
@@ -240,7 +240,7 @@ void ChargePointConfiguration::init_supported_measurands() {
             default:
                 EVLOG_AND_THROW(std::runtime_error("Given SupportedMeasurands are invalid"));
             }
-        } catch (std::out_of_range& o) {
+        } catch (const StringToEnumException& o) {
             EVLOG_AND_THROW(std::runtime_error("Given SupportedMeasurands are invalid"));
         }
     }
@@ -723,7 +723,7 @@ bool ChargePointConfiguration::measurands_supported(std::string csv) {
     for (auto component : components) {
         try {
             conversions::string_to_measurand(component);
-        } catch (std::out_of_range& o) {
+        } catch (const StringToEnumException& o) {
             EVLOG_warning << "Measurand: " << component << " is not supported!";
             return false;
         }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3760,7 +3760,7 @@ std::vector<Measurand> ChargePointImpl::get_measurands_vec(const std::string& me
     for (const auto& measurand_string : measurands_strings) {
         try {
             measurands.push_back(conversions::string_to_measurand(measurand_string));
-        } catch (std::out_of_range& e) {
+        } catch (const StringToEnumException& e) {
             EVLOG_warning << "Could not convert string: " << measurand_string << " to MeasurandEnum";
         }
     }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1037,7 +1037,7 @@ void ChargePointImpl::connected_callback() {
 void ChargePointImpl::message_callback(const std::string& message) {
     EVLOG_debug << "Received Message: " << message;
 
-    EnhancedMessage<v201::MessageType> enhanced_message;
+    EnhancedMessage<v16::MessageType> enhanced_message;
     try {
         enhanced_message = this->message_queue->receive(message);
     } catch (const json::exception& e) {
@@ -1127,7 +1127,7 @@ void ChargePointImpl::message_callback(const std::string& message) {
             this->send(call_error);
             this->securityEventNotification(ocpp::security_events::INVALIDMESSAGES, message, true);
         }
-    } catch (const EnumConversionException &e) {
+    } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}, true));
         this->send(call_error);

--- a/lib/ocpp/v16/ocpp_enums.cpp
+++ b/lib/ocpp/v16/ocpp_enums.cpp
@@ -4,8 +4,9 @@
 
 #include <ocpp/v16/ocpp_enums.hpp>
 
-#include <stdexcept>
 #include <string>
+
+#include <ocpp/common/types.hpp>
 
 namespace ocpp {
 namespace v16 {
@@ -26,7 +27,7 @@ std::string authorization_status_to_string(AuthorizationStatus e) {
         return "ConcurrentTx";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type AuthorizationStatus");
+    throw EnumToStringException{e, "AuthorizationStatus"};
 }
 
 AuthorizationStatus string_to_authorization_status(const std::string& s) {
@@ -46,7 +47,7 @@ AuthorizationStatus string_to_authorization_status(const std::string& s) {
         return AuthorizationStatus::ConcurrentTx;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AuthorizationStatus");
+    throw StringToEnumException{s, "AuthorizationStatus"};
 }
 } // namespace conversions
 
@@ -67,7 +68,7 @@ std::string registration_status_to_string(RegistrationStatus e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type RegistrationStatus");
+    throw EnumToStringException{e, "RegistrationStatus"};
 }
 
 RegistrationStatus string_to_registration_status(const std::string& s) {
@@ -81,7 +82,7 @@ RegistrationStatus string_to_registration_status(const std::string& s) {
         return RegistrationStatus::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RegistrationStatus");
+    throw StringToEnumException{s, "RegistrationStatus"};
 }
 } // namespace conversions
 
@@ -100,7 +101,7 @@ std::string cancel_reservation_status_to_string(CancelReservationStatus e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CancelReservationStatus");
+    throw EnumToStringException{e, "CancelReservationStatus"};
 }
 
 CancelReservationStatus string_to_cancel_reservation_status(const std::string& s) {
@@ -111,7 +112,7 @@ CancelReservationStatus string_to_cancel_reservation_status(const std::string& s
         return CancelReservationStatus::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type CancelReservationStatus");
+    throw StringToEnumException{s, "CancelReservationStatus"};
 }
 } // namespace conversions
 
@@ -130,7 +131,7 @@ std::string certificate_signed_status_enum_type_to_string(CertificateSignedStatu
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateSignedStatusEnumType");
+    throw EnumToStringException{e, "CertificateSignedStatusEnumType"};
 }
 
 CertificateSignedStatusEnumType string_to_certificate_signed_status_enum_type(const std::string& s) {
@@ -141,8 +142,7 @@ CertificateSignedStatusEnumType string_to_certificate_signed_status_enum_type(co
         return CertificateSignedStatusEnumType::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type CertificateSignedStatusEnumType");
+    throw StringToEnumException{s, "CertificateSignedStatusEnumType"};
 }
 } // namespace conversions
 
@@ -161,7 +161,7 @@ std::string availability_type_to_string(AvailabilityType e) {
         return "Operative";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type AvailabilityType");
+    throw EnumToStringException{e, "AvailabilityType"};
 }
 
 AvailabilityType string_to_availability_type(const std::string& s) {
@@ -172,7 +172,7 @@ AvailabilityType string_to_availability_type(const std::string& s) {
         return AvailabilityType::Operative;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AvailabilityType");
+    throw StringToEnumException{s, "AvailabilityType"};
 }
 } // namespace conversions
 
@@ -193,7 +193,7 @@ std::string availability_status_to_string(AvailabilityStatus e) {
         return "Scheduled";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type AvailabilityStatus");
+    throw EnumToStringException{e, "AvailabilityStatus"};
 }
 
 AvailabilityStatus string_to_availability_status(const std::string& s) {
@@ -207,7 +207,7 @@ AvailabilityStatus string_to_availability_status(const std::string& s) {
         return AvailabilityStatus::Scheduled;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AvailabilityStatus");
+    throw StringToEnumException{s, "AvailabilityStatus"};
 }
 } // namespace conversions
 
@@ -230,7 +230,7 @@ std::string configuration_status_to_string(ConfigurationStatus e) {
         return "NotSupported";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ConfigurationStatus");
+    throw EnumToStringException{e, "ConfigurationStatus"};
 }
 
 ConfigurationStatus string_to_configuration_status(const std::string& s) {
@@ -247,7 +247,7 @@ ConfigurationStatus string_to_configuration_status(const std::string& s) {
         return ConfigurationStatus::NotSupported;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ConfigurationStatus");
+    throw StringToEnumException{s, "ConfigurationStatus"};
 }
 } // namespace conversions
 
@@ -266,7 +266,7 @@ std::string clear_cache_status_to_string(ClearCacheStatus e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ClearCacheStatus");
+    throw EnumToStringException{e, "ClearCacheStatus"};
 }
 
 ClearCacheStatus string_to_clear_cache_status(const std::string& s) {
@@ -277,7 +277,7 @@ ClearCacheStatus string_to_clear_cache_status(const std::string& s) {
         return ClearCacheStatus::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ClearCacheStatus");
+    throw StringToEnumException{s, "ClearCacheStatus"};
 }
 } // namespace conversions
 
@@ -298,7 +298,7 @@ std::string charging_profile_purpose_type_to_string(ChargingProfilePurposeType e
         return "TxProfile";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfilePurposeType");
+    throw EnumToStringException{e, "ChargingProfilePurposeType"};
 }
 
 ChargingProfilePurposeType string_to_charging_profile_purpose_type(const std::string& s) {
@@ -312,8 +312,7 @@ ChargingProfilePurposeType string_to_charging_profile_purpose_type(const std::st
         return ChargingProfilePurposeType::TxProfile;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ChargingProfilePurposeType");
+    throw StringToEnumException{s, "ChargingProfilePurposeType"};
 }
 } // namespace conversions
 
@@ -332,7 +331,7 @@ std::string clear_charging_profile_status_to_string(ClearChargingProfileStatus e
         return "Unknown";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ClearChargingProfileStatus");
+    throw EnumToStringException{e, "ClearChargingProfileStatus"};
 }
 
 ClearChargingProfileStatus string_to_clear_charging_profile_status(const std::string& s) {
@@ -343,8 +342,7 @@ ClearChargingProfileStatus string_to_clear_charging_profile_status(const std::st
         return ClearChargingProfileStatus::Unknown;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ClearChargingProfileStatus");
+    throw StringToEnumException{s, "ClearChargingProfileStatus"};
 }
 } // namespace conversions
 
@@ -367,7 +365,7 @@ std::string data_transfer_status_to_string(DataTransferStatus e) {
         return "UnknownVendorId";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DataTransferStatus");
+    throw EnumToStringException{e, "DataTransferStatus"};
 }
 
 DataTransferStatus string_to_data_transfer_status(const std::string& s) {
@@ -384,7 +382,7 @@ DataTransferStatus string_to_data_transfer_status(const std::string& s) {
         return DataTransferStatus::UnknownVendorId;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type DataTransferStatus");
+    throw StringToEnumException{s, "DataTransferStatus"};
 }
 } // namespace conversions
 
@@ -405,7 +403,7 @@ std::string hash_algorithm_enum_type_to_string(HashAlgorithmEnumType e) {
         return "SHA512";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type HashAlgorithmEnumType");
+    throw EnumToStringException{e, "HashAlgorithmEnumType"};
 }
 
 HashAlgorithmEnumType string_to_hash_algorithm_enum_type(const std::string& s) {
@@ -419,7 +417,7 @@ HashAlgorithmEnumType string_to_hash_algorithm_enum_type(const std::string& s) {
         return HashAlgorithmEnumType::SHA512;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type HashAlgorithmEnumType");
+    throw StringToEnumException{s, "HashAlgorithmEnumType"};
 }
 } // namespace conversions
 
@@ -440,7 +438,7 @@ std::string delete_certificate_status_enum_type_to_string(DeleteCertificateStatu
         return "NotFound";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DeleteCertificateStatusEnumType");
+    throw EnumToStringException{e, "DeleteCertificateStatusEnumType"};
 }
 
 DeleteCertificateStatusEnumType string_to_delete_certificate_status_enum_type(const std::string& s) {
@@ -454,8 +452,7 @@ DeleteCertificateStatusEnumType string_to_delete_certificate_status_enum_type(co
         return DeleteCertificateStatusEnumType::NotFound;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type DeleteCertificateStatusEnumType");
+    throw StringToEnumException{s, "DeleteCertificateStatusEnumType"};
 }
 } // namespace conversions
 
@@ -478,7 +475,7 @@ std::string diagnostics_status_to_string(DiagnosticsStatus e) {
         return "Uploading";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DiagnosticsStatus");
+    throw EnumToStringException{e, "DiagnosticsStatus"};
 }
 
 DiagnosticsStatus string_to_diagnostics_status(const std::string& s) {
@@ -495,7 +492,7 @@ DiagnosticsStatus string_to_diagnostics_status(const std::string& s) {
         return DiagnosticsStatus::Uploading;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type DiagnosticsStatus");
+    throw StringToEnumException{s, "DiagnosticsStatus"};
 }
 } // namespace conversions
 
@@ -524,7 +521,7 @@ std::string message_trigger_enum_type_to_string(MessageTriggerEnumType e) {
         return "StatusNotification";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MessageTriggerEnumType");
+    throw EnumToStringException{e, "MessageTriggerEnumType"};
 }
 
 MessageTriggerEnumType string_to_message_trigger_enum_type(const std::string& s) {
@@ -550,7 +547,7 @@ MessageTriggerEnumType string_to_message_trigger_enum_type(const std::string& s)
         return MessageTriggerEnumType::StatusNotification;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageTriggerEnumType");
+    throw StringToEnumException{s, "MessageTriggerEnumType"};
 }
 } // namespace conversions
 
@@ -571,7 +568,7 @@ std::string trigger_message_status_enum_type_to_string(TriggerMessageStatusEnumT
         return "NotImplemented";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type TriggerMessageStatusEnumType");
+    throw EnumToStringException{e, "TriggerMessageStatusEnumType"};
 }
 
 TriggerMessageStatusEnumType string_to_trigger_message_status_enum_type(const std::string& s) {
@@ -585,8 +582,7 @@ TriggerMessageStatusEnumType string_to_trigger_message_status_enum_type(const st
         return TriggerMessageStatusEnumType::NotImplemented;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type TriggerMessageStatusEnumType");
+    throw StringToEnumException{s, "TriggerMessageStatusEnumType"};
 }
 } // namespace conversions
 
@@ -615,7 +611,7 @@ std::string firmware_status_to_string(FirmwareStatus e) {
         return "Installed";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type FirmwareStatus");
+    throw EnumToStringException{e, "FirmwareStatus"};
 }
 
 FirmwareStatus string_to_firmware_status(const std::string& s) {
@@ -641,7 +637,7 @@ FirmwareStatus string_to_firmware_status(const std::string& s) {
         return FirmwareStatus::Installed;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type FirmwareStatus");
+    throw StringToEnumException{s, "FirmwareStatus"};
 }
 } // namespace conversions
 
@@ -660,7 +656,7 @@ std::string charging_rate_unit_to_string(ChargingRateUnit e) {
         return "W";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingRateUnit");
+    throw EnumToStringException{e, "ChargingRateUnit"};
 }
 
 ChargingRateUnit string_to_charging_rate_unit(const std::string& s) {
@@ -671,7 +667,7 @@ ChargingRateUnit string_to_charging_rate_unit(const std::string& s) {
         return ChargingRateUnit::W;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingRateUnit");
+    throw StringToEnumException{s, "ChargingRateUnit"};
 }
 } // namespace conversions
 
@@ -690,7 +686,7 @@ std::string get_composite_schedule_status_to_string(GetCompositeScheduleStatus e
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GetCompositeScheduleStatus");
+    throw EnumToStringException{e, "GetCompositeScheduleStatus"};
 }
 
 GetCompositeScheduleStatus string_to_get_composite_schedule_status(const std::string& s) {
@@ -701,8 +697,7 @@ GetCompositeScheduleStatus string_to_get_composite_schedule_status(const std::st
         return GetCompositeScheduleStatus::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type GetCompositeScheduleStatus");
+    throw StringToEnumException{s, "GetCompositeScheduleStatus"};
 }
 } // namespace conversions
 
@@ -721,7 +716,7 @@ std::string certificate_use_enum_type_to_string(CertificateUseEnumType e) {
         return "ManufacturerRootCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateUseEnumType");
+    throw EnumToStringException{e, "CertificateUseEnumType"};
 }
 
 CertificateUseEnumType string_to_certificate_use_enum_type(const std::string& s) {
@@ -732,7 +727,7 @@ CertificateUseEnumType string_to_certificate_use_enum_type(const std::string& s)
         return CertificateUseEnumType::ManufacturerRootCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type CertificateUseEnumType");
+    throw StringToEnumException{s, "CertificateUseEnumType"};
 }
 } // namespace conversions
 
@@ -751,8 +746,7 @@ std::string get_installed_certificate_status_enum_type_to_string(GetInstalledCer
         return "NotFound";
     }
 
-    throw std::out_of_range(
-        "No known string conversion for provided enum of type GetInstalledCertificateStatusEnumType");
+    throw EnumToStringException{e, "GetInstalledCertificateStatusEnumType"};
 }
 
 GetInstalledCertificateStatusEnumType string_to_get_installed_certificate_status_enum_type(const std::string& s) {
@@ -763,8 +757,7 @@ GetInstalledCertificateStatusEnumType string_to_get_installed_certificate_status
         return GetInstalledCertificateStatusEnumType::NotFound;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type GetInstalledCertificateStatusEnumType");
+    throw StringToEnumException{s, "GetInstalledCertificateStatusEnumType"};
 }
 } // namespace conversions
 
@@ -784,7 +777,7 @@ std::string log_enum_type_to_string(LogEnumType e) {
         return "SecurityLog";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type LogEnumType");
+    throw EnumToStringException{e, "LogEnumType"};
 }
 
 LogEnumType string_to_log_enum_type(const std::string& s) {
@@ -795,7 +788,7 @@ LogEnumType string_to_log_enum_type(const std::string& s) {
         return LogEnumType::SecurityLog;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type LogEnumType");
+    throw StringToEnumException{s, "LogEnumType"};
 }
 } // namespace conversions
 
@@ -816,7 +809,7 @@ std::string log_status_enum_type_to_string(LogStatusEnumType e) {
         return "AcceptedCanceled";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type LogStatusEnumType");
+    throw EnumToStringException{e, "LogStatusEnumType"};
 }
 
 LogStatusEnumType string_to_log_status_enum_type(const std::string& s) {
@@ -830,7 +823,7 @@ LogStatusEnumType string_to_log_status_enum_type(const std::string& s) {
         return LogStatusEnumType::AcceptedCanceled;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type LogStatusEnumType");
+    throw StringToEnumException{s, "LogStatusEnumType"};
 }
 } // namespace conversions
 
@@ -851,7 +844,7 @@ std::string install_certificate_status_enum_type_to_string(InstallCertificateSta
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type InstallCertificateStatusEnumType");
+    throw EnumToStringException{e, "InstallCertificateStatusEnumType"};
 }
 
 InstallCertificateStatusEnumType string_to_install_certificate_status_enum_type(const std::string& s) {
@@ -865,8 +858,7 @@ InstallCertificateStatusEnumType string_to_install_certificate_status_enum_type(
         return InstallCertificateStatusEnumType::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type InstallCertificateStatusEnumType");
+    throw StringToEnumException{s, "InstallCertificateStatusEnumType"};
 }
 } // namespace conversions
 
@@ -896,7 +888,7 @@ std::string upload_log_status_enum_type_to_string(UploadLogStatusEnumType e) {
         return "Uploading";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UploadLogStatusEnumType");
+    throw EnumToStringException{e, "UploadLogStatusEnumType"};
 }
 
 UploadLogStatusEnumType string_to_upload_log_status_enum_type(const std::string& s) {
@@ -922,7 +914,7 @@ UploadLogStatusEnumType string_to_upload_log_status_enum_type(const std::string&
         return UploadLogStatusEnumType::Uploading;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UploadLogStatusEnumType");
+    throw StringToEnumException{s, "UploadLogStatusEnumType"};
 }
 } // namespace conversions
 
@@ -953,7 +945,7 @@ std::string reading_context_to_string(ReadingContext e) {
         return "Other";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ReadingContext");
+    throw EnumToStringException{e, "ReadingContext"};
 }
 
 ReadingContext string_to_reading_context(const std::string& s) {
@@ -982,7 +974,7 @@ ReadingContext string_to_reading_context(const std::string& s) {
         return ReadingContext::Other;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReadingContext");
+    throw StringToEnumException{s, "ReadingContext"};
 }
 } // namespace conversions
 
@@ -1001,7 +993,7 @@ std::string value_format_to_string(ValueFormat e) {
         return "SignedData";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ValueFormat");
+    throw EnumToStringException{e, "ValueFormat"};
 }
 
 ValueFormat string_to_value_format(const std::string& s) {
@@ -1012,7 +1004,7 @@ ValueFormat string_to_value_format(const std::string& s) {
         return ValueFormat::SignedData;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ValueFormat");
+    throw StringToEnumException{s, "ValueFormat"};
 }
 } // namespace conversions
 
@@ -1071,7 +1063,7 @@ std::string measurand_to_string(Measurand e) {
         return "RPM";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type Measurand");
+    throw EnumToStringException{e, "Measurand"};
 }
 
 Measurand string_to_measurand(const std::string& s) {
@@ -1142,7 +1134,7 @@ Measurand string_to_measurand(const std::string& s) {
         return Measurand::RPM;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Measurand");
+    throw StringToEnumException{s, "Measurand"};
 }
 } // namespace conversions
 
@@ -1177,7 +1169,7 @@ std::string phase_to_string(Phase e) {
         return "L3-L1";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type Phase");
+    throw EnumToStringException{e, "Phase"};
 }
 
 Phase string_to_phase(const std::string& s) {
@@ -1212,7 +1204,7 @@ Phase string_to_phase(const std::string& s) {
         return Phase::L3_L1;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Phase");
+    throw StringToEnumException{s, "Phase"};
 }
 } // namespace conversions
 
@@ -1237,7 +1229,7 @@ std::string location_to_string(Location e) {
         return "Body";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type Location");
+    throw EnumToStringException{e, "Location"};
 }
 
 Location string_to_location(const std::string& s) {
@@ -1257,7 +1249,7 @@ Location string_to_location(const std::string& s) {
         return Location::Body;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Location");
+    throw StringToEnumException{s, "Location"};
 }
 } // namespace conversions
 
@@ -1306,7 +1298,7 @@ std::string unit_of_measure_to_string(UnitOfMeasure e) {
         return "Percent";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UnitOfMeasure");
+    throw EnumToStringException{e, "UnitOfMeasure"};
 }
 
 UnitOfMeasure string_to_unit_of_measure(const std::string& s) {
@@ -1362,7 +1354,7 @@ UnitOfMeasure string_to_unit_of_measure(const std::string& s) {
         return UnitOfMeasure::Percent;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UnitOfMeasure");
+    throw StringToEnumException{s, "UnitOfMeasure"};
 }
 } // namespace conversions
 
@@ -1383,7 +1375,7 @@ std::string charging_profile_kind_type_to_string(ChargingProfileKindType e) {
         return "Relative";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileKindType");
+    throw EnumToStringException{e, "ChargingProfileKindType"};
 }
 
 ChargingProfileKindType string_to_charging_profile_kind_type(const std::string& s) {
@@ -1397,7 +1389,7 @@ ChargingProfileKindType string_to_charging_profile_kind_type(const std::string& 
         return ChargingProfileKindType::Relative;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingProfileKindType");
+    throw StringToEnumException{s, "ChargingProfileKindType"};
 }
 } // namespace conversions
 
@@ -1416,7 +1408,7 @@ std::string recurrency_kind_type_to_string(RecurrencyKindType e) {
         return "Weekly";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type RecurrencyKindType");
+    throw EnumToStringException{e, "RecurrencyKindType"};
 }
 
 RecurrencyKindType string_to_recurrency_kind_type(const std::string& s) {
@@ -1427,7 +1419,7 @@ RecurrencyKindType string_to_recurrency_kind_type(const std::string& s) {
         return RecurrencyKindType::Weekly;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RecurrencyKindType");
+    throw StringToEnumException{s, "RecurrencyKindType"};
 }
 } // namespace conversions
 
@@ -1446,7 +1438,7 @@ std::string remote_start_stop_status_to_string(RemoteStartStopStatus e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type RemoteStartStopStatus");
+    throw EnumToStringException{e, "RemoteStartStopStatus"};
 }
 
 RemoteStartStopStatus string_to_remote_start_stop_status(const std::string& s) {
@@ -1457,7 +1449,7 @@ RemoteStartStopStatus string_to_remote_start_stop_status(const std::string& s) {
         return RemoteStartStopStatus::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RemoteStartStopStatus");
+    throw StringToEnumException{s, "RemoteStartStopStatus"};
 }
 } // namespace conversions
 
@@ -1482,7 +1474,7 @@ std::string reservation_status_to_string(ReservationStatus e) {
         return "Unavailable";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ReservationStatus");
+    throw EnumToStringException{e, "ReservationStatus"};
 }
 
 ReservationStatus string_to_reservation_status(const std::string& s) {
@@ -1502,7 +1494,7 @@ ReservationStatus string_to_reservation_status(const std::string& s) {
         return ReservationStatus::Unavailable;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReservationStatus");
+    throw StringToEnumException{s, "ReservationStatus"};
 }
 } // namespace conversions
 
@@ -1521,7 +1513,7 @@ std::string reset_type_to_string(ResetType e) {
         return "Soft";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ResetType");
+    throw EnumToStringException{e, "ResetType"};
 }
 
 ResetType string_to_reset_type(const std::string& s) {
@@ -1532,7 +1524,7 @@ ResetType string_to_reset_type(const std::string& s) {
         return ResetType::Soft;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ResetType");
+    throw StringToEnumException{s, "ResetType"};
 }
 } // namespace conversions
 
@@ -1551,7 +1543,7 @@ std::string reset_status_to_string(ResetStatus e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ResetStatus");
+    throw EnumToStringException{e, "ResetStatus"};
 }
 
 ResetStatus string_to_reset_status(const std::string& s) {
@@ -1562,7 +1554,7 @@ ResetStatus string_to_reset_status(const std::string& s) {
         return ResetStatus::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ResetStatus");
+    throw StringToEnumException{s, "ResetStatus"};
 }
 } // namespace conversions
 
@@ -1581,7 +1573,7 @@ std::string update_type_to_string(UpdateType e) {
         return "Full";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UpdateType");
+    throw EnumToStringException{e, "UpdateType"};
 }
 
 UpdateType string_to_update_type(const std::string& s) {
@@ -1592,7 +1584,7 @@ UpdateType string_to_update_type(const std::string& s) {
         return UpdateType::Full;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UpdateType");
+    throw StringToEnumException{s, "UpdateType"};
 }
 } // namespace conversions
 
@@ -1615,7 +1607,7 @@ std::string update_status_to_string(UpdateStatus e) {
         return "VersionMismatch";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UpdateStatus");
+    throw EnumToStringException{e, "UpdateStatus"};
 }
 
 UpdateStatus string_to_update_status(const std::string& s) {
@@ -1632,7 +1624,7 @@ UpdateStatus string_to_update_status(const std::string& s) {
         return UpdateStatus::VersionMismatch;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UpdateStatus");
+    throw StringToEnumException{s, "UpdateStatus"};
 }
 } // namespace conversions
 
@@ -1653,7 +1645,7 @@ std::string charging_profile_status_to_string(ChargingProfileStatus e) {
         return "NotSupported";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileStatus");
+    throw EnumToStringException{e, "ChargingProfileStatus"};
 }
 
 ChargingProfileStatus string_to_charging_profile_status(const std::string& s) {
@@ -1667,7 +1659,7 @@ ChargingProfileStatus string_to_charging_profile_status(const std::string& s) {
         return ChargingProfileStatus::NotSupported;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingProfileStatus");
+    throw StringToEnumException{s, "ChargingProfileStatus"};
 }
 } // namespace conversions
 
@@ -1686,7 +1678,7 @@ std::string generic_status_enum_type_to_string(GenericStatusEnumType e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GenericStatusEnumType");
+    throw EnumToStringException{e, "GenericStatusEnumType"};
 }
 
 GenericStatusEnumType string_to_generic_status_enum_type(const std::string& s) {
@@ -1697,7 +1689,7 @@ GenericStatusEnumType string_to_generic_status_enum_type(const std::string& s) {
         return GenericStatusEnumType::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type GenericStatusEnumType");
+    throw StringToEnumException{s, "GenericStatusEnumType"};
 }
 } // namespace conversions
 
@@ -1740,7 +1732,7 @@ std::string firmware_status_enum_type_to_string(FirmwareStatusEnumType e) {
         return "SignatureVerified";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type FirmwareStatusEnumType");
+    throw EnumToStringException{e, "FirmwareStatusEnumType"};
 }
 
 FirmwareStatusEnumType string_to_firmware_status_enum_type(const std::string& s) {
@@ -1787,7 +1779,7 @@ FirmwareStatusEnumType string_to_firmware_status_enum_type(const std::string& s)
         return FirmwareStatusEnumType::SignatureVerified;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type FirmwareStatusEnumType");
+    throw StringToEnumException{s, "FirmwareStatusEnumType"};
 }
 } // namespace conversions
 
@@ -1812,7 +1804,7 @@ std::string update_firmware_status_enum_type_to_string(UpdateFirmwareStatusEnumT
         return "RevokedCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UpdateFirmwareStatusEnumType");
+    throw EnumToStringException{e, "UpdateFirmwareStatusEnumType"};
 }
 
 UpdateFirmwareStatusEnumType string_to_update_firmware_status_enum_type(const std::string& s) {
@@ -1832,8 +1824,7 @@ UpdateFirmwareStatusEnumType string_to_update_firmware_status_enum_type(const st
         return UpdateFirmwareStatusEnumType::RevokedCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type UpdateFirmwareStatusEnumType");
+    throw StringToEnumException{s, "UpdateFirmwareStatusEnumType"};
 }
 } // namespace conversions
 
@@ -1880,7 +1871,7 @@ std::string charge_point_error_code_to_string(ChargePointErrorCode e) {
         return "WeakSignal";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargePointErrorCode");
+    throw EnumToStringException{e, "ChargePointErrorCode"};
 }
 
 ChargePointErrorCode string_to_charge_point_error_code(const std::string& s) {
@@ -1933,7 +1924,7 @@ ChargePointErrorCode string_to_charge_point_error_code(const std::string& s) {
         return ChargePointErrorCode::WeakSignal;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargePointErrorCode");
+    throw StringToEnumException{s, "ChargePointErrorCode"};
 }
 } // namespace conversions
 
@@ -1966,7 +1957,7 @@ std::string charge_point_status_to_string(ChargePointStatus e) {
         return "Faulted";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargePointStatus");
+    throw EnumToStringException{e, "ChargePointStatus"};
 }
 
 ChargePointStatus string_to_charge_point_status(const std::string& s) {
@@ -1998,7 +1989,7 @@ ChargePointStatus string_to_charge_point_status(const std::string& s) {
         return ChargePointStatus::Faulted;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargePointStatus");
+    throw StringToEnumException{s, "ChargePointStatus"};
 }
 } // namespace conversions
 
@@ -2035,7 +2026,7 @@ std::string reason_to_string(Reason e) {
         return "DeAuthorized";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type Reason");
+    throw EnumToStringException{e, "Reason"};
 }
 
 Reason string_to_reason(const std::string& s) {
@@ -2073,7 +2064,7 @@ Reason string_to_reason(const std::string& s) {
         return Reason::DeAuthorized;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type Reason");
+    throw StringToEnumException{s, "Reason"};
 }
 } // namespace conversions
 
@@ -2100,7 +2091,7 @@ std::string message_trigger_to_string(MessageTrigger e) {
         return "StatusNotification";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MessageTrigger");
+    throw EnumToStringException{e, "MessageTrigger"};
 }
 
 MessageTrigger string_to_message_trigger(const std::string& s) {
@@ -2123,7 +2114,7 @@ MessageTrigger string_to_message_trigger(const std::string& s) {
         return MessageTrigger::StatusNotification;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageTrigger");
+    throw StringToEnumException{s, "MessageTrigger"};
 }
 } // namespace conversions
 
@@ -2144,7 +2135,7 @@ std::string trigger_message_status_to_string(TriggerMessageStatus e) {
         return "NotImplemented";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type TriggerMessageStatus");
+    throw EnumToStringException{e, "TriggerMessageStatus"};
 }
 
 TriggerMessageStatus string_to_trigger_message_status(const std::string& s) {
@@ -2158,7 +2149,7 @@ TriggerMessageStatus string_to_trigger_message_status(const std::string& s) {
         return TriggerMessageStatus::NotImplemented;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type TriggerMessageStatus");
+    throw StringToEnumException{s, "TriggerMessageStatus"};
 }
 } // namespace conversions
 
@@ -2179,7 +2170,7 @@ std::string unlock_status_to_string(UnlockStatus e) {
         return "NotSupported";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UnlockStatus");
+    throw EnumToStringException{e, "UnlockStatus"};
 }
 
 UnlockStatus string_to_unlock_status(const std::string& s) {
@@ -2193,7 +2184,7 @@ UnlockStatus string_to_unlock_status(const std::string& s) {
         return UnlockStatus::NotSupported;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UnlockStatus");
+    throw StringToEnumException{s, "UnlockStatus"};
 }
 } // namespace conversions
 

--- a/lib/ocpp/v16/types.cpp
+++ b/lib/ocpp/v16/types.cpp
@@ -176,7 +176,7 @@ std::string messagetype_to_string(MessageType m) {
         return "InternalError";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MessageType");
+    throw EnumToStringException{e, "MessageType"};
 }
 
 MessageType string_to_messagetype(const std::string& s) {
@@ -415,7 +415,7 @@ MessageType string_to_messagetype(const std::string& s) {
         return MessageType::UpdateFirmwareResponse;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageType");
+    throw StringToEnumException{s, "MessageType"};
 }
 
 } // namespace conversions
@@ -452,7 +452,7 @@ std::string supported_feature_profiles_to_string(SupportedFeatureProfiles e) {
         return "Custom";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type SupportedFeatureProfiles");
+    throw EnumToStringException{e, "SupportedFeatureProfiles"};
 }
 
 /// \brief Converts the given std::string \p s to SupportedFeatureProfiles
@@ -489,8 +489,7 @@ SupportedFeatureProfiles string_to_supported_feature_profiles(const std::string&
         return SupportedFeatureProfiles::Custom;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type SupportedFeatureProfiles");
+    throw StringToEnumException{s, "SupportedFeatureProfiles"};
 }
 } // namespace conversions
 
@@ -517,7 +516,7 @@ std::string charge_point_connection_state_to_string(ChargePointConnectionState e
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargePointConnectionState");
+    throw EnumToStringException{e, "ChargePointConnectionState"};
 }
 
 ChargePointConnectionState string_to_charge_point_connection_state(const std::string& s) {
@@ -537,8 +536,7 @@ ChargePointConnectionState string_to_charge_point_connection_state(const std::st
         return ChargePointConnectionState::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ChargePointConnectionState");
+    throw StringToEnumException{s, "ChargePointConnectionState"};
 }
 } // namespace conversions
 

--- a/lib/ocpp/v16/types.cpp
+++ b/lib/ocpp/v16/types.cpp
@@ -176,7 +176,7 @@ std::string messagetype_to_string(MessageType m) {
         return "InternalError";
     }
 
-    throw EnumToStringException{e, "MessageType"};
+    throw EnumToStringException{m, "MessageType"};
 }
 
 MessageType string_to_messagetype(const std::string& s) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -376,7 +376,7 @@ ChargePoint::on_get_15118_ev_certificate_request(const Get15118EVCertificateRequ
     try {
         ocpp::CallResult<Get15118EVCertificateResponse> call_result = response_message.message;
         return call_result.msg;
-    } catch (const EnumConversionException &e) {
+    } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         auto call_error = CallError(response_message.uniqueId, "FormationViolation", e.what(), json({}));
         this->send(call_error);
@@ -1359,7 +1359,7 @@ void ChargePoint::message_callback(const std::string& message) {
         EVLOG_error << "JSON exception during reception of message: " << e.what();
         this->send(CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
         return;
-    } catch (const EnumConversionException &e) {
+    } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         auto call_error = CallError(MessageId("-1"), "FormationViolation", e.what(), json({}));
         this->send(call_error);
@@ -1437,7 +1437,7 @@ void ChargePoint::message_callback(const std::string& message) {
         EVLOG_error << "Exception during handling of message: " << e.what();
         auto call_error = CallError(enhanced_message.uniqueId, "OccurrenceConstraintViolation", e.what(), json({}));
         this->send(call_error);
-    } catch (const EnumConversionException &e) {
+    } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
         this->send(call_error);
@@ -2102,7 +2102,7 @@ AuthorizeResponse ChargePoint::authorize_req(const IdToken id_token, const std::
     try {
         ocpp::CallResult<AuthorizeResponse> call_result = enhanced_message.message;
         return call_result.msg;
-    } catch (const EnumConversionException &e) {
+    } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
         this->send(call_error);
@@ -3636,7 +3636,7 @@ std::optional<DataTransferResponse> ChargePoint::data_transfer_req(const DataTra
         try {
             ocpp::CallResult<DataTransferResponse> call_result = enhanced_message.message;
             response = call_result.msg;
-        } catch (const EnumConversionException &e) {
+        } catch (const EnumConversionException& e) {
             EVLOG_error << "EnumConversionException during handling of message: " << e.what();
             auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
             this->send(call_error);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -373,8 +373,15 @@ ChargePoint::on_get_15118_ev_certificate_request(const Get15118EVCertificateRequ
         return response;
     }
 
-    ocpp::CallResult<Get15118EVCertificateResponse> call_result = response_message.message;
-    return call_result.msg;
+    try {
+        ocpp::CallResult<Get15118EVCertificateResponse> call_result = response_message.message;
+        return call_result.msg;
+    } catch (const EnumConversionException &e) {
+        EVLOG_error << "EnumConversionException during handling of message: " << e.what();
+        auto call_error = CallError(response_message.uniqueId, "FormationViolation", e.what(), json({}));
+        this->send(call_error);
+        return response;
+    }
 }
 
 void ChargePoint::on_transaction_started(const int32_t evse_id, const int32_t connector_id,
@@ -1344,7 +1351,21 @@ void ChargePoint::handle_message(const EnhancedMessage<v201::MessageType>& messa
 }
 
 void ChargePoint::message_callback(const std::string& message) {
-    auto enhanced_message = this->message_queue->receive(message);
+    EnhancedMessage<v201::MessageType> enhanced_message;
+    try {
+        enhanced_message = this->message_queue->receive(message);
+    } catch (const json::exception& e) {
+        this->logging->central_system("Unknown", message);
+        EVLOG_error << "JSON exception during reception of message: " << e.what();
+        this->send(CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
+        return;
+    } catch (const EnumConversionException &e) {
+        EVLOG_error << "EnumConversionException during handling of message: " << e.what();
+        auto call_error = CallError(MessageId("-1"), "FormationViolation", e.what(), json({}));
+        this->send(call_error);
+        return;
+    }
+
     enhanced_message.message_size = message.size();
     auto json_message = enhanced_message.message;
     this->logging->central_system(conversions::messagetype_to_string(enhanced_message.messageType), message);
@@ -1414,14 +1435,16 @@ void ChargePoint::message_callback(const std::string& message) {
         }
     } catch (const EvseOutOfRangeException& e) {
         EVLOG_error << "Exception during handling of message: " << e.what();
-        auto call_error = CallError(MessageId(json_message.at(MESSAGE_ID).get<std::string>()),
-                                    "OccurrenceConstraintViolation", e.what(), json({}));
+        auto call_error = CallError(enhanced_message.uniqueId, "OccurrenceConstraintViolation", e.what(), json({}));
+        this->send(call_error);
+    } catch (const EnumConversionException &e) {
+        EVLOG_error << "EnumConversionException during handling of message: " << e.what();
+        auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
         this->send(call_error);
     } catch (json::exception& e) {
         EVLOG_error << "JSON exception during handling of message: " << e.what();
         if (json_message.is_array() && json_message.size() > MESSAGE_ID) {
-            auto call_error = CallError(MessageId(json_message.at(MESSAGE_ID).get<std::string>()), "FormationViolation",
-                                        e.what(), json({}));
+            auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
             this->send(call_error);
         }
     }
@@ -2076,8 +2099,15 @@ AuthorizeResponse ChargePoint::authorize_req(const IdToken id_token, const std::
         return response;
     }
 
-    ocpp::CallResult<AuthorizeResponse> call_result = enhanced_message.message;
-    return call_result.msg;
+    try {
+        ocpp::CallResult<AuthorizeResponse> call_result = enhanced_message.message;
+        return call_result.msg;
+    } catch (const EnumConversionException &e) {
+        EVLOG_error << "EnumConversionException during handling of message: " << e.what();
+        auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
+        this->send(call_error);
+        return response;
+    }
 }
 
 void ChargePoint::status_notification_req(const int32_t evse_id, const int32_t connector_id,
@@ -3603,8 +3633,15 @@ std::optional<DataTransferResponse> ChargePoint::data_transfer_req(const DataTra
 
     auto enhanced_message = data_transfer_future.get();
     if (enhanced_message.messageType == MessageType::DataTransferResponse) {
-        ocpp::CallResult<DataTransferResponse> call_result = enhanced_message.message;
-        response = call_result.msg;
+        try {
+            ocpp::CallResult<DataTransferResponse> call_result = enhanced_message.message;
+            response = call_result.msg;
+        } catch (const EnumConversionException &e) {
+            EVLOG_error << "EnumConversionException during handling of message: " << e.what();
+            auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
+            this->send(call_error);
+            return std::nullopt;
+        }
     }
     if (enhanced_message.offline) {
         return std::nullopt;

--- a/lib/ocpp/v201/connector.cpp
+++ b/lib/ocpp/v201/connector.cpp
@@ -30,7 +30,7 @@ std::string connector_event_to_string(ConnectorEvent e) {
         return "ErrorCleared";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ConnectorEvent");
+    throw EnumToStringException{e, "ConnectorEvent"};
 }
 
 } // namespace conversions

--- a/lib/ocpp/v201/init_device_model_db.cpp
+++ b/lib/ocpp/v201/init_device_model_db.cpp
@@ -730,7 +730,7 @@ InitDeviceModelDb::get_config_values(const std::filesystem::path& config_file_pa
                     key.name = variable.value().at("variable_name");
                     try {
                         key.attribute_type = conversions::string_to_attribute_enum(attributes.key());
-                    } catch (const std::out_of_range& /* e*/) {
+                    } catch (const StringToEnumException& /* e*/) {
                         EVLOG_error << "Could not find type " << attributes.key() << " of component " << p.name
                                     << " and variable " << key.name;
                         throw InitDeviceModelDbError("Could not find type " + attributes.key() + " of component " +

--- a/lib/ocpp/v201/ocpp_enums.cpp
+++ b/lib/ocpp/v201/ocpp_enums.cpp
@@ -4,8 +4,9 @@
 
 #include <ocpp/v201/ocpp_enums.hpp>
 
-#include <stdexcept>
 #include <string>
+
+#include <ocpp/common/types.hpp>
 
 namespace ocpp {
 namespace v201 {
@@ -32,7 +33,7 @@ std::string id_token_enum_to_string(IdTokenEnum e) {
         return "NoAuthorization";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type IdTokenEnum");
+    throw EnumToStringException{e, "IdTokenEnum"};
 }
 
 IdTokenEnum string_to_id_token_enum(const std::string& s) {
@@ -61,7 +62,7 @@ IdTokenEnum string_to_id_token_enum(const std::string& s) {
         return IdTokenEnum::NoAuthorization;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type IdTokenEnum");
+    throw StringToEnumException{s, "IdTokenEnum"};
 }
 } // namespace conversions
 
@@ -82,7 +83,7 @@ std::string hash_algorithm_enum_to_string(HashAlgorithmEnum e) {
         return "SHA512";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type HashAlgorithmEnum");
+    throw EnumToStringException{e, "HashAlgorithmEnum"};
 }
 
 HashAlgorithmEnum string_to_hash_algorithm_enum(const std::string& s) {
@@ -96,7 +97,7 @@ HashAlgorithmEnum string_to_hash_algorithm_enum(const std::string& s) {
         return HashAlgorithmEnum::SHA512;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type HashAlgorithmEnum");
+    throw StringToEnumException{s, "HashAlgorithmEnum"};
 }
 } // namespace conversions
 
@@ -131,7 +132,7 @@ std::string authorization_status_enum_to_string(AuthorizationStatusEnum e) {
         return "Unknown";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type AuthorizationStatusEnum");
+    throw EnumToStringException{e, "AuthorizationStatusEnum"};
 }
 
 AuthorizationStatusEnum string_to_authorization_status_enum(const std::string& s) {
@@ -166,7 +167,7 @@ AuthorizationStatusEnum string_to_authorization_status_enum(const std::string& s
         return AuthorizationStatusEnum::Unknown;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AuthorizationStatusEnum");
+    throw StringToEnumException{s, "AuthorizationStatusEnum"};
 }
 } // namespace conversions
 
@@ -189,7 +190,7 @@ std::string message_format_enum_to_string(MessageFormatEnum e) {
         return "UTF8";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MessageFormatEnum");
+    throw EnumToStringException{e, "MessageFormatEnum"};
 }
 
 MessageFormatEnum string_to_message_format_enum(const std::string& s) {
@@ -206,7 +207,7 @@ MessageFormatEnum string_to_message_format_enum(const std::string& s) {
         return MessageFormatEnum::UTF8;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageFormatEnum");
+    throw StringToEnumException{s, "MessageFormatEnum"};
 }
 } // namespace conversions
 
@@ -235,7 +236,7 @@ std::string authorize_certificate_status_enum_to_string(AuthorizeCertificateStat
         return "ContractCancelled";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type AuthorizeCertificateStatusEnum");
+    throw EnumToStringException{e, "AuthorizeCertificateStatusEnum"};
 }
 
 AuthorizeCertificateStatusEnum string_to_authorize_certificate_status_enum(const std::string& s) {
@@ -261,8 +262,7 @@ AuthorizeCertificateStatusEnum string_to_authorize_certificate_status_enum(const
         return AuthorizeCertificateStatusEnum::ContractCancelled;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type AuthorizeCertificateStatusEnum");
+    throw StringToEnumException{s, "AuthorizeCertificateStatusEnum"};
 }
 } // namespace conversions
 
@@ -295,7 +295,7 @@ std::string boot_reason_enum_to_string(BootReasonEnum e) {
         return "Watchdog";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type BootReasonEnum");
+    throw EnumToStringException{e, "BootReasonEnum"};
 }
 
 BootReasonEnum string_to_boot_reason_enum(const std::string& s) {
@@ -327,7 +327,7 @@ BootReasonEnum string_to_boot_reason_enum(const std::string& s) {
         return BootReasonEnum::Watchdog;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type BootReasonEnum");
+    throw StringToEnumException{s, "BootReasonEnum"};
 }
 } // namespace conversions
 
@@ -348,7 +348,7 @@ std::string registration_status_enum_to_string(RegistrationStatusEnum e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type RegistrationStatusEnum");
+    throw EnumToStringException{e, "RegistrationStatusEnum"};
 }
 
 RegistrationStatusEnum string_to_registration_status_enum(const std::string& s) {
@@ -362,7 +362,7 @@ RegistrationStatusEnum string_to_registration_status_enum(const std::string& s) 
         return RegistrationStatusEnum::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RegistrationStatusEnum");
+    throw StringToEnumException{s, "RegistrationStatusEnum"};
 }
 } // namespace conversions
 
@@ -381,7 +381,7 @@ std::string cancel_reservation_status_enum_to_string(CancelReservationStatusEnum
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CancelReservationStatusEnum");
+    throw EnumToStringException{e, "CancelReservationStatusEnum"};
 }
 
 CancelReservationStatusEnum string_to_cancel_reservation_status_enum(const std::string& s) {
@@ -392,8 +392,7 @@ CancelReservationStatusEnum string_to_cancel_reservation_status_enum(const std::
         return CancelReservationStatusEnum::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type CancelReservationStatusEnum");
+    throw StringToEnumException{s, "CancelReservationStatusEnum"};
 }
 } // namespace conversions
 
@@ -412,7 +411,7 @@ std::string certificate_signing_use_enum_to_string(CertificateSigningUseEnum e) 
         return "V2GCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateSigningUseEnum");
+    throw EnumToStringException{e, "CertificateSigningUseEnum"};
 }
 
 CertificateSigningUseEnum string_to_certificate_signing_use_enum(const std::string& s) {
@@ -423,8 +422,7 @@ CertificateSigningUseEnum string_to_certificate_signing_use_enum(const std::stri
         return CertificateSigningUseEnum::V2GCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type CertificateSigningUseEnum");
+    throw StringToEnumException{s, "CertificateSigningUseEnum"};
 }
 } // namespace conversions
 
@@ -443,7 +441,7 @@ std::string certificate_signed_status_enum_to_string(CertificateSignedStatusEnum
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateSignedStatusEnum");
+    throw EnumToStringException{e, "CertificateSignedStatusEnum"};
 }
 
 CertificateSignedStatusEnum string_to_certificate_signed_status_enum(const std::string& s) {
@@ -454,8 +452,7 @@ CertificateSignedStatusEnum string_to_certificate_signed_status_enum(const std::
         return CertificateSignedStatusEnum::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type CertificateSignedStatusEnum");
+    throw StringToEnumException{s, "CertificateSignedStatusEnum"};
 }
 } // namespace conversions
 
@@ -474,7 +471,7 @@ std::string operational_status_enum_to_string(OperationalStatusEnum e) {
         return "Operative";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type OperationalStatusEnum");
+    throw EnumToStringException{e, "OperationalStatusEnum"};
 }
 
 OperationalStatusEnum string_to_operational_status_enum(const std::string& s) {
@@ -485,7 +482,7 @@ OperationalStatusEnum string_to_operational_status_enum(const std::string& s) {
         return OperationalStatusEnum::Operative;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type OperationalStatusEnum");
+    throw StringToEnumException{s, "OperationalStatusEnum"};
 }
 } // namespace conversions
 
@@ -506,7 +503,7 @@ std::string change_availability_status_enum_to_string(ChangeAvailabilityStatusEn
         return "Scheduled";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChangeAvailabilityStatusEnum");
+    throw EnumToStringException{e, "ChangeAvailabilityStatusEnum"};
 }
 
 ChangeAvailabilityStatusEnum string_to_change_availability_status_enum(const std::string& s) {
@@ -520,8 +517,7 @@ ChangeAvailabilityStatusEnum string_to_change_availability_status_enum(const std
         return ChangeAvailabilityStatusEnum::Scheduled;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ChangeAvailabilityStatusEnum");
+    throw StringToEnumException{s, "ChangeAvailabilityStatusEnum"};
 }
 } // namespace conversions
 
@@ -540,7 +536,7 @@ std::string clear_cache_status_enum_to_string(ClearCacheStatusEnum e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ClearCacheStatusEnum");
+    throw EnumToStringException{e, "ClearCacheStatusEnum"};
 }
 
 ClearCacheStatusEnum string_to_clear_cache_status_enum(const std::string& s) {
@@ -551,7 +547,7 @@ ClearCacheStatusEnum string_to_clear_cache_status_enum(const std::string& s) {
         return ClearCacheStatusEnum::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ClearCacheStatusEnum");
+    throw StringToEnumException{s, "ClearCacheStatusEnum"};
 }
 } // namespace conversions
 
@@ -574,7 +570,7 @@ std::string charging_profile_purpose_enum_to_string(ChargingProfilePurposeEnum e
         return "TxProfile";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfilePurposeEnum");
+    throw EnumToStringException{e, "ChargingProfilePurposeEnum"};
 }
 
 ChargingProfilePurposeEnum string_to_charging_profile_purpose_enum(const std::string& s) {
@@ -591,8 +587,7 @@ ChargingProfilePurposeEnum string_to_charging_profile_purpose_enum(const std::st
         return ChargingProfilePurposeEnum::TxProfile;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ChargingProfilePurposeEnum");
+    throw StringToEnumException{s, "ChargingProfilePurposeEnum"};
 }
 } // namespace conversions
 
@@ -611,7 +606,7 @@ std::string clear_charging_profile_status_enum_to_string(ClearChargingProfileSta
         return "Unknown";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ClearChargingProfileStatusEnum");
+    throw EnumToStringException{e, "ClearChargingProfileStatusEnum"};
 }
 
 ClearChargingProfileStatusEnum string_to_clear_charging_profile_status_enum(const std::string& s) {
@@ -622,8 +617,7 @@ ClearChargingProfileStatusEnum string_to_clear_charging_profile_status_enum(cons
         return ClearChargingProfileStatusEnum::Unknown;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ClearChargingProfileStatusEnum");
+    throw StringToEnumException{s, "ClearChargingProfileStatusEnum"};
 }
 } // namespace conversions
 
@@ -642,7 +636,7 @@ std::string clear_message_status_enum_to_string(ClearMessageStatusEnum e) {
         return "Unknown";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ClearMessageStatusEnum");
+    throw EnumToStringException{e, "ClearMessageStatusEnum"};
 }
 
 ClearMessageStatusEnum string_to_clear_message_status_enum(const std::string& s) {
@@ -653,7 +647,7 @@ ClearMessageStatusEnum string_to_clear_message_status_enum(const std::string& s)
         return ClearMessageStatusEnum::Unknown;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ClearMessageStatusEnum");
+    throw StringToEnumException{s, "ClearMessageStatusEnum"};
 }
 } // namespace conversions
 
@@ -674,7 +668,7 @@ std::string clear_monitoring_status_enum_to_string(ClearMonitoringStatusEnum e) 
         return "NotFound";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ClearMonitoringStatusEnum");
+    throw EnumToStringException{e, "ClearMonitoringStatusEnum"};
 }
 
 ClearMonitoringStatusEnum string_to_clear_monitoring_status_enum(const std::string& s) {
@@ -688,8 +682,7 @@ ClearMonitoringStatusEnum string_to_clear_monitoring_status_enum(const std::stri
         return ClearMonitoringStatusEnum::NotFound;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ClearMonitoringStatusEnum");
+    throw StringToEnumException{s, "ClearMonitoringStatusEnum"};
 }
 } // namespace conversions
 
@@ -712,7 +705,7 @@ std::string charging_limit_source_enum_to_string(ChargingLimitSourceEnum e) {
         return "CSO";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingLimitSourceEnum");
+    throw EnumToStringException{e, "ChargingLimitSourceEnum"};
 }
 
 ChargingLimitSourceEnum string_to_charging_limit_source_enum(const std::string& s) {
@@ -729,7 +722,7 @@ ChargingLimitSourceEnum string_to_charging_limit_source_enum(const std::string& 
         return ChargingLimitSourceEnum::CSO;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingLimitSourceEnum");
+    throw StringToEnumException{s, "ChargingLimitSourceEnum"};
 }
 } // namespace conversions
 
@@ -750,7 +743,7 @@ std::string customer_information_status_enum_to_string(CustomerInformationStatus
         return "Invalid";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CustomerInformationStatusEnum");
+    throw EnumToStringException{e, "CustomerInformationStatusEnum"};
 }
 
 CustomerInformationStatusEnum string_to_customer_information_status_enum(const std::string& s) {
@@ -764,8 +757,7 @@ CustomerInformationStatusEnum string_to_customer_information_status_enum(const s
         return CustomerInformationStatusEnum::Invalid;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type CustomerInformationStatusEnum");
+    throw StringToEnumException{s, "CustomerInformationStatusEnum"};
 }
 } // namespace conversions
 
@@ -788,7 +780,7 @@ std::string data_transfer_status_enum_to_string(DataTransferStatusEnum e) {
         return "UnknownVendorId";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DataTransferStatusEnum");
+    throw EnumToStringException{e, "DataTransferStatusEnum"};
 }
 
 DataTransferStatusEnum string_to_data_transfer_status_enum(const std::string& s) {
@@ -805,7 +797,7 @@ DataTransferStatusEnum string_to_data_transfer_status_enum(const std::string& s)
         return DataTransferStatusEnum::UnknownVendorId;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type DataTransferStatusEnum");
+    throw StringToEnumException{s, "DataTransferStatusEnum"};
 }
 } // namespace conversions
 
@@ -826,7 +818,7 @@ std::string delete_certificate_status_enum_to_string(DeleteCertificateStatusEnum
         return "NotFound";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DeleteCertificateStatusEnum");
+    throw EnumToStringException{e, "DeleteCertificateStatusEnum"};
 }
 
 DeleteCertificateStatusEnum string_to_delete_certificate_status_enum(const std::string& s) {
@@ -840,8 +832,7 @@ DeleteCertificateStatusEnum string_to_delete_certificate_status_enum(const std::
         return DeleteCertificateStatusEnum::NotFound;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type DeleteCertificateStatusEnum");
+    throw StringToEnumException{s, "DeleteCertificateStatusEnum"};
 }
 } // namespace conversions
 
@@ -884,7 +875,7 @@ std::string firmware_status_enum_to_string(FirmwareStatusEnum e) {
         return "SignatureVerified";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type FirmwareStatusEnum");
+    throw EnumToStringException{e, "FirmwareStatusEnum"};
 }
 
 FirmwareStatusEnum string_to_firmware_status_enum(const std::string& s) {
@@ -931,7 +922,7 @@ FirmwareStatusEnum string_to_firmware_status_enum(const std::string& s) {
         return FirmwareStatusEnum::SignatureVerified;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type FirmwareStatusEnum");
+    throw StringToEnumException{s, "FirmwareStatusEnum"};
 }
 } // namespace conversions
 
@@ -950,7 +941,7 @@ std::string certificate_action_enum_to_string(CertificateActionEnum e) {
         return "Update";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CertificateActionEnum");
+    throw EnumToStringException{e, "CertificateActionEnum"};
 }
 
 CertificateActionEnum string_to_certificate_action_enum(const std::string& s) {
@@ -961,7 +952,7 @@ CertificateActionEnum string_to_certificate_action_enum(const std::string& s) {
         return CertificateActionEnum::Update;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type CertificateActionEnum");
+    throw StringToEnumException{s, "CertificateActionEnum"};
 }
 } // namespace conversions
 
@@ -980,7 +971,7 @@ std::string iso15118evcertificate_status_enum_to_string(Iso15118EVCertificateSta
         return "Failed";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type Iso15118EVCertificateStatusEnum");
+    throw EnumToStringException{e, "Iso15118EVCertificateStatusEnum"};
 }
 
 Iso15118EVCertificateStatusEnum string_to_iso15118evcertificate_status_enum(const std::string& s) {
@@ -991,8 +982,7 @@ Iso15118EVCertificateStatusEnum string_to_iso15118evcertificate_status_enum(cons
         return Iso15118EVCertificateStatusEnum::Failed;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type Iso15118EVCertificateStatusEnum");
+    throw StringToEnumException{s, "Iso15118EVCertificateStatusEnum"};
 }
 } // namespace conversions
 
@@ -1013,7 +1003,7 @@ std::string report_base_enum_to_string(ReportBaseEnum e) {
         return "SummaryInventory";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ReportBaseEnum");
+    throw EnumToStringException{e, "ReportBaseEnum"};
 }
 
 ReportBaseEnum string_to_report_base_enum(const std::string& s) {
@@ -1027,7 +1017,7 @@ ReportBaseEnum string_to_report_base_enum(const std::string& s) {
         return ReportBaseEnum::SummaryInventory;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReportBaseEnum");
+    throw StringToEnumException{s, "ReportBaseEnum"};
 }
 } // namespace conversions
 
@@ -1050,7 +1040,7 @@ std::string generic_device_model_status_enum_to_string(GenericDeviceModelStatusE
         return "EmptyResultSet";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GenericDeviceModelStatusEnum");
+    throw EnumToStringException{e, "GenericDeviceModelStatusEnum"};
 }
 
 GenericDeviceModelStatusEnum string_to_generic_device_model_status_enum(const std::string& s) {
@@ -1067,8 +1057,7 @@ GenericDeviceModelStatusEnum string_to_generic_device_model_status_enum(const st
         return GenericDeviceModelStatusEnum::EmptyResultSet;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type GenericDeviceModelStatusEnum");
+    throw StringToEnumException{s, "GenericDeviceModelStatusEnum"};
 }
 } // namespace conversions
 
@@ -1087,7 +1076,7 @@ std::string get_certificate_status_enum_to_string(GetCertificateStatusEnum e) {
         return "Failed";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GetCertificateStatusEnum");
+    throw EnumToStringException{e, "GetCertificateStatusEnum"};
 }
 
 GetCertificateStatusEnum string_to_get_certificate_status_enum(const std::string& s) {
@@ -1098,8 +1087,7 @@ GetCertificateStatusEnum string_to_get_certificate_status_enum(const std::string
         return GetCertificateStatusEnum::Failed;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type GetCertificateStatusEnum");
+    throw StringToEnumException{s, "GetCertificateStatusEnum"};
 }
 } // namespace conversions
 
@@ -1118,7 +1106,7 @@ std::string get_charging_profile_status_enum_to_string(GetChargingProfileStatusE
         return "NoProfiles";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GetChargingProfileStatusEnum");
+    throw EnumToStringException{e, "GetChargingProfileStatusEnum"};
 }
 
 GetChargingProfileStatusEnum string_to_get_charging_profile_status_enum(const std::string& s) {
@@ -1129,8 +1117,7 @@ GetChargingProfileStatusEnum string_to_get_charging_profile_status_enum(const st
         return GetChargingProfileStatusEnum::NoProfiles;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type GetChargingProfileStatusEnum");
+    throw StringToEnumException{s, "GetChargingProfileStatusEnum"};
 }
 } // namespace conversions
 
@@ -1149,7 +1136,7 @@ std::string charging_rate_unit_enum_to_string(ChargingRateUnitEnum e) {
         return "A";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingRateUnitEnum");
+    throw EnumToStringException{e, "ChargingRateUnitEnum"};
 }
 
 ChargingRateUnitEnum string_to_charging_rate_unit_enum(const std::string& s) {
@@ -1160,7 +1147,7 @@ ChargingRateUnitEnum string_to_charging_rate_unit_enum(const std::string& s) {
         return ChargingRateUnitEnum::A;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingRateUnitEnum");
+    throw StringToEnumException{s, "ChargingRateUnitEnum"};
 }
 } // namespace conversions
 
@@ -1179,7 +1166,7 @@ std::string generic_status_enum_to_string(GenericStatusEnum e) {
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GenericStatusEnum");
+    throw EnumToStringException{e, "GenericStatusEnum"};
 }
 
 GenericStatusEnum string_to_generic_status_enum(const std::string& s) {
@@ -1190,7 +1177,7 @@ GenericStatusEnum string_to_generic_status_enum(const std::string& s) {
         return GenericStatusEnum::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type GenericStatusEnum");
+    throw StringToEnumException{s, "GenericStatusEnum"};
 }
 } // namespace conversions
 
@@ -1211,7 +1198,7 @@ std::string message_priority_enum_to_string(MessagePriorityEnum e) {
         return "NormalCycle";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MessagePriorityEnum");
+    throw EnumToStringException{e, "MessagePriorityEnum"};
 }
 
 MessagePriorityEnum string_to_message_priority_enum(const std::string& s) {
@@ -1225,7 +1212,7 @@ MessagePriorityEnum string_to_message_priority_enum(const std::string& s) {
         return MessagePriorityEnum::NormalCycle;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessagePriorityEnum");
+    throw StringToEnumException{s, "MessagePriorityEnum"};
 }
 } // namespace conversions
 
@@ -1248,7 +1235,7 @@ std::string message_state_enum_to_string(MessageStateEnum e) {
         return "Unavailable";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MessageStateEnum");
+    throw EnumToStringException{e, "MessageStateEnum"};
 }
 
 MessageStateEnum string_to_message_state_enum(const std::string& s) {
@@ -1265,7 +1252,7 @@ MessageStateEnum string_to_message_state_enum(const std::string& s) {
         return MessageStateEnum::Unavailable;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageStateEnum");
+    throw StringToEnumException{s, "MessageStateEnum"};
 }
 } // namespace conversions
 
@@ -1284,7 +1271,7 @@ std::string get_display_messages_status_enum_to_string(GetDisplayMessagesStatusE
         return "Unknown";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GetDisplayMessagesStatusEnum");
+    throw EnumToStringException{e, "GetDisplayMessagesStatusEnum"};
 }
 
 GetDisplayMessagesStatusEnum string_to_get_display_messages_status_enum(const std::string& s) {
@@ -1295,8 +1282,7 @@ GetDisplayMessagesStatusEnum string_to_get_display_messages_status_enum(const st
         return GetDisplayMessagesStatusEnum::Unknown;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type GetDisplayMessagesStatusEnum");
+    throw StringToEnumException{s, "GetDisplayMessagesStatusEnum"};
 }
 } // namespace conversions
 
@@ -1321,7 +1307,7 @@ std::string get_certificate_id_use_enum_to_string(GetCertificateIdUseEnum e) {
         return "ManufacturerRootCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GetCertificateIdUseEnum");
+    throw EnumToStringException{e, "GetCertificateIdUseEnum"};
 }
 
 GetCertificateIdUseEnum string_to_get_certificate_id_use_enum(const std::string& s) {
@@ -1341,7 +1327,7 @@ GetCertificateIdUseEnum string_to_get_certificate_id_use_enum(const std::string&
         return GetCertificateIdUseEnum::ManufacturerRootCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type GetCertificateIdUseEnum");
+    throw StringToEnumException{s, "GetCertificateIdUseEnum"};
 }
 } // namespace conversions
 
@@ -1360,7 +1346,7 @@ std::string get_installed_certificate_status_enum_to_string(GetInstalledCertific
         return "NotFound";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GetInstalledCertificateStatusEnum");
+    throw EnumToStringException{e, "GetInstalledCertificateStatusEnum"};
 }
 
 GetInstalledCertificateStatusEnum string_to_get_installed_certificate_status_enum(const std::string& s) {
@@ -1371,8 +1357,7 @@ GetInstalledCertificateStatusEnum string_to_get_installed_certificate_status_enu
         return GetInstalledCertificateStatusEnum::NotFound;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type GetInstalledCertificateStatusEnum");
+    throw StringToEnumException{s, "GetInstalledCertificateStatusEnum"};
 }
 } // namespace conversions
 
@@ -1392,7 +1377,7 @@ std::string log_enum_to_string(LogEnum e) {
         return "SecurityLog";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type LogEnum");
+    throw EnumToStringException{e, "LogEnum"};
 }
 
 LogEnum string_to_log_enum(const std::string& s) {
@@ -1403,7 +1388,7 @@ LogEnum string_to_log_enum(const std::string& s) {
         return LogEnum::SecurityLog;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type LogEnum");
+    throw StringToEnumException{s, "LogEnum"};
 }
 } // namespace conversions
 
@@ -1424,7 +1409,7 @@ std::string log_status_enum_to_string(LogStatusEnum e) {
         return "AcceptedCanceled";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type LogStatusEnum");
+    throw EnumToStringException{e, "LogStatusEnum"};
 }
 
 LogStatusEnum string_to_log_status_enum(const std::string& s) {
@@ -1438,7 +1423,7 @@ LogStatusEnum string_to_log_status_enum(const std::string& s) {
         return LogStatusEnum::AcceptedCanceled;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type LogStatusEnum");
+    throw StringToEnumException{s, "LogStatusEnum"};
 }
 } // namespace conversions
 
@@ -1459,7 +1444,7 @@ std::string monitoring_criterion_enum_to_string(MonitoringCriterionEnum e) {
         return "PeriodicMonitoring";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MonitoringCriterionEnum");
+    throw EnumToStringException{e, "MonitoringCriterionEnum"};
 }
 
 MonitoringCriterionEnum string_to_monitoring_criterion_enum(const std::string& s) {
@@ -1473,7 +1458,7 @@ MonitoringCriterionEnum string_to_monitoring_criterion_enum(const std::string& s
         return MonitoringCriterionEnum::PeriodicMonitoring;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MonitoringCriterionEnum");
+    throw StringToEnumException{s, "MonitoringCriterionEnum"};
 }
 } // namespace conversions
 
@@ -1496,7 +1481,7 @@ std::string component_criterion_enum_to_string(ComponentCriterionEnum e) {
         return "Problem";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ComponentCriterionEnum");
+    throw EnumToStringException{e, "ComponentCriterionEnum"};
 }
 
 ComponentCriterionEnum string_to_component_criterion_enum(const std::string& s) {
@@ -1513,7 +1498,7 @@ ComponentCriterionEnum string_to_component_criterion_enum(const std::string& s) 
         return ComponentCriterionEnum::Problem;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ComponentCriterionEnum");
+    throw StringToEnumException{s, "ComponentCriterionEnum"};
 }
 } // namespace conversions
 
@@ -1536,7 +1521,7 @@ std::string attribute_enum_to_string(AttributeEnum e) {
         return "MaxSet";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type AttributeEnum");
+    throw EnumToStringException{e, "AttributeEnum"};
 }
 
 AttributeEnum string_to_attribute_enum(const std::string& s) {
@@ -1553,7 +1538,7 @@ AttributeEnum string_to_attribute_enum(const std::string& s) {
         return AttributeEnum::MaxSet;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type AttributeEnum");
+    throw StringToEnumException{s, "AttributeEnum"};
 }
 } // namespace conversions
 
@@ -1578,7 +1563,7 @@ std::string get_variable_status_enum_to_string(GetVariableStatusEnum e) {
         return "NotSupportedAttributeType";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type GetVariableStatusEnum");
+    throw EnumToStringException{e, "GetVariableStatusEnum"};
 }
 
 GetVariableStatusEnum string_to_get_variable_status_enum(const std::string& s) {
@@ -1598,7 +1583,7 @@ GetVariableStatusEnum string_to_get_variable_status_enum(const std::string& s) {
         return GetVariableStatusEnum::NotSupportedAttributeType;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type GetVariableStatusEnum");
+    throw StringToEnumException{s, "GetVariableStatusEnum"};
 }
 } // namespace conversions
 
@@ -1621,7 +1606,7 @@ std::string install_certificate_use_enum_to_string(InstallCertificateUseEnum e) 
         return "ManufacturerRootCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type InstallCertificateUseEnum");
+    throw EnumToStringException{e, "InstallCertificateUseEnum"};
 }
 
 InstallCertificateUseEnum string_to_install_certificate_use_enum(const std::string& s) {
@@ -1638,8 +1623,7 @@ InstallCertificateUseEnum string_to_install_certificate_use_enum(const std::stri
         return InstallCertificateUseEnum::ManufacturerRootCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type InstallCertificateUseEnum");
+    throw StringToEnumException{s, "InstallCertificateUseEnum"};
 }
 } // namespace conversions
 
@@ -1660,7 +1644,7 @@ std::string install_certificate_status_enum_to_string(InstallCertificateStatusEn
         return "Failed";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type InstallCertificateStatusEnum");
+    throw EnumToStringException{e, "InstallCertificateStatusEnum"};
 }
 
 InstallCertificateStatusEnum string_to_install_certificate_status_enum(const std::string& s) {
@@ -1674,8 +1658,7 @@ InstallCertificateStatusEnum string_to_install_certificate_status_enum(const std
         return InstallCertificateStatusEnum::Failed;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type InstallCertificateStatusEnum");
+    throw StringToEnumException{s, "InstallCertificateStatusEnum"};
 }
 } // namespace conversions
 
@@ -1706,7 +1689,7 @@ std::string upload_log_status_enum_to_string(UploadLogStatusEnum e) {
         return "AcceptedCanceled";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UploadLogStatusEnum");
+    throw EnumToStringException{e, "UploadLogStatusEnum"};
 }
 
 UploadLogStatusEnum string_to_upload_log_status_enum(const std::string& s) {
@@ -1735,7 +1718,7 @@ UploadLogStatusEnum string_to_upload_log_status_enum(const std::string& s) {
         return UploadLogStatusEnum::AcceptedCanceled;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UploadLogStatusEnum");
+    throw StringToEnumException{s, "UploadLogStatusEnum"};
 }
 } // namespace conversions
 
@@ -1766,7 +1749,7 @@ std::string reading_context_enum_to_string(ReadingContextEnum e) {
         return "Trigger";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ReadingContextEnum");
+    throw EnumToStringException{e, "ReadingContextEnum"};
 }
 
 ReadingContextEnum string_to_reading_context_enum(const std::string& s) {
@@ -1795,7 +1778,7 @@ ReadingContextEnum string_to_reading_context_enum(const std::string& s) {
         return ReadingContextEnum::Trigger;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReadingContextEnum");
+    throw StringToEnumException{s, "ReadingContextEnum"};
 }
 } // namespace conversions
 
@@ -1860,7 +1843,7 @@ std::string measurand_enum_to_string(MeasurandEnum e) {
         return "Voltage";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MeasurandEnum");
+    throw EnumToStringException{e, "MeasurandEnum"};
 }
 
 MeasurandEnum string_to_measurand_enum(const std::string& s) {
@@ -1940,7 +1923,7 @@ MeasurandEnum string_to_measurand_enum(const std::string& s) {
         return MeasurandEnum::Voltage;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MeasurandEnum");
+    throw StringToEnumException{s, "MeasurandEnum"};
 }
 } // namespace conversions
 
@@ -1975,7 +1958,7 @@ std::string phase_enum_to_string(PhaseEnum e) {
         return "L3-L1";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type PhaseEnum");
+    throw EnumToStringException{e, "PhaseEnum"};
 }
 
 PhaseEnum string_to_phase_enum(const std::string& s) {
@@ -2010,7 +1993,7 @@ PhaseEnum string_to_phase_enum(const std::string& s) {
         return PhaseEnum::L3_L1;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type PhaseEnum");
+    throw StringToEnumException{s, "PhaseEnum"};
 }
 } // namespace conversions
 
@@ -2035,7 +2018,7 @@ std::string location_enum_to_string(LocationEnum e) {
         return "Outlet";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type LocationEnum");
+    throw EnumToStringException{e, "LocationEnum"};
 }
 
 LocationEnum string_to_location_enum(const std::string& s) {
@@ -2055,7 +2038,7 @@ LocationEnum string_to_location_enum(const std::string& s) {
         return LocationEnum::Outlet;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type LocationEnum");
+    throw StringToEnumException{s, "LocationEnum"};
 }
 } // namespace conversions
 
@@ -2076,7 +2059,7 @@ std::string cost_kind_enum_to_string(CostKindEnum e) {
         return "RenewableGenerationPercentage";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type CostKindEnum");
+    throw EnumToStringException{e, "CostKindEnum"};
 }
 
 CostKindEnum string_to_cost_kind_enum(const std::string& s) {
@@ -2090,7 +2073,7 @@ CostKindEnum string_to_cost_kind_enum(const std::string& s) {
         return CostKindEnum::RenewableGenerationPercentage;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type CostKindEnum");
+    throw StringToEnumException{s, "CostKindEnum"};
 }
 } // namespace conversions
 
@@ -2113,7 +2096,7 @@ std::string energy_transfer_mode_enum_to_string(EnergyTransferModeEnum e) {
         return "AC_three_phase";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type EnergyTransferModeEnum");
+    throw EnumToStringException{e, "EnergyTransferModeEnum"};
 }
 
 EnergyTransferModeEnum string_to_energy_transfer_mode_enum(const std::string& s) {
@@ -2130,7 +2113,7 @@ EnergyTransferModeEnum string_to_energy_transfer_mode_enum(const std::string& s)
         return EnergyTransferModeEnum::AC_three_phase;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type EnergyTransferModeEnum");
+    throw StringToEnumException{s, "EnergyTransferModeEnum"};
 }
 } // namespace conversions
 
@@ -2151,7 +2134,7 @@ std::string notify_evcharging_needs_status_enum_to_string(NotifyEVChargingNeedsS
         return "Processing";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type NotifyEVChargingNeedsStatusEnum");
+    throw EnumToStringException{e, "NotifyEVChargingNeedsStatusEnum"};
 }
 
 NotifyEVChargingNeedsStatusEnum string_to_notify_evcharging_needs_status_enum(const std::string& s) {
@@ -2165,8 +2148,7 @@ NotifyEVChargingNeedsStatusEnum string_to_notify_evcharging_needs_status_enum(co
         return NotifyEVChargingNeedsStatusEnum::Processing;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type NotifyEVChargingNeedsStatusEnum");
+    throw StringToEnumException{s, "NotifyEVChargingNeedsStatusEnum"};
 }
 } // namespace conversions
 
@@ -2187,7 +2169,7 @@ std::string event_trigger_enum_to_string(EventTriggerEnum e) {
         return "Periodic";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type EventTriggerEnum");
+    throw EnumToStringException{e, "EventTriggerEnum"};
 }
 
 EventTriggerEnum string_to_event_trigger_enum(const std::string& s) {
@@ -2201,7 +2183,7 @@ EventTriggerEnum string_to_event_trigger_enum(const std::string& s) {
         return EventTriggerEnum::Periodic;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type EventTriggerEnum");
+    throw StringToEnumException{s, "EventTriggerEnum"};
 }
 } // namespace conversions
 
@@ -2224,7 +2206,7 @@ std::string event_notification_enum_to_string(EventNotificationEnum e) {
         return "CustomMonitor";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type EventNotificationEnum");
+    throw EnumToStringException{e, "EventNotificationEnum"};
 }
 
 EventNotificationEnum string_to_event_notification_enum(const std::string& s) {
@@ -2241,7 +2223,7 @@ EventNotificationEnum string_to_event_notification_enum(const std::string& s) {
         return EventNotificationEnum::CustomMonitor;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type EventNotificationEnum");
+    throw StringToEnumException{s, "EventNotificationEnum"};
 }
 } // namespace conversions
 
@@ -2266,7 +2248,7 @@ std::string monitor_enum_to_string(MonitorEnum e) {
         return "PeriodicClockAligned";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MonitorEnum");
+    throw EnumToStringException{e, "MonitorEnum"};
 }
 
 MonitorEnum string_to_monitor_enum(const std::string& s) {
@@ -2286,7 +2268,7 @@ MonitorEnum string_to_monitor_enum(const std::string& s) {
         return MonitorEnum::PeriodicClockAligned;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MonitorEnum");
+    throw StringToEnumException{s, "MonitorEnum"};
 }
 } // namespace conversions
 
@@ -2307,7 +2289,7 @@ std::string mutability_enum_to_string(MutabilityEnum e) {
         return "ReadWrite";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MutabilityEnum");
+    throw EnumToStringException{e, "MutabilityEnum"};
 }
 
 MutabilityEnum string_to_mutability_enum(const std::string& s) {
@@ -2321,7 +2303,7 @@ MutabilityEnum string_to_mutability_enum(const std::string& s) {
         return MutabilityEnum::ReadWrite;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MutabilityEnum");
+    throw StringToEnumException{s, "MutabilityEnum"};
 }
 } // namespace conversions
 
@@ -2352,7 +2334,7 @@ std::string data_enum_to_string(DataEnum e) {
         return "MemberList";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DataEnum");
+    throw EnumToStringException{e, "DataEnum"};
 }
 
 DataEnum string_to_data_enum(const std::string& s) {
@@ -2381,7 +2363,7 @@ DataEnum string_to_data_enum(const std::string& s) {
         return DataEnum::MemberList;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type DataEnum");
+    throw StringToEnumException{s, "DataEnum"};
 }
 } // namespace conversions
 
@@ -2416,7 +2398,7 @@ std::string publish_firmware_status_enum_to_string(PublishFirmwareStatusEnum e) 
         return "PublishFailed";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type PublishFirmwareStatusEnum");
+    throw EnumToStringException{e, "PublishFirmwareStatusEnum"};
 }
 
 PublishFirmwareStatusEnum string_to_publish_firmware_status_enum(const std::string& s) {
@@ -2451,8 +2433,7 @@ PublishFirmwareStatusEnum string_to_publish_firmware_status_enum(const std::stri
         return PublishFirmwareStatusEnum::PublishFailed;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type PublishFirmwareStatusEnum");
+    throw StringToEnumException{s, "PublishFirmwareStatusEnum"};
 }
 } // namespace conversions
 
@@ -2473,7 +2454,7 @@ std::string charging_profile_kind_enum_to_string(ChargingProfileKindEnum e) {
         return "Relative";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileKindEnum");
+    throw EnumToStringException{e, "ChargingProfileKindEnum"};
 }
 
 ChargingProfileKindEnum string_to_charging_profile_kind_enum(const std::string& s) {
@@ -2487,7 +2468,7 @@ ChargingProfileKindEnum string_to_charging_profile_kind_enum(const std::string& 
         return ChargingProfileKindEnum::Relative;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingProfileKindEnum");
+    throw StringToEnumException{s, "ChargingProfileKindEnum"};
 }
 } // namespace conversions
 
@@ -2506,7 +2487,7 @@ std::string recurrency_kind_enum_to_string(RecurrencyKindEnum e) {
         return "Weekly";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type RecurrencyKindEnum");
+    throw EnumToStringException{e, "RecurrencyKindEnum"};
 }
 
 RecurrencyKindEnum string_to_recurrency_kind_enum(const std::string& s) {
@@ -2517,7 +2498,7 @@ RecurrencyKindEnum string_to_recurrency_kind_enum(const std::string& s) {
         return RecurrencyKindEnum::Weekly;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type RecurrencyKindEnum");
+    throw StringToEnumException{s, "RecurrencyKindEnum"};
 }
 } // namespace conversions
 
@@ -2536,7 +2517,7 @@ std::string request_start_stop_status_enum_to_string(RequestStartStopStatusEnum 
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type RequestStartStopStatusEnum");
+    throw EnumToStringException{e, "RequestStartStopStatusEnum"};
 }
 
 RequestStartStopStatusEnum string_to_request_start_stop_status_enum(const std::string& s) {
@@ -2547,8 +2528,7 @@ RequestStartStopStatusEnum string_to_request_start_stop_status_enum(const std::s
         return RequestStartStopStatusEnum::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type RequestStartStopStatusEnum");
+    throw StringToEnumException{s, "RequestStartStopStatusEnum"};
 }
 } // namespace conversions
 
@@ -2567,7 +2547,7 @@ std::string reservation_update_status_enum_to_string(ReservationUpdateStatusEnum
         return "Removed";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ReservationUpdateStatusEnum");
+    throw EnumToStringException{e, "ReservationUpdateStatusEnum"};
 }
 
 ReservationUpdateStatusEnum string_to_reservation_update_status_enum(const std::string& s) {
@@ -2578,8 +2558,7 @@ ReservationUpdateStatusEnum string_to_reservation_update_status_enum(const std::
         return ReservationUpdateStatusEnum::Removed;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ReservationUpdateStatusEnum");
+    throw StringToEnumException{s, "ReservationUpdateStatusEnum"};
 }
 } // namespace conversions
 
@@ -2638,7 +2617,7 @@ std::string connector_enum_to_string(ConnectorEnum e) {
         return "Unknown";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ConnectorEnum");
+    throw EnumToStringException{e, "ConnectorEnum"};
 }
 
 ConnectorEnum string_to_connector_enum(const std::string& s) {
@@ -2709,7 +2688,7 @@ ConnectorEnum string_to_connector_enum(const std::string& s) {
         return ConnectorEnum::Unknown;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ConnectorEnum");
+    throw StringToEnumException{s, "ConnectorEnum"};
 }
 } // namespace conversions
 
@@ -2734,7 +2713,7 @@ std::string reserve_now_status_enum_to_string(ReserveNowStatusEnum e) {
         return "Unavailable";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ReserveNowStatusEnum");
+    throw EnumToStringException{e, "ReserveNowStatusEnum"};
 }
 
 ReserveNowStatusEnum string_to_reserve_now_status_enum(const std::string& s) {
@@ -2754,7 +2733,7 @@ ReserveNowStatusEnum string_to_reserve_now_status_enum(const std::string& s) {
         return ReserveNowStatusEnum::Unavailable;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReserveNowStatusEnum");
+    throw StringToEnumException{s, "ReserveNowStatusEnum"};
 }
 } // namespace conversions
 
@@ -2773,7 +2752,7 @@ std::string reset_enum_to_string(ResetEnum e) {
         return "OnIdle";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ResetEnum");
+    throw EnumToStringException{e, "ResetEnum"};
 }
 
 ResetEnum string_to_reset_enum(const std::string& s) {
@@ -2784,7 +2763,7 @@ ResetEnum string_to_reset_enum(const std::string& s) {
         return ResetEnum::OnIdle;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ResetEnum");
+    throw StringToEnumException{s, "ResetEnum"};
 }
 } // namespace conversions
 
@@ -2805,7 +2784,7 @@ std::string reset_status_enum_to_string(ResetStatusEnum e) {
         return "Scheduled";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ResetStatusEnum");
+    throw EnumToStringException{e, "ResetStatusEnum"};
 }
 
 ResetStatusEnum string_to_reset_status_enum(const std::string& s) {
@@ -2819,7 +2798,7 @@ ResetStatusEnum string_to_reset_status_enum(const std::string& s) {
         return ResetStatusEnum::Scheduled;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ResetStatusEnum");
+    throw StringToEnumException{s, "ResetStatusEnum"};
 }
 } // namespace conversions
 
@@ -2838,7 +2817,7 @@ std::string update_enum_to_string(UpdateEnum e) {
         return "Full";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UpdateEnum");
+    throw EnumToStringException{e, "UpdateEnum"};
 }
 
 UpdateEnum string_to_update_enum(const std::string& s) {
@@ -2849,7 +2828,7 @@ UpdateEnum string_to_update_enum(const std::string& s) {
         return UpdateEnum::Full;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UpdateEnum");
+    throw StringToEnumException{s, "UpdateEnum"};
 }
 } // namespace conversions
 
@@ -2870,7 +2849,7 @@ std::string send_local_list_status_enum_to_string(SendLocalListStatusEnum e) {
         return "VersionMismatch";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type SendLocalListStatusEnum");
+    throw EnumToStringException{e, "SendLocalListStatusEnum"};
 }
 
 SendLocalListStatusEnum string_to_send_local_list_status_enum(const std::string& s) {
@@ -2884,7 +2863,7 @@ SendLocalListStatusEnum string_to_send_local_list_status_enum(const std::string&
         return SendLocalListStatusEnum::VersionMismatch;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type SendLocalListStatusEnum");
+    throw StringToEnumException{s, "SendLocalListStatusEnum"};
 }
 } // namespace conversions
 
@@ -2903,7 +2882,7 @@ std::string charging_profile_status_enum_to_string(ChargingProfileStatusEnum e) 
         return "Rejected";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingProfileStatusEnum");
+    throw EnumToStringException{e, "ChargingProfileStatusEnum"};
 }
 
 ChargingProfileStatusEnum string_to_charging_profile_status_enum(const std::string& s) {
@@ -2914,8 +2893,7 @@ ChargingProfileStatusEnum string_to_charging_profile_status_enum(const std::stri
         return ChargingProfileStatusEnum::Rejected;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type ChargingProfileStatusEnum");
+    throw StringToEnumException{s, "ChargingProfileStatusEnum"};
 }
 } // namespace conversions
 
@@ -2942,7 +2920,7 @@ std::string display_message_status_enum_to_string(DisplayMessageStatusEnum e) {
         return "UnknownTransaction";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type DisplayMessageStatusEnum");
+    throw EnumToStringException{e, "DisplayMessageStatusEnum"};
 }
 
 DisplayMessageStatusEnum string_to_display_message_status_enum(const std::string& s) {
@@ -2965,8 +2943,7 @@ DisplayMessageStatusEnum string_to_display_message_status_enum(const std::string
         return DisplayMessageStatusEnum::UnknownTransaction;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type DisplayMessageStatusEnum");
+    throw StringToEnumException{s, "DisplayMessageStatusEnum"};
 }
 } // namespace conversions
 
@@ -2987,7 +2964,7 @@ std::string monitoring_base_enum_to_string(MonitoringBaseEnum e) {
         return "HardWiredOnly";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MonitoringBaseEnum");
+    throw EnumToStringException{e, "MonitoringBaseEnum"};
 }
 
 MonitoringBaseEnum string_to_monitoring_base_enum(const std::string& s) {
@@ -3001,7 +2978,7 @@ MonitoringBaseEnum string_to_monitoring_base_enum(const std::string& s) {
         return MonitoringBaseEnum::HardWiredOnly;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MonitoringBaseEnum");
+    throw StringToEnumException{s, "MonitoringBaseEnum"};
 }
 } // namespace conversions
 
@@ -3024,7 +3001,7 @@ std::string apnauthentication_enum_to_string(APNAuthenticationEnum e) {
         return "AUTO";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type APNAuthenticationEnum");
+    throw EnumToStringException{e, "APNAuthenticationEnum"};
 }
 
 APNAuthenticationEnum string_to_apnauthentication_enum(const std::string& s) {
@@ -3041,7 +3018,7 @@ APNAuthenticationEnum string_to_apnauthentication_enum(const std::string& s) {
         return APNAuthenticationEnum::AUTO;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type APNAuthenticationEnum");
+    throw StringToEnumException{s, "APNAuthenticationEnum"};
 }
 } // namespace conversions
 
@@ -3064,7 +3041,7 @@ std::string ocppversion_enum_to_string(OCPPVersionEnum e) {
         return "OCPP20";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type OCPPVersionEnum");
+    throw EnumToStringException{e, "OCPPVersionEnum"};
 }
 
 OCPPVersionEnum string_to_ocppversion_enum(const std::string& s) {
@@ -3081,7 +3058,7 @@ OCPPVersionEnum string_to_ocppversion_enum(const std::string& s) {
         return OCPPVersionEnum::OCPP20;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type OCPPVersionEnum");
+    throw StringToEnumException{s, "OCPPVersionEnum"};
 }
 } // namespace conversions
 
@@ -3100,7 +3077,7 @@ std::string ocpptransport_enum_to_string(OCPPTransportEnum e) {
         return "SOAP";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type OCPPTransportEnum");
+    throw EnumToStringException{e, "OCPPTransportEnum"};
 }
 
 OCPPTransportEnum string_to_ocpptransport_enum(const std::string& s) {
@@ -3111,7 +3088,7 @@ OCPPTransportEnum string_to_ocpptransport_enum(const std::string& s) {
         return OCPPTransportEnum::SOAP;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type OCPPTransportEnum");
+    throw StringToEnumException{s, "OCPPTransportEnum"};
 }
 } // namespace conversions
 
@@ -3142,7 +3119,7 @@ std::string ocppinterface_enum_to_string(OCPPInterfaceEnum e) {
         return "Wireless3";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type OCPPInterfaceEnum");
+    throw EnumToStringException{e, "OCPPInterfaceEnum"};
 }
 
 OCPPInterfaceEnum string_to_ocppinterface_enum(const std::string& s) {
@@ -3171,7 +3148,7 @@ OCPPInterfaceEnum string_to_ocppinterface_enum(const std::string& s) {
         return OCPPInterfaceEnum::Wireless3;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type OCPPInterfaceEnum");
+    throw StringToEnumException{s, "OCPPInterfaceEnum"};
 }
 } // namespace conversions
 
@@ -3194,7 +3171,7 @@ std::string vpnenum_to_string(VPNEnum e) {
         return "PPTP";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type VPNEnum");
+    throw EnumToStringException{e, "VPNEnum"};
 }
 
 VPNEnum string_to_vpnenum(const std::string& s) {
@@ -3211,7 +3188,7 @@ VPNEnum string_to_vpnenum(const std::string& s) {
         return VPNEnum::PPTP;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type VPNEnum");
+    throw StringToEnumException{s, "VPNEnum"};
 }
 } // namespace conversions
 
@@ -3232,7 +3209,7 @@ std::string set_network_profile_status_enum_to_string(SetNetworkProfileStatusEnu
         return "Failed";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type SetNetworkProfileStatusEnum");
+    throw EnumToStringException{e, "SetNetworkProfileStatusEnum"};
 }
 
 SetNetworkProfileStatusEnum string_to_set_network_profile_status_enum(const std::string& s) {
@@ -3246,8 +3223,7 @@ SetNetworkProfileStatusEnum string_to_set_network_profile_status_enum(const std:
         return SetNetworkProfileStatusEnum::Failed;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type SetNetworkProfileStatusEnum");
+    throw StringToEnumException{s, "SetNetworkProfileStatusEnum"};
 }
 } // namespace conversions
 
@@ -3274,7 +3250,7 @@ std::string set_monitoring_status_enum_to_string(SetMonitoringStatusEnum e) {
         return "Duplicate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type SetMonitoringStatusEnum");
+    throw EnumToStringException{e, "SetMonitoringStatusEnum"};
 }
 
 SetMonitoringStatusEnum string_to_set_monitoring_status_enum(const std::string& s) {
@@ -3297,7 +3273,7 @@ SetMonitoringStatusEnum string_to_set_monitoring_status_enum(const std::string& 
         return SetMonitoringStatusEnum::Duplicate;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type SetMonitoringStatusEnum");
+    throw StringToEnumException{s, "SetMonitoringStatusEnum"};
 }
 } // namespace conversions
 
@@ -3324,7 +3300,7 @@ std::string set_variable_status_enum_to_string(SetVariableStatusEnum e) {
         return "RebootRequired";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type SetVariableStatusEnum");
+    throw EnumToStringException{e, "SetVariableStatusEnum"};
 }
 
 SetVariableStatusEnum string_to_set_variable_status_enum(const std::string& s) {
@@ -3347,7 +3323,7 @@ SetVariableStatusEnum string_to_set_variable_status_enum(const std::string& s) {
         return SetVariableStatusEnum::RebootRequired;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type SetVariableStatusEnum");
+    throw StringToEnumException{s, "SetVariableStatusEnum"};
 }
 } // namespace conversions
 
@@ -3372,7 +3348,7 @@ std::string connector_status_enum_to_string(ConnectorStatusEnum e) {
         return "Faulted";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ConnectorStatusEnum");
+    throw EnumToStringException{e, "ConnectorStatusEnum"};
 }
 
 ConnectorStatusEnum string_to_connector_status_enum(const std::string& s) {
@@ -3392,7 +3368,7 @@ ConnectorStatusEnum string_to_connector_status_enum(const std::string& s) {
         return ConnectorStatusEnum::Faulted;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ConnectorStatusEnum");
+    throw StringToEnumException{s, "ConnectorStatusEnum"};
 }
 } // namespace conversions
 
@@ -3413,7 +3389,7 @@ std::string transaction_event_enum_to_string(TransactionEventEnum e) {
         return "Updated";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type TransactionEventEnum");
+    throw EnumToStringException{e, "TransactionEventEnum"};
 }
 
 TransactionEventEnum string_to_transaction_event_enum(const std::string& s) {
@@ -3427,7 +3403,7 @@ TransactionEventEnum string_to_transaction_event_enum(const std::string& s) {
         return TransactionEventEnum::Updated;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type TransactionEventEnum");
+    throw StringToEnumException{s, "TransactionEventEnum"};
 }
 } // namespace conversions
 
@@ -3484,7 +3460,7 @@ std::string trigger_reason_enum_to_string(TriggerReasonEnum e) {
         return "ResetCommand";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type TriggerReasonEnum");
+    throw EnumToStringException{e, "TriggerReasonEnum"};
 }
 
 TriggerReasonEnum string_to_trigger_reason_enum(const std::string& s) {
@@ -3552,7 +3528,7 @@ TriggerReasonEnum string_to_trigger_reason_enum(const std::string& s) {
         return TriggerReasonEnum::ResetCommand;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type TriggerReasonEnum");
+    throw StringToEnumException{s, "TriggerReasonEnum"};
 }
 } // namespace conversions
 
@@ -3577,7 +3553,7 @@ std::string charging_state_enum_to_string(ChargingStateEnum e) {
         return "Idle";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ChargingStateEnum");
+    throw EnumToStringException{e, "ChargingStateEnum"};
 }
 
 ChargingStateEnum string_to_charging_state_enum(const std::string& s) {
@@ -3597,7 +3573,7 @@ ChargingStateEnum string_to_charging_state_enum(const std::string& s) {
         return ChargingStateEnum::Idle;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ChargingStateEnum");
+    throw StringToEnumException{s, "ChargingStateEnum"};
 }
 } // namespace conversions
 
@@ -3650,7 +3626,7 @@ std::string reason_enum_to_string(ReasonEnum e) {
         return "Timeout";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ReasonEnum");
+    throw EnumToStringException{e, "ReasonEnum"};
 }
 
 ReasonEnum string_to_reason_enum(const std::string& s) {
@@ -3712,7 +3688,7 @@ ReasonEnum string_to_reason_enum(const std::string& s) {
         return ReasonEnum::Timeout;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type ReasonEnum");
+    throw StringToEnumException{s, "ReasonEnum"};
 }
 } // namespace conversions
 
@@ -3749,7 +3725,7 @@ std::string message_trigger_enum_to_string(MessageTriggerEnum e) {
         return "PublishFirmwareStatusNotification";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type MessageTriggerEnum");
+    throw EnumToStringException{e, "MessageTriggerEnum"};
 }
 
 MessageTriggerEnum string_to_message_trigger_enum(const std::string& s) {
@@ -3787,7 +3763,7 @@ MessageTriggerEnum string_to_message_trigger_enum(const std::string& s) {
         return MessageTriggerEnum::PublishFirmwareStatusNotification;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageTriggerEnum");
+    throw StringToEnumException{s, "MessageTriggerEnum"};
 }
 } // namespace conversions
 
@@ -3808,7 +3784,7 @@ std::string trigger_message_status_enum_to_string(TriggerMessageStatusEnum e) {
         return "NotImplemented";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type TriggerMessageStatusEnum");
+    throw EnumToStringException{e, "TriggerMessageStatusEnum"};
 }
 
 TriggerMessageStatusEnum string_to_trigger_message_status_enum(const std::string& s) {
@@ -3822,8 +3798,7 @@ TriggerMessageStatusEnum string_to_trigger_message_status_enum(const std::string
         return TriggerMessageStatusEnum::NotImplemented;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type TriggerMessageStatusEnum");
+    throw StringToEnumException{s, "TriggerMessageStatusEnum"};
 }
 } // namespace conversions
 
@@ -3846,7 +3821,7 @@ std::string unlock_status_enum_to_string(UnlockStatusEnum e) {
         return "UnknownConnector";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UnlockStatusEnum");
+    throw EnumToStringException{e, "UnlockStatusEnum"};
 }
 
 UnlockStatusEnum string_to_unlock_status_enum(const std::string& s) {
@@ -3863,7 +3838,7 @@ UnlockStatusEnum string_to_unlock_status_enum(const std::string& s) {
         return UnlockStatusEnum::UnknownConnector;
     }
 
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type UnlockStatusEnum");
+    throw StringToEnumException{s, "UnlockStatusEnum"};
 }
 } // namespace conversions
 
@@ -3884,7 +3859,7 @@ std::string unpublish_firmware_status_enum_to_string(UnpublishFirmwareStatusEnum
         return "Unpublished";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UnpublishFirmwareStatusEnum");
+    throw EnumToStringException{e, "UnpublishFirmwareStatusEnum"};
 }
 
 UnpublishFirmwareStatusEnum string_to_unpublish_firmware_status_enum(const std::string& s) {
@@ -3898,8 +3873,7 @@ UnpublishFirmwareStatusEnum string_to_unpublish_firmware_status_enum(const std::
         return UnpublishFirmwareStatusEnum::Unpublished;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type UnpublishFirmwareStatusEnum");
+    throw StringToEnumException{s, "UnpublishFirmwareStatusEnum"};
 }
 } // namespace conversions
 
@@ -3924,7 +3898,7 @@ std::string update_firmware_status_enum_to_string(UpdateFirmwareStatusEnum e) {
         return "RevokedCertificate";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type UpdateFirmwareStatusEnum");
+    throw EnumToStringException{e, "UpdateFirmwareStatusEnum"};
 }
 
 UpdateFirmwareStatusEnum string_to_update_firmware_status_enum(const std::string& s) {
@@ -3944,8 +3918,7 @@ UpdateFirmwareStatusEnum string_to_update_firmware_status_enum(const std::string
         return UpdateFirmwareStatusEnum::RevokedCertificate;
     }
 
-    throw std::out_of_range("Provided string " + s +
-                            " could not be converted to enum of type UpdateFirmwareStatusEnum");
+    throw StringToEnumException{s, "UpdateFirmwareStatusEnum"};
 }
 } // namespace conversions
 

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -72,7 +72,7 @@ std::string profile_validation_result_to_string(ProfileValidationResultEnum e) {
         return "DuplicateProfileValidityPeriod";
     }
 
-    throw std::out_of_range("No known string conversion for provided enum of type ProfileValidationResultEnum");
+    throw EnumToStringException{e, "ProfileValidationResultEnum"};
 }
 
 std::string profile_validation_result_to_reason_code(ProfileValidationResultEnum e) {

--- a/lib/ocpp/v201/types.cpp
+++ b/lib/ocpp/v201/types.cpp
@@ -3,6 +3,8 @@
 
 #include <everest/logging.hpp>
 #include <ocpp/v201/types.hpp>
+#include <ocpp/common/types.hpp>
+
 
 namespace ocpp {
 namespace v201 {
@@ -270,7 +272,7 @@ std::string messagetype_to_string(MessageType m) {
     case MessageType::InternalError:
         return "InternalError";
     }
-    throw std::out_of_range("No known string conversion for provided enum of type MessageType");
+    throw EnumToStringException{m, "MessageType"};
 }
 
 MessageType string_to_messagetype(const std::string& s) {
@@ -533,7 +535,7 @@ MessageType string_to_messagetype(const std::string& s) {
     } else if (s == "InternalError") {
         return MessageType::InternalError;
     }
-    throw std::out_of_range("Provided string " + s + " could not be converted to enum of type MessageType");
+    throw StringToEnumException{s, "MessageType"};
 }
 } // namespace conversions
 

--- a/lib/ocpp/v201/types.cpp
+++ b/lib/ocpp/v201/types.cpp
@@ -2,9 +2,8 @@
 // Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
 
 #include <everest/logging.hpp>
-#include <ocpp/v201/types.hpp>
 #include <ocpp/common/types.hpp>
-
+#include <ocpp/v201/types.hpp>
 
 namespace ocpp {
 namespace v201 {

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -21,7 +21,7 @@ std::vector<MeasurandEnum> get_measurands_vec(const std::string& measurands_csv)
     for (const auto& measurand_string : measurands_strings) {
         try {
             measurands.push_back(conversions::string_to_measurand_enum(measurand_string));
-        } catch (std::out_of_range& e) {
+        } catch (const StringToEnumException& e) {
             EVLOG_warning << "Could not convert string: " << measurand_string << " to MeasurandEnum";
         }
     }

--- a/src/code_generator/common/templates/ocpp_enums.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_enums.cpp.jinja
@@ -6,7 +6,8 @@
 #include <ocpp/{{namespace}}/ocpp_enums.hpp>
 
 #include <string>
-#include <stdexcept>
+
+#include <ocpp/common/types.hpp>
 
 namespace ocpp {
 namespace {{namespace}} {
@@ -23,7 +24,7 @@ namespace conversions {
             {% endfor %}
         }
 
-        throw std::out_of_range("No known string conversion for provided enum of type {{ enum_type.name }}");
+        throw EnumToStringException{e, "{{ enum_type.name }}"};
     }
 
     {{ enum_type.name }} string_to_{{ enum_type.name | snake_case }}(const std::string& s) {
@@ -33,7 +34,7 @@ namespace conversions {
         }
         {% endfor %}
 
-        throw std::out_of_range("Provided string " + s + " could not be converted to enum of type {{ enum_type.name }}");
+        throw StringToEnumException{s, "{{ enum_type.name }}"};
     }
 }
 


### PR DESCRIPTION
## Describe your changes

I've seen some issues where a formatting error in a received message or an invalid string would lead to either crashes of libocpp or just dropping a message without ever responding to the csms.

This PR addresses those issues. To do so I introduced custom exceptions for String to Enum conversions and vice versa. Those and `json::exception` will now be caught on the higher layer and instead of crashing or dropping we will send a `CallError` response.

This should increase general stability. Since I derived the `EnumConversionException` from `std::out_of_range` even code that tries to catch the previously thrown exceptions will still catch the new one.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

