### PR TITLE
SmartCharging use cases K09 and K10

### DIFF
--- a/config/v201/component_config/standardized/SmartChargingCtrlr.json
+++ b/config/v201/component_config/standardized/SmartChargingCtrlr.json
@@ -172,7 +172,7 @@
         {
           "type": "Actual",
           "mutability": "ReadOnly",
-          "value": ""
+          "value": "A,W"
         }
       ],
       "description": "A list of supported quantities for use in a ChargingSchedule. Allowed values: 'A' and 'W\ufffd",

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1355,26 +1355,26 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| K09.FR.01 |        |        |
-| K09.FR.02 |        |        |
-| K09.FR.03 |        |        |
-| K09.FR.04 |        |        |
-| K09.FR.05 |        |        |
-| K09.FR.06 |        |        |
+| K09.FR.01 | ✅     |        |
+| K09.FR.02 | ✅     |        |
+| K09.FR.03 | 🌐     |        |
+| K09.FR.04 | ✅     |        |
+| K09.FR.05 | ✅     |        |
+| K09.FR.06 | ✅     |        |
 
 ## SmartCharging - Clear Charging Profile
 
 | ID        | Status | Remark |
 |-----------|--------|--------|
-| K10.FR.01 |        |        |
-| K10.FR.02 | ❎     |        |
-| K10.FR.03 |        |        |
-| K10.FR.04 |        |        |
-| K10.FR.05 |        |        |
-| K10.FR.06 |        |        |
-| K10.FR.07 |        |        |
-| K10.FR.08 |        |        |
-| K10.FR.09 |        |        |
+| K10.FR.01 | ✅     |        |
+| K10.FR.02 | 🌐     |        |
+| K10.FR.03 | ✅     |        |
+| K10.FR.04 | ✅     |        |
+| K10.FR.05 | ⛽️     |        |
+| K10.FR.06 | 🌐     |        |
+| K10.FR.07 | ⛽️     |        |
+| K10.FR.08 | ✅     |        |
+| K10.FR.09 | ✅     |        |
 
 ## SmartCharging - Set / Update External Charging Limit With Ongoing Transaction
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -688,7 +688,7 @@ private:
 
     // Functional Block K: Smart Charging
     void report_charging_profile_req(const int32_t request_id, const int32_t evse_id,
-                                     const ChargingLimitSourceEnum source, const std::vector<ChargingProfile> profiles,
+                                     const ChargingLimitSourceEnum source, const std::vector<ChargingProfile>& profiles,
                                      const bool tbc);
     void report_charging_profile_req(const ReportChargingProfilesRequest& req);
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -29,11 +29,13 @@
 #include <ocpp/v201/messages/CertificateSigned.hpp>
 #include <ocpp/v201/messages/ChangeAvailability.hpp>
 #include <ocpp/v201/messages/ClearCache.hpp>
+#include <ocpp/v201/messages/ClearChargingProfile.hpp>
 #include <ocpp/v201/messages/ClearVariableMonitoring.hpp>
 #include <ocpp/v201/messages/CustomerInformation.hpp>
 #include <ocpp/v201/messages/DataTransfer.hpp>
 #include <ocpp/v201/messages/DeleteCertificate.hpp>
 #include <ocpp/v201/messages/GetBaseReport.hpp>
+#include <ocpp/v201/messages/GetChargingProfiles.hpp>
 #include <ocpp/v201/messages/GetInstalledCertificateIds.hpp>
 #include <ocpp/v201/messages/GetLocalListVersion.hpp>
 #include <ocpp/v201/messages/GetLog.hpp>
@@ -48,6 +50,7 @@
 #include <ocpp/v201/messages/NotifyEvent.hpp>
 #include <ocpp/v201/messages/NotifyMonitoringReport.hpp>
 #include <ocpp/v201/messages/NotifyReport.hpp>
+#include <ocpp/v201/messages/ReportChargingProfiles.hpp>
 #include <ocpp/v201/messages/RequestStartTransaction.hpp>
 #include <ocpp/v201/messages/RequestStopTransaction.hpp>
 #include <ocpp/v201/messages/Reset.hpp>
@@ -683,6 +686,12 @@ private:
     void meter_values_req(const int32_t evse_id, const std::vector<MeterValue>& meter_values,
                           const bool initiated_by_trigger_message = false);
 
+    // Functional Block K: Smart Charging
+    void report_charging_profile_req(const int32_t request_id, const int32_t evse_id,
+                                     const ChargingLimitSourceEnum source, const std::vector<ChargingProfile> profiles,
+                                     const bool tbc);
+    void report_charging_profile_req(const ReportChargingProfilesRequest& req);
+
     // Functional Block N: Diagnostics
     void notify_event_req(const std::vector<EventData>& events);
     void notify_customer_information_req(const std::string& data, const int32_t request_id);
@@ -726,6 +735,8 @@ private:
 
     // Functional Block K: Smart Charging
     void handle_set_charging_profile_req(Call<SetChargingProfileRequest> call);
+    void handle_clear_charging_profile_req(Call<ClearChargingProfileRequest> call);
+    void handle_get_charging_profiles_req(Call<GetChargingProfilesRequest> call);
 
     // Functional Block L: Firmware management
     void handle_firmware_update_req(Call<UpdateFirmwareRequest> call);

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -49,38 +49,15 @@ enum class ProfileValidationResultEnum {
 
 /// \brief This enhances the ChargingProfile type by additional paramaters that are required in the
 /// ReportChargingProfilesRequest (EvseId, ChargingLimitSourceEnum)
-struct ReportedChargingProfile : public ChargingProfile {
+struct ReportedChargingProfile {
+    ChargingProfile profile;
     int32_t evse_id;
     ChargingLimitSourceEnum source;
 
     ReportedChargingProfile(const ChargingProfile& profile, const int32_t evse_id,
                             const ChargingLimitSourceEnum source) :
-        evse_id(evse_id), source(source) {
-        id = profile.id;
-        stackLevel = profile.stackLevel;
-        chargingProfilePurpose = profile.chargingProfilePurpose;
-        chargingProfileKind = profile.chargingProfileKind;
-        chargingSchedule = profile.chargingSchedule;
-        customData = profile.customData;
-        recurrencyKind = profile.recurrencyKind;
-        validFrom = profile.validFrom;
-        validTo = profile.validTo;
-        transactionId = profile.transactionId;
-    };
-
-    /// \brief Gets the original ChargingProfile from this extended type
-    ChargingProfile get_charging_profile() const {
-        return {id,
-                stackLevel,
-                chargingProfilePurpose,
-                chargingProfileKind,
-                chargingSchedule,
-                customData,
-                recurrencyKind,
-                validFrom,
-                validTo,
-                transactionId};
-    };
+        profile(profile), evse_id(evse_id), source(source) {
+    }
 };
 
 namespace conversions {
@@ -107,7 +84,8 @@ public:
 
     virtual ClearChargingProfileResponse clear_profiles(const ClearChargingProfileRequest& request) = 0;
 
-    virtual std::vector<ReportedChargingProfile> get_profiles(const GetChargingProfilesRequest& request) const = 0;
+    virtual std::vector<ReportedChargingProfile>
+    get_reported_profiles(const GetChargingProfilesRequest& request) const = 0;
 };
 
 /// \brief This class handles and maintains incoming ChargingProfiles and contains the logic
@@ -156,7 +134,8 @@ public:
     ///
     /// \brief Gets the charging profiles for the given \p request
     ///
-    std::vector<ReportedChargingProfile> get_profiles(const GetChargingProfilesRequest& request) const override;
+    std::vector<ReportedChargingProfile>
+    get_reported_profiles(const GetChargingProfilesRequest& request) const override;
 
 protected:
     ///

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -10,9 +10,9 @@
 #include <ocpp/v201/database_handler.hpp>
 #include <ocpp/v201/device_model.hpp>
 #include <ocpp/v201/evse_manager.hpp>
-#include <ocpp/v201/messages/SetChargingProfile.hpp>
 #include <ocpp/v201/messages/ClearChargingProfile.hpp>
 #include <ocpp/v201/messages/GetChargingProfiles.hpp>
+#include <ocpp/v201/messages/SetChargingProfile.hpp>
 #include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/transaction.hpp>

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3332,20 +3332,16 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
                 req.evseId = evse_id;
                 req.chargingLimitSource = source;
                 req.chargingProfile = original_profiles;
+                req.tbc = true;
                 requests_to_send.push_back(req);
             }
         }
     }
 
+    requests_to_send.back().tbc = false;
+
     // requests_to_send are ready, send them and define tbc property
-    for (size_t index = 0; index < requests_to_send.size(); index++) {
-        auto& request_to_send = requests_to_send.at(index);
-        request_to_send.tbc = true; // K09.FR.02
-        if (index == requests_to_send.size() - 1) {
-            // last element
-            request_to_send.tbc = false; // K09.FR.02
-        }
-        // this sends the ReportChargingProfilesRequest
+    for (const auto &request_to_send : requests_to_send) {
         this->report_charging_profile_req(request_to_send);
     }
 }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3319,7 +3319,7 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
     for (const auto evse_id : evse_ids) {
         for (const auto source : sources) {
             std::vector<ChargingProfile> original_profiles;
-            for (const auto &reported_profile : profiles_to_report) {
+            for (const auto& reported_profile : profiles_to_report) {
                 if (reported_profile.evse_id == evse_id and reported_profile.source == source) {
                     original_profiles.push_back(reported_profile.profile);
                 }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3309,10 +3309,10 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
     std::set<ChargingLimitSourceEnum> sources; // will contain all sources of the profiles
 
     // fill evse_ids and sources sets
-    std::transform(profiles_to_report.begin(), profiles_to_report.end(), std::inserter(evse_ids, evse_ids.end()),
-                   [](const ReportedChargingProfile& profile) { return profile.evse_id; });
-    std::transform(profiles_to_report.begin(), profiles_to_report.end(), std::inserter(sources, sources.end()),
-                   [](const ReportedChargingProfile& profile) { return profile.source; });
+    for(const auto& profile: profiles to report) {
+        evse_ids.insert(profile.evse_id);
+        sources.insert(profile.source);
+    }
 
     std::vector<ReportChargingProfilesRequest> requests_to_send;
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3289,7 +3289,7 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
     const auto msg = call.msg;
     GetChargingProfilesResponse response;
 
-    const auto profiles_to_report = this->smart_charging_handler->get_profiles(msg);
+    const auto profiles_to_report = this->smart_charging_handler->get_reported_profiles(msg);
 
     if (not profiles_to_report.empty()) {
         response.status = GetChargingProfileStatusEnum::Accepted;
@@ -3321,9 +3321,9 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
         for (const auto source : sources) {
             std::vector<ChargingProfile> original_profiles;
             std::for_each(profiles_to_report.begin(), profiles_to_report.end(),
-                          [evse_id, source, &original_profiles](ReportedChargingProfile profile) {
-                              if (profile.evse_id == evse_id and profile.source == source) {
-                                  original_profiles.push_back(profile.get_charging_profile());
+                          [evse_id, source, &original_profiles](ReportedChargingProfile reported_profile) {
+                              if (reported_profile.evse_id == evse_id and reported_profile.source == source) {
+                                  original_profiles.push_back(reported_profile.profile);
                               };
                           });
             if (not original_profiles.empty()) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3309,7 +3309,7 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
     std::set<ChargingLimitSourceEnum> sources; // will contain all sources of the profiles
 
     // fill evse_ids and sources sets
-    for (const auto& profile : profiles to report) {
+    for (const auto& profile : profiles_to_report) {
         evse_ids.insert(profile.evse_id);
         sources.insert(profile.source);
     }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3309,7 +3309,7 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
     std::set<ChargingLimitSourceEnum> sources; // will contain all sources of the profiles
 
     // fill evse_ids and sources sets
-    for(const auto& profile: profiles to report) {
+    for (const auto& profile : profiles to report) {
         evse_ids.insert(profile.evse_id);
         sources.insert(profile.source);
     }
@@ -3341,7 +3341,7 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
     requests_to_send.back().tbc = false;
 
     // requests_to_send are ready, send them and define tbc property
-    for (const auto &request_to_send : requests_to_send) {
+    for (const auto& request_to_send : requests_to_send) {
         this->report_charging_profile_req(request_to_send);
     }
 }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3291,14 +3291,13 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
 
     const auto profiles_to_report = this->smart_charging_handler->get_reported_profiles(msg);
 
-    if (not profiles_to_report.empty()) {
-        response.status = GetChargingProfileStatusEnum::Accepted;
-        ocpp::CallResult<GetChargingProfilesResponse> call_result(response, call.uniqueId);
-        this->send<GetChargingProfilesResponse>(call_result);
-    } else {
-        response.status = GetChargingProfileStatusEnum::NoProfiles;
-        ocpp::CallResult<GetChargingProfilesResponse> call_result(response, call.uniqueId);
-        this->send<GetChargingProfilesResponse>(call_result);
+    response.status =
+        profiles_to_report.empty() ? GetChargingProfileStatusEnum::NoProfiles : GetChargingProfileStatusEnum::Accepted;
+
+    ocpp::CallResult<GetChargingProfilesResponse> call_result(response, call.uniqueId);
+    this->send<GetChargingProfilesResponse>(call_result);
+
+    if (response.status == GetChargingProfileStatusEnum::NoProfiles) {
         return;
     }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -2225,7 +2225,7 @@ void ChargePoint::meter_values_req(const int32_t evse_id, const std::vector<Mete
 
 void ChargePoint::report_charging_profile_req(const int32_t request_id, const int32_t evse_id,
                                               const ChargingLimitSourceEnum source,
-                                              const std::vector<ChargingProfile> profiles, const bool tbc) {
+                                              const std::vector<ChargingProfile>& profiles, const bool tbc) {
     ReportChargingProfilesRequest req;
     req.requestId = request_id;
     req.evseId = evse_id;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3319,12 +3319,11 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
     for (const auto evse_id : evse_ids) {
         for (const auto source : sources) {
             std::vector<ChargingProfile> original_profiles;
-            std::for_each(profiles_to_report.begin(), profiles_to_report.end(),
-                          [evse_id, source, &original_profiles](ReportedChargingProfile reported_profile) {
-                              if (reported_profile.evse_id == evse_id and reported_profile.source == source) {
-                                  original_profiles.push_back(reported_profile.profile);
-                              };
-                          });
+            for (const auto &reported_profile : profiles_to_report) {
+                if (reported_profile.evse_id == evse_id and reported_profile.source == source) {
+                    original_profiles.push_back(reported_profile.profile);
+                }
+            }
             if (not original_profiles.empty()) {
                 // prepare a ReportChargingProfilesRequest
                 ReportChargingProfilesRequest req;

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -15,7 +15,7 @@ public:
     MOCK_METHOD(ProfileValidationResultEnum, validate_profile, (ChargingProfile & profile, int32_t evse_id));
     MOCK_METHOD(SetChargingProfileResponse, add_profile, (ChargingProfile & profile, int32_t evse_id));
     MOCK_METHOD(ClearChargingProfileResponse, clear_profiles, (const ClearChargingProfileRequest& request), (override));
-    MOCK_METHOD(std::vector<ReportedChargingProfile>, get_profiles, (const GetChargingProfilesRequest& request),
-                (const, override));
+    MOCK_METHOD(std::vector<ReportedChargingProfile>, get_reported_profiles,
+                (const GetChargingProfilesRequest& request), (const, override));
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -14,5 +14,8 @@ public:
     MOCK_METHOD(SetChargingProfileResponse, validate_and_add_profile, (ChargingProfile & profile, int32_t evse_id));
     MOCK_METHOD(ProfileValidationResultEnum, validate_profile, (ChargingProfile & profile, int32_t evse_id));
     MOCK_METHOD(SetChargingProfileResponse, add_profile, (ChargingProfile & profile, int32_t evse_id));
+    MOCK_METHOD(ClearChargingProfileResponse, clear_profiles, (const ClearChargingProfileRequest& request), (override));
+    MOCK_METHOD(std::vector<ReportedChargingProfile>, get_profiles, (const GetChargingProfilesRequest& request),
+                (const, override));
 };
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -39,6 +39,7 @@ static const int STATION_WIDE_ID = 0;
 static const int DEFAULT_EVSE_ID = 1;
 static const int DEFAULT_PROFILE_ID = 1;
 static const int DEFAULT_STACK_LEVEL = 1;
+static const int DEFAULT_REQUEST_ID = 1;
 static const std::string DEFAULT_TX_ID = "10c75ff7-74f5-44f5-9d01-f649f3ac7b78";
 const static std::string MIGRATION_FILES_PATH = "./resources/v201/device_model_migration_files";
 const static std::string SCHEMAS_PATH = "./resources/example_config/v201/component_config";
@@ -156,6 +157,45 @@ protected:
                                .validFrom = validFrom,
                                .validTo = validTo,
                                .transactionId = transaction_id};
+    }
+
+    ChargingProfileCriterion create_charging_profile_criteria(
+        std::optional<std::vector<ocpp::v201::ChargingLimitSourceEnum>> sources = std::nullopt,
+        std::optional<std::vector<int32_t>> ids = std::nullopt,
+        std::optional<ChargingProfilePurposeEnum> purpose = std::nullopt,
+        std::optional<int32_t> stack_level = std::nullopt) {
+        ChargingProfileCriterion criteria;
+        criteria.chargingLimitSource = sources;
+        criteria.chargingProfileId = ids;
+        criteria.chargingProfilePurpose = purpose;
+        criteria.stackLevel = stack_level;
+        return criteria;
+    }
+
+    GetChargingProfilesRequest create_get_charging_profile_request(int32_t request_id,
+                                                                   ChargingProfileCriterion criteria,
+                                                                   std::optional<int32_t> evse_id = std::nullopt) {
+        GetChargingProfilesRequest req;
+        req.requestId = request_id;
+        req.chargingProfile = criteria;
+        req.evseId = evse_id;
+        return req;
+    }
+
+    ClearChargingProfileRequest
+    create_clear_charging_profile_request(std::optional<int32_t> id = std::nullopt,
+                                          std::optional<ClearChargingProfile> criteria = std::nullopt) {
+        ClearChargingProfileRequest req;
+        req.chargingProfileId = id;
+        req.chargingProfileCriteria = criteria;
+        return req;
+    }
+
+    ClearChargingProfile create_clear_charging_profile(std::optional<int32_t> evse_id = std::nullopt,
+                                                       std::optional<ChargingProfilePurposeEnum> purpose = std::nullopt,
+                                                       std::optional<int32_t> stack_level = std::nullopt) {
+        return ClearChargingProfile{
+            .customData = {}, .evseId = evse_id, .chargingProfilePurpose = purpose, .stackLevel = stack_level};
     }
 
     void create_device_model_db(const std::string& path) {
@@ -1163,6 +1203,235 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles) {
     EXPECT_THAT(sut.statusInfo.has_value(), testing::IsFalse());
 
     auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::Contains(profile));
+}
+
+TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseId) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile1 = create_charging_profile(
+        1, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+    auto profile2 = create_charging_profile(
+        2, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::SizeIs(2));
+
+    auto reported_profiles = handler.get_profiles(
+        create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria(), 0));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(1));
+
+    auto reported_profile = reported_profiles.at(0);
+    EXPECT_THAT(profile1, testing::Eq(reported_profile.get_charging_profile()));
+
+    reported_profiles = handler.get_profiles(
+        create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria(), 1));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(1));
+
+    reported_profile = reported_profiles.at(0);
+    EXPECT_THAT(profile2, testing::Eq(reported_profile.get_charging_profile()));
+}
+
+TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_NoEvseId) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile1 = create_charging_profile(
+        1, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+    auto profile2 = create_charging_profile(
+        2, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::SizeIs(2));
+
+    auto reported_profiles = handler.get_profiles(
+        create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria()));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(2));
+
+    EXPECT_THAT(profiles, testing::Contains(reported_profiles.at(0).get_charging_profile()));
+    EXPECT_THAT(profiles, testing::Contains(reported_profiles.at(1).get_charging_profile()));
+}
+
+TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_ProfileId) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile1 = create_charging_profile(
+        1, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+    auto profile2 = create_charging_profile(
+        2, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::SizeIs(2));
+
+    std::vector<int32_t> requested_profile_ids{1};
+    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+        DEFAULT_REQUEST_ID, create_charging_profile_criteria(std::nullopt, requested_profile_ids)));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(1));
+
+    EXPECT_THAT(profile1, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+}
+
+TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndStackLevel) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile1 = create_charging_profile(
+        1, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), std::nullopt,
+        ChargingProfileKindEnum::Absolute, 2); // contains different stackLevel(2)
+    auto profile2 = create_charging_profile(
+        2, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods,
+                               ocpp::DateTime("2024-01-17T17:00:00"))); // contains default stackLevel(1)
+
+    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::SizeIs(2));
+
+    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+        DEFAULT_REQUEST_ID,
+        create_charging_profile_criteria(std::nullopt, std::nullopt, std::nullopt, DEFAULT_STACK_LEVEL),
+        DEFAULT_EVSE_ID));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(1));
+    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+}
+
+TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSource) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut1 = handler.validate_and_add_profile(profile, 1);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::SizeIs(1));
+
+    std::vector<ChargingLimitSourceEnum> requested_sources_cso{ChargingLimitSourceEnum::CSO};
+    std::vector<ChargingLimitSourceEnum> requested_sources_ems{ChargingLimitSourceEnum::EMS};
+
+    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+        DEFAULT_REQUEST_ID, create_charging_profile_criteria(requested_sources_cso), DEFAULT_EVSE_ID));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(1));
+    EXPECT_THAT(profile, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+
+    reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+        DEFAULT_REQUEST_ID, create_charging_profile_criteria(requested_sources_ems), DEFAULT_EVSE_ID));
+
+    EXPECT_THAT(reported_profiles, testing::SizeIs(0));
+}
+
+TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndPurposeAndStackLevel) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile1 = create_charging_profile(
+        1, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+    auto profile2 = create_charging_profile(
+        2, ChargingProfilePurposeEnum::TxDefaultProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::SizeIs(2));
+
+    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+        DEFAULT_REQUEST_ID,
+        create_charging_profile_criteria(std::nullopt, std::nullopt, ChargingProfilePurposeEnum::TxDefaultProfile),
+        DEFAULT_EVSE_ID));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(1));
+    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+
+    reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+        DEFAULT_REQUEST_ID,
+        create_charging_profile_criteria(std::nullopt, std::nullopt, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                         DEFAULT_STACK_LEVEL),
+        DEFAULT_EVSE_ID));
+    EXPECT_THAT(reported_profiles, testing::SizeIs(1));
+    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+}
+
+TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsId) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+    handler.validate_and_add_profile(profile, 0);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::Contains(profile));
+
+    auto sut = handler.clear_profiles(create_clear_charging_profile_request(DEFAULT_PROFILE_ID));
+    EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Accepted));
+
+    profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::Not(testing::Contains(profile)));
+}
+
+TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsStackLevelPurposeCombination) {
+    install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
+
+    auto sut = handler.clear_profiles(create_clear_charging_profile_request(
+        std::nullopt, create_clear_charging_profile(std::nullopt, ChargingProfilePurposeEnum::TxDefaultProfile,
+                                                    DEFAULT_STACK_LEVEL)));
+    EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Accepted));
+
+    profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::IsEmpty());
+}
+
+TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownStackLevelPurposeCombination) {
+    install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
+
+    auto sut = handler.clear_profiles(create_clear_charging_profile_request(
+        std::nullopt,
+        create_clear_charging_profile(std::nullopt, ChargingProfilePurposeEnum::ChargingStationMaxProfile, 0)));
+    EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Unknown));
+
+    profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
+}
+
+TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownId) {
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
+    handler.validate_and_add_profile(profile, 0);
+
+    auto profiles = handler.get_profiles();
+    EXPECT_THAT(profiles, testing::Contains(profile));
+
+    auto sut = handler.clear_profiles(create_clear_charging_profile_request(178));
+    EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Unknown));
+
+    profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));
 }
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1216,25 +1216,25 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseId) {
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
     auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
 
-    auto reported_profiles = handler.get_profiles(
-        create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria(), 0));
+    auto reported_profiles = handler.get_reported_profiles(
+        create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria(), STATION_WIDE_ID));
     EXPECT_THAT(reported_profiles, testing::SizeIs(1));
 
     auto reported_profile = reported_profiles.at(0);
-    EXPECT_THAT(profile1, testing::Eq(reported_profile.get_charging_profile()));
+    EXPECT_THAT(profile1, testing::Eq(reported_profile.profile));
 
-    reported_profiles = handler.get_profiles(
-        create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria(), 1));
+    reported_profiles = handler.get_reported_profiles(
+        create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria(), DEFAULT_EVSE_ID));
     EXPECT_THAT(reported_profiles, testing::SizeIs(1));
 
     reported_profile = reported_profiles.at(0);
-    EXPECT_THAT(profile2, testing::Eq(reported_profile.get_charging_profile()));
+    EXPECT_THAT(profile2, testing::Eq(reported_profile.profile));
 }
 
 TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_NoEvseId) {
@@ -1247,18 +1247,18 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_NoEvseId) {
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
     auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
 
-    auto reported_profiles = handler.get_profiles(
+    auto reported_profiles = handler.get_reported_profiles(
         create_get_charging_profile_request(DEFAULT_REQUEST_ID, create_charging_profile_criteria()));
     EXPECT_THAT(reported_profiles, testing::SizeIs(2));
 
-    EXPECT_THAT(profiles, testing::Contains(reported_profiles.at(0).get_charging_profile()));
-    EXPECT_THAT(profiles, testing::Contains(reported_profiles.at(1).get_charging_profile()));
+    EXPECT_THAT(profiles, testing::Contains(reported_profiles.at(0).profile));
+    EXPECT_THAT(profiles, testing::Contains(reported_profiles.at(1).profile));
 }
 
 TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_ProfileId) {
@@ -1271,18 +1271,18 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_ProfileId) {
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
     auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
 
     std::vector<int32_t> requested_profile_ids{1};
-    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+    auto reported_profiles = handler.get_reported_profiles(create_get_charging_profile_request(
         DEFAULT_REQUEST_ID, create_charging_profile_criteria(std::nullopt, requested_profile_ids)));
     EXPECT_THAT(reported_profiles, testing::SizeIs(1));
 
-    EXPECT_THAT(profile1, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+    EXPECT_THAT(profile1, testing::Eq(reported_profiles.at(0).profile));
 }
 
 TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndStackLevel) {
@@ -1297,18 +1297,18 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndStackLevel) 
         create_charge_schedule(ChargingRateUnitEnum::A, periods,
                                ocpp::DateTime("2024-01-17T17:00:00"))); // contains default stackLevel(1)
 
-    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
     auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
 
-    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+    auto reported_profiles = handler.get_reported_profiles(create_get_charging_profile_request(
         DEFAULT_REQUEST_ID,
         create_charging_profile_criteria(std::nullopt, std::nullopt, std::nullopt, DEFAULT_STACK_LEVEL),
         DEFAULT_EVSE_ID));
     EXPECT_THAT(reported_profiles, testing::SizeIs(1));
-    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).profile));
 }
 
 TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSource) {
@@ -1318,7 +1318,7 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSource) {
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile, 1);
+    auto sut1 = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(1));
@@ -1326,12 +1326,12 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSource) {
     std::vector<ChargingLimitSourceEnum> requested_sources_cso{ChargingLimitSourceEnum::CSO};
     std::vector<ChargingLimitSourceEnum> requested_sources_ems{ChargingLimitSourceEnum::EMS};
 
-    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+    auto reported_profiles = handler.get_reported_profiles(create_get_charging_profile_request(
         DEFAULT_REQUEST_ID, create_charging_profile_criteria(requested_sources_cso), DEFAULT_EVSE_ID));
     EXPECT_THAT(reported_profiles, testing::SizeIs(1));
-    EXPECT_THAT(profile, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+    EXPECT_THAT(profile, testing::Eq(reported_profiles.at(0).profile));
 
-    reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+    reported_profiles = handler.get_reported_profiles(create_get_charging_profile_request(
         DEFAULT_REQUEST_ID, create_charging_profile_criteria(requested_sources_ems), DEFAULT_EVSE_ID));
 
     EXPECT_THAT(reported_profiles, testing::SizeIs(0));
@@ -1347,26 +1347,26 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndPurposeAndSt
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, 0);
+    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
     auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
 
-    auto reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+    auto reported_profiles = handler.get_reported_profiles(create_get_charging_profile_request(
         DEFAULT_REQUEST_ID,
         create_charging_profile_criteria(std::nullopt, std::nullopt, ChargingProfilePurposeEnum::TxDefaultProfile),
         DEFAULT_EVSE_ID));
     EXPECT_THAT(reported_profiles, testing::SizeIs(1));
-    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).profile));
 
-    reported_profiles = handler.get_profiles(create_get_charging_profile_request(
+    reported_profiles = handler.get_reported_profiles(create_get_charging_profile_request(
         DEFAULT_REQUEST_ID,
         create_charging_profile_criteria(std::nullopt, std::nullopt, ChargingProfilePurposeEnum::TxDefaultProfile,
                                          DEFAULT_STACK_LEVEL),
         DEFAULT_EVSE_ID));
     EXPECT_THAT(reported_profiles, testing::SizeIs(1));
-    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).get_charging_profile()));
+    EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).profile));
 }
 
 TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsId) {
@@ -1375,7 +1375,7 @@ TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsId) {
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-    handler.validate_and_add_profile(profile, 0);
+    handler.validate_and_add_profile(profile, STATION_WIDE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));
@@ -1409,8 +1409,8 @@ TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownStackLevelPur
     EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
 
     auto sut = handler.clear_profiles(create_clear_charging_profile_request(
-        std::nullopt,
-        create_clear_charging_profile(std::nullopt, ChargingProfilePurposeEnum::ChargingStationMaxProfile, 0)));
+        std::nullopt, create_clear_charging_profile(std::nullopt, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                                    STATION_WIDE_ID)));
     EXPECT_THAT(sut.status, testing::Eq(ClearChargingProfileStatusEnum::Unknown));
 
     profiles = handler.get_profiles();
@@ -1423,7 +1423,7 @@ TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownId) {
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-    handler.validate_and_add_profile(profile, 0);
+    handler.validate_and_add_profile(profile, STATION_WIDE_ID);
 
     auto profiles = handler.get_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));


### PR DESCRIPTION
## Describe your changes
Implements SmartCharging use cases K09 and K10.
Adds support for the following messages:
* ClearChargingProfile
* GetChargingProfiles
* ReportChargingProfiles 

Tested Cases tested with OCTT:
TC_K_05
TC_K_06
TC_K_07
TC_K_08
TC_K_09 fails because GetCompositeSchedule handling is a prerequisite.
TC_K_24
TC_K_29
TC_K_30
TC_K_31
TC_K_32
TC_K_33
TC_K_34
TC_K_35
TC_K_36

This PR is branched off https://github.com/EVerest/libocpp/pull/711 .
Additional requires some changes in the code generator, which will be applied in this PR: https://github.com/EVerest/libocpp/pull/741 

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/309
https://github.com/EVerest/libocpp/issues/369

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

