### PR TITLE
K01 - Small cleanups

### DIFF
--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -16,7 +16,6 @@
             }
         }
     },
-
     {
         "name": "Connector",
         "evse_id": 1,
@@ -774,6 +773,12 @@
                 "variable_name": "RateUnit",
                 "attributes": {
                     "Actual": ""
+                }
+            },
+            "SmartChargingCtrlrAvailable": {
+                "variable_name": "Available",
+                "attributes": {
+                    "Actual": true
                 }
             },
             "SmartChargingCtrlrAvailableEnabled": {

--- a/config/v201/config.json
+++ b/config/v201/config.json
@@ -784,7 +784,7 @@
             "SmartChargingCtrlrAvailableEnabled": {
                 "variable_name": "Enabled",
                 "attributes": {
-                    "Actual": false
+                    "Actual": true
                 }
             }
         }

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1254,7 +1254,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K01.FR.26 | ✅     |                                                                                                 |
 | K01.FR.27 | ✅     |                                                                                                 |
 | K01.FR.28 | ✅     |                                                                                                 |
-| K01.FR.29 |        |                                                                                                 |
+| K01.FR.29 | ✅     |                                                                                                 |
 | K01.FR.30 |        |                                                                                                 |
 | K01.FR.31 |        |                                                                                                 |
 | K01.FR.32 | ✅     |                                                                                                 |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -12,7 +12,6 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | ❓     | Actor responsible for or status of requirement is unknown                      |
 | 🤓     | Catch-all for FRs that are satisfied for other reasons (see the Remark column) |
 
-
 ## General - General
 
 | ID    | Status | Remark |
@@ -1225,7 +1224,6 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 |-----------|--------|--------|
 | J03.FR.04 |        |        |
 
-
 ## SmartCharging - SetChargingProfile
 
 | ID        | Status | Remark                                                                                          |
@@ -1233,50 +1231,50 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K01.FR.01 | 🌐     | `TxProfile`s are supported.                                                                     |
 | K01.FR.02 | 🌐     |                                                                                                 |
 | K01.FR.03 | 🌐 💂  | `TxProfile`s without `transactionId`s are rejected.                                             |
-| K01.FR.04 | ✅     |                                                                                                 |
+| K01.FR.04 | 🌐     |                                                                                                 |
 | K01.FR.05 | ✅     |                                                                                                 |
-| K01.FR.06 | 🌐     |                                                                                                 |
-| K01.FR.07 | ⛽️     | Notified through the `signal_set_charging_profiles` callback.                                   |
+| K01.FR.06 | ✅     |                                                                                                 |
+| K01.FR.07 | ⛽️K08  | Notified through the `signal_set_charging_profiles` callback.                                   |
 | K01.FR.08 | 🌐     | `TxDefaultProfile`s are supported.                                                              |
 | K01.FR.09 | ✅     |                                                                                                 |
-| K01.FR.10 | ✅     |                                                                                                 |
-| K01.FR.11 |        |                                                                                                 |
-| K01.FR.12 |        |                                                                                                 |
-| K01.FR.13 |        |                                                                                                 |
+| K01.FR.10 | ⛽️K08  | During validation `validFrom` and `validTo` are sets if they are blank to support this          |
+| K01.FR.11 | ⛽️K08  |                                                                                                 |
+| K01.FR.12 | ⛽️K08  |                                                                                                 |
+| K01.FR.13 | ⛽️K08  |                                                                                                 |
 | K01.FR.14 | ✅     |                                                                                                 |
 | K01.FR.15 | ✅     |                                                                                                 |
 | K01.FR.16 | ✅     |                                                                                                 |
-| K01.FR.17 |        |                                                                                                 |
-| K01.FR.19 |        |                                                                                                 |
+| K01.FR.17 | ⛽️K08  |                                                                                                 |
+| K01.FR.19 | ✅     |                                                                                                 |
 | K01.FR.20 | ✅     | Suggests `ACPhaseSwitchingSupported` should be per EVSE, conflicting with the rest of the spec. |
-| K01.FR.21 |        |                                                                                                 |
+| K01.FR.21 |        | There is an active community discussion on this topic.                                          |
 | K01.FR.22 |        |                                                                                                 |
 | K01.FR.26 | ✅     |                                                                                                 |
 | K01.FR.27 | ✅     |                                                                                                 |
 | K01.FR.28 | ✅     |                                                                                                 |
 | K01.FR.29 | ✅     |                                                                                                 |
-| K01.FR.30 |        |                                                                                                 |
-| K01.FR.31 |        |                                                                                                 |
-| K01.FR.32 | ✅     |                                                                                                 |
+| K01.FR.30 | ⛽️K08  |                                                                                                 |
+| K01.FR.31 | ✅     |                                                                                                 |
+| K01.FR.32 | ⛽️K08  |                                                                                                 |
 | K01.FR.33 | ✅     |                                                                                                 |
-| K01.FR.34 | ✅     |                                                                                                 |
+| K01.FR.34 |        | Defer to K15 - K17 work                                                                          |
 | K01.FR.35 | ✅     |                                                                                                 |
-| K01.FR.36 | ✅     |                                                                                                 |
-| K01.FR.37 |        |                                                                                                 |
-| K01.FR.38 | 🌐 💂  | `ChargingStationMaxProfile`s with `Relative` for `chargingProfileKind` are rejected.            |
-| K01.FR.39 | 🌐 💂  | New `TxProfile`s matching existing `(stackLevel, transactionId)` are rejected.                  |
-| K01.FR.40 | 🌐 💂  | `Absolute`/`Recurring` profiles without `startSchedule` fields are rejected.                    |
-| K01.FR.41 | 🌐 💂  | `Relative` profiles with `startSchedule` fields are rejected.                                   |
-| K01.FR.42 |        |                                                                                                 |
-| K01.FR.43 |        |                                                                                                 |
+| K01.FR.36 | ⛽️K08  |                                                                                                 |
+| K01.FR.37 | ⛽️K08  |                                                                                                 |
+| K01.FR.38 | ✅     | `ChargingStationMaxProfile`s with `Relative` for `chargingProfileKind` are rejected.            |
+| K01.FR.39 | ✅     | New `TxProfile`s matching existing `(stackLevel, transactionId)` are rejected.                  |
+| K01.FR.40 | ✅     | `Absolute`/`Recurring` profiles without `startSchedule` fields are rejected.                    |
+| K01.FR.41 | ✅     | `Relative` profiles with `startSchedule` fields are rejected.                                   |
+| K01.FR.42 | ⛽️K08  |                                                                                                 |
+| K01.FR.43 |        |  Open question to OCA                                                                           |
 | K01.FR.44 | ✅     | We reject invalid profiles instead of modifying and accepting them.                             |
 | K01.FR.45 | ✅     | We reject invalid profiles instead of modifying and accepting them.                             |
-| K01.FR.46 |        |                                                                                                 |
-| K01.FR.47 |        |                                                                                                 |
-| K01.FR.48 |        |                                                                                                 |
+| K01.FR.46 | ⛽️K08  |                                                                                                 |
+| K01.FR.47 | ⛽️K08  |                                                                                                 |
+| K01.FR.48 | ✅     |                                                                                                 |
 | K01.FR.49 | ✅     |                                                                                                 |
-| K01.FR.50 |        |                                                                                                 |
-| K01.FR.51 |        |                                                                                                 |
+| K01.FR.50 | ⛽️K08  |                                                                                                 |
+| K01.FR.51 | ⛽️K08  |                                                                                                 |
 | K01.FR.52 | ✅     |                                                                                                 |
 | K01.FR.53 | ✅     |                                                                                                 |
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -419,7 +419,7 @@ private:
     std::unique_ptr<EvseManager> evse_manager;
 
     // utility
-    std::unique_ptr<MessageQueue<v201::MessageType>> message_queue;
+    std::shared_ptr<MessageQueue<v201::MessageType>> message_queue;
     std::shared_ptr<DeviceModel> device_model;
     std::shared_ptr<DatabaseHandler> database_handler;
 
@@ -794,6 +794,11 @@ public:
     /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
     /// the EVSEs have to increment starting with 1.
     /// \param device_model_storage_address address to device model storage (e.g. location of SQLite database)
+    /// \brief Construct a new ChargePoint object
+    /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The
+    /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
+    /// the EVSEs have to increment starting with 1.
+    /// \param device_model_storage_address address to device model storage (e.g. location of SQLite database)
     /// \param initialize_device_model  Set to true to initialize the device model database
     /// \param device_model_migration_path  Path to the device model database migration files
     /// \param device_model_schemas_path    Path to the device model schemas
@@ -848,6 +853,22 @@ public:
                 const std::string& core_database_path, const std::string& sql_init_path,
                 const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
                 const Callbacks& callbacks);
+
+    /// \brief Construct a new ChargePoint object
+    /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The
+    /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
+    /// the EVSEs have to increment starting with 1.
+    /// \param device_model_storage device model storage instance
+    /// \param database_handler database handler instance
+    /// \param message_queue message queue instance
+    /// \param message_log_path Path to where logfiles are written to
+    /// \param evse_security Pointer to evse_security that manages security related operations
+    /// \param callbacks Callbacks that will be registered for ChargePoint
+    ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
+                std::shared_ptr<DatabaseHandler> database_handler,
+                std::shared_ptr<MessageQueue<v201::MessageType>> message_queue, const std::string& message_log_path,
+                const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
+
     ~ChargePoint();
 
     void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp) override;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -63,6 +63,114 @@ bool Callbacks::all_callbacks_valid() const {
 }
 
 ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                         std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
+                         std::shared_ptr<MessageQueue<v201::MessageType>> message_queue,
+                         const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                         const Callbacks& callbacks) :
+    ocpp::ChargingStationBase(evse_security),
+    message_queue(message_queue),
+    device_model(device_model),
+    database_handler(database_handler),
+    registration_status(RegistrationStatusEnum::Rejected),
+    network_configuration_priority(0),
+    disable_automatic_websocket_reconnects(false),
+    skip_invalid_csms_certificate_notifications(false),
+    reset_scheduled(false),
+    reset_scheduled_evseids{},
+    firmware_status(FirmwareStatusEnum::Idle),
+    upload_log_status(UploadLogStatusEnum::Idle),
+    bootreason(BootReasonEnum::PowerUp),
+    ocsp_updater(this->evse_security, this->send_callback<GetCertificateStatusRequest, GetCertificateStatusResponse>(
+                                          MessageType::GetCertificateStatusResponse)),
+    monitoring_updater(
+        device_model, [this](const std::vector<EventData>& events) { this->notify_event_req(events); },
+        [this]() { return this->is_offline(); }),
+    csr_attempt(1),
+    client_certificate_expiration_check_timer([this]() { this->scheduled_check_client_certificate_expiration(); }),
+    v2g_certificate_expiration_check_timer([this]() { this->scheduled_check_v2g_certificate_expiration(); }),
+    callbacks(callbacks) {
+
+    // Make sure the received callback struct is completely filled early before we actually start running
+    if (!this->callbacks.all_callbacks_valid()) {
+        EVLOG_AND_THROW(std::invalid_argument("All non-optional callbacks must be supplied"));
+    }
+
+    if (!this->device_model) {
+        EVLOG_AND_THROW(std::invalid_argument("Device model should not be null"));
+    }
+    this->device_model->check_integrity(evse_connector_structure);
+
+    if (!this->database_handler) {
+        EVLOG_AND_THROW(std::invalid_argument("Database handler should not be null"));
+    }
+    this->database_handler->open_connection();
+
+    // Component state manager - needs evse_connector_structure, database_handler,
+    // send_connector_status_notification_callback Setup callbacks using compomnent state manager
+
+    this->component_state_manager = std::make_shared<ComponentStateManager>(
+        evse_connector_structure, database_handler,
+        [this](auto evse_id, auto connector_id, auto status, bool initiated_by_trigger_message) {
+            this->update_dm_availability_state(evse_id, connector_id, status);
+            if (this->websocket == nullptr || !this->websocket->is_connected() ||
+                this->registration_status != RegistrationStatusEnum::Accepted) {
+                return false;
+            } else {
+                this->status_notification_req(evse_id, connector_id, status, initiated_by_trigger_message);
+                return true;
+            }
+        });
+    if (this->callbacks.cs_effective_operative_status_changed_callback.has_value()) {
+        this->component_state_manager->set_cs_effective_availability_changed_callback(
+            this->callbacks.cs_effective_operative_status_changed_callback.value());
+    }
+    if (this->callbacks.evse_effective_operative_status_changed_callback.has_value()) {
+        this->component_state_manager->set_evse_effective_availability_changed_callback(
+            this->callbacks.evse_effective_operative_status_changed_callback.value());
+    }
+    this->component_state_manager->set_connector_effective_availability_changed_callback(
+        this->callbacks.connector_effective_operative_status_changed_callback);
+
+    auto transaction_meter_value_callback = [this](const MeterValue& _meter_value, EnhancedTransaction& transaction) {
+        if (_meter_value.sampledValue.empty() or !_meter_value.sampledValue.at(0).context.has_value()) {
+            EVLOG_info << "Not sending MeterValue due to no values";
+            return;
+        }
+
+        auto type = _meter_value.sampledValue.at(0).context.value();
+        if (type != ReadingContextEnum::Sample_Clock and type != ReadingContextEnum::Sample_Periodic) {
+            EVLOG_info << "Not sending MeterValue due to wrong context";
+            return;
+        }
+
+        const auto filter_vec = utils::get_measurands_vec(this->device_model->get_value<std::string>(
+            type == ReadingContextEnum::Sample_Clock ? ControllerComponentVariables::AlignedDataMeasurands
+                                                     : ControllerComponentVariables::SampledDataTxUpdatedMeasurands));
+
+        const auto filtered_meter_value = utils::get_meter_value_with_measurands_applied(_meter_value, filter_vec);
+
+        if (!filtered_meter_value.sampledValue.empty()) {
+            const auto trigger = type == ReadingContextEnum::Sample_Clock ? TriggerReasonEnum::MeterValueClock
+                                                                          : TriggerReasonEnum::MeterValuePeriodic;
+            this->transaction_event_req(TransactionEventEnum::Updated, DateTime(), transaction, trigger,
+                                        transaction.get_seq_no(), std::nullopt, std::nullopt, std::nullopt,
+                                        std::vector<MeterValue>(1, filtered_meter_value), std::nullopt,
+                                        this->is_offline(), std::nullopt);
+        }
+    };
+
+    // Setup EvseManager - needs evse_connector_structure, device_model, database_handler, component_state_manager,
+    // callbacks
+    this->evse_manager = std::make_unique<EvseManager>(
+        evse_connector_structure, *this->device_model, this->database_handler, component_state_manager,
+        transaction_meter_value_callback, this->callbacks.pause_charging_callback);
+
+    this->configure_message_logging_format(message_log_path);
+
+    this->auth_cache_cleanup_thread = std::thread(&ChargePoint::cache_cleanup_handler, this);
+}
+
+ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
                          const std::string& device_model_storage_address, const bool initialize_device_model,
                          const std::string& device_model_migration_path, const std::string& device_model_schemas_path,
                          const std::string& config_path, const std::string& ocpp_main_path,

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3271,7 +3271,7 @@ void ChargePoint::handle_set_charging_profile_req(Call<SetChargingProfileRequest
 
     // K01.FR.29: Reject if SmartCharging is not available for this Charging Station
     bool is_charging_station_enable =
-        this->device_model->get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrAvailable)
+        this->device_model->get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrAvailableEnabled)
             .value_or(false);
 
     if (!is_charging_station_enable) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3269,6 +3269,21 @@ void ChargePoint::handle_set_charging_profile_req(Call<SetChargingProfileRequest
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatusEnum::Rejected;
 
+    // K01.FR.29: Reject if SmartCharging is not available for this Charging Station
+    bool is_charging_station_enable =
+        this->device_model->get_optional_value<bool>(ControllerComponentVariables::SmartChargingCtrlrAvailable)
+            .value_or(false);
+
+    if (!is_charging_station_enable) {
+        EVLOG_warning << "SmartChargingCtrlrAvailable is not set for Charging Station. Returning NotSupported error";
+
+        const auto call_error =
+            CallError(call.uniqueId, "NotSupported", "Charging Station does not support smart charging", json({}));
+        this->send(call_error);
+
+        return;
+    }
+
     // K01.FR.22: Reject ChargingStationExternalConstraints profiles in SetChargingProfileRequest
     if (msg.chargingProfile.chargingProfilePurpose == ChargingProfilePurposeEnum::ChargingStationExternalConstraints) {
         response.statusInfo = StatusInfo();

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -322,12 +322,12 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
 
         for (auto i = 0; i < schedule.chargingSchedulePeriod.size(); i++) {
             auto& charging_schedule_period = schedule.chargingSchedulePeriod[i];
-            // K01.FR.19
+            // K01.FR.48 and K01.FR.19
             if (charging_schedule_period.numberPhases != 1 && charging_schedule_period.phaseToUse.has_value()) {
                 return ProfileValidationResultEnum::ChargingSchedulePeriodInvalidPhaseToUse;
             }
 
-            // K01.FR.20
+            // K01.FR.48 and K01.FR.20
             if (charging_schedule_period.phaseToUse.has_value() &&
                 !device_model->get_optional_value<bool>(ControllerComponentVariables::ACPhaseSwitchingSupported)
                      .value_or(false)) {

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -711,4 +711,49 @@ TEST_F(ChargePointFixture, K01FR22_SetChargingProfileRequest_RejectsChargingStat
     charge_point->handle_message(set_charging_profile_req);
 }
 
+/// This test ensures that when Smart Charging isn't available it doesn't process the submitted profile.
+///
+/// This test is disabled because it only passes if the ControllerComponentVariables::SmartChargingCtrlrAvailable
+/// entry is removed from the config/v201/config.json file.
+TEST_F(ChargePointFixture, DISABLED_K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCallError) {
+    auto evse_connector_structure = create_evse_connector_structure();
+    auto database_handler = create_database_handler();
+    auto evse_security = std::make_shared<EvseSecurityMock>();
+    configure_callbacks_with_mocks();
+
+    const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
+    std::shared_ptr<MessageQueue<v201::MessageType>> message_queue =
+        std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
+            [this](json message) -> bool { return false; },
+            MessageQueueConfig{
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageAttempts),
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageAttemptInterval),
+                this->device_model->get_optional_value<int>(ControllerComponentVariables::MessageQueueSizeThreshold)
+                    .value_or(DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD),
+                this->device_model->get_optional_value<bool>(ControllerComponentVariables::QueueAllMessages)
+                    .value_or(false),
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageTimeout)},
+            database_handler);
+
+    ocpp::v201::ChargePoint chargePoint(evse_connector_structure, device_model, database_handler, message_queue, "/tmp",
+                                        evse_security, callbacks);
+
+    auto periods = create_charging_schedule_periods({0, 1, 2});
+
+    auto profile = create_charging_profile(
+        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
+
+    SetChargingProfileRequest req;
+    req.evseId = DEFAULT_EVSE_ID;
+    req.chargingProfile = profile;
+
+    auto set_charging_profile_req =
+        request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
+
+    EXPECT_CALL(*smart_charging_handler, validate_profile(testing::_, testing::_)).Times(0);
+
+    charge_point->handle_message(set_charging_profile_req);
+}
+
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -61,6 +61,13 @@ public:
         charge_point->stop();
     }
 
+    std::map<int32_t, int32_t> create_evse_connector_structure() {
+        std::map<int32_t, int32_t> evse_connector_structure;
+        evse_connector_structure.insert_or_assign(1, 1);
+        evse_connector_structure.insert_or_assign(2, 1);
+        return evse_connector_structure;
+    }
+
     void create_device_model_db(const std::string& path) {
         InitDeviceModelDb db(path, MIGRATION_FILES_PATH);
         db.initialize_database(SCHEMAS_PATH, true);
@@ -72,7 +79,6 @@ public:
         create_device_model_db(DEVICE_MODEL_DB_IN_MEMORY_PATH);
         auto device_model_storage = std::make_unique<DeviceModelStorageSqlite>(DEVICE_MODEL_DB_IN_MEMORY_PATH);
         auto device_model = std::make_shared<DeviceModel>(std::move(device_model_storage));
-
         // Defaults
         const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;
         device_model->set_value(charging_rate_unit_cv.component, charging_rate_unit_cv.variable.value(),
@@ -175,6 +181,27 @@ public:
     std::unique_ptr<TestChargePoint> charge_point = create_charge_point();
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
 
+    std::shared_ptr<DatabaseHandler> create_database_handler() {
+        auto database_connection = std::make_unique<common::DatabaseConnection>(fs::path("/tmp/ocpp201") / "cp.db");
+        return std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V201);
+    }
+
+    std::shared_ptr<MessageQueue<v201::MessageType>>
+    create_message_queue(std::shared_ptr<DatabaseHandler>& database_handler) {
+        const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
+        return std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
+            [this](json message) -> bool { return false; },
+            MessageQueueConfig{
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageAttempts),
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageAttemptInterval),
+                this->device_model->get_optional_value<int>(ControllerComponentVariables::MessageQueueSizeThreshold)
+                    .value_or(DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD),
+                this->device_model->get_optional_value<bool>(ControllerComponentVariables::QueueAllMessages)
+                    .value_or(false),
+                this->device_model->get_value<int>(ControllerComponentVariables::MessageTimeout)},
+            database_handler);
+    }
+
     void configure_callbacks_with_mocks() {
         callbacks.is_reset_allowed_callback = is_reset_allowed_callback_mock.AsStdFunction();
         callbacks.reset_callback = reset_callback_mock.AsStdFunction();
@@ -260,6 +287,68 @@ public:
  * consider its collection of callbacks valid if set_charging_profiles_callback
  * is provided.
  */
+
+TEST_F(ChargePointFixture, CreateChargePoint) {
+    auto evse_connector_structure = create_evse_connector_structure();
+    auto database_handler = create_database_handler();
+    auto evse_security = std::make_shared<EvseSecurityMock>();
+    configure_callbacks_with_mocks();
+    auto message_queue = create_message_queue(database_handler);
+
+    EXPECT_NO_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
+                                            "/tmp", evse_security, callbacks));
+}
+
+TEST_F(ChargePointFixture, CreateChargePoint_EVSEConnectorStructureDefinedBadly_ThrowsDeviceModelStorageError) {
+    auto database_handler = create_database_handler();
+    auto evse_security = std::make_shared<EvseSecurityMock>();
+    configure_callbacks_with_mocks();
+    auto message_queue = create_message_queue(database_handler);
+
+    auto evse_connector_structure = std::map<int32_t, int32_t>();
+
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
+                                         "/tmp", evse_security, callbacks),
+                 DeviceModelStorageError);
+}
+
+TEST_F(ChargePointFixture, CreateChargePoint_MissingDeviceModel_ThrowsInvalidArgument) {
+    auto evse_connector_structure = create_evse_connector_structure();
+    auto database_handler = create_database_handler();
+    auto evse_security = std::make_shared<EvseSecurityMock>();
+    configure_callbacks_with_mocks();
+    auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
+        [this](json message) -> bool { return false; }, MessageQueueConfig{}, database_handler);
+
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, nullptr, database_handler, message_queue, "/tmp",
+                                         evse_security, callbacks),
+                 std::invalid_argument);
+}
+
+TEST_F(ChargePointFixture, CreateChargePoint_MissingDatabaseHandler_ThrowsInvalidArgument) {
+    auto evse_connector_structure = create_evse_connector_structure();
+    auto evse_security = std::make_shared<EvseSecurityMock>();
+    configure_callbacks_with_mocks();
+    auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
+        [this](json message) -> bool { return false; }, MessageQueueConfig{}, nullptr);
+
+    auto database_handler = nullptr;
+
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
+                                         "/tmp", evse_security, callbacks),
+                 std::invalid_argument);
+}
+
+TEST_F(ChargePointFixture, CreateChargePoint_CallbacksNotValid_ThrowsInvalidArgument) {
+    auto evse_connector_structure = create_evse_connector_structure();
+    auto database_handler = create_database_handler();
+    auto evse_security = std::make_shared<EvseSecurityMock>();
+    auto message_queue = create_message_queue(database_handler);
+
+    EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, device_model, database_handler, message_queue,
+                                         "/tmp", evse_security, callbacks),
+                 std::invalid_argument);
+}
 
 TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
     configure_callbacks_with_mocks();

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -270,7 +270,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
+TEST_F(ChargepointTestFixtureV201, K01FR48FR19_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 0, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -282,7 +282,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPhaseToUseSe
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodInvalidPhaseToUse));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedUndefined_ThenProfileIsInvalid) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR48FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedUndefined_ThenProfileIsInvalid) {
     // As a device model with ac switching supported default set to 'true', we want to create a new database with the
     // ac switching support not set. But this is an in memory database, which is kept open until all handles to it are
     // closed. So we close all connections to the database.
@@ -306,7 +307,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSup
                 testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedFalse_ThenProfileIsInvalid) {
+TEST_F(ChargepointTestFixtureV201, K01FR48FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedFalse_ThenProfileIsInvalid) {
     // As a device model with ac switching supported default set to 'true', we want to create a new database with the
     // ac switching support not set. But this is an in memory database, which is kept open until all handles to it are
     // closed. So we close all connections to the database.
@@ -330,7 +331,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSup
                 testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedTrue_ThenProfileIsNotInvalid) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR48FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedTrue_ThenProfileIsNotInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,


### PR DESCRIPTION
## Describe your changes

Created a new constructor for ChargePoint which allows dependency injection of the DeviceModel, DatabaseHandler, and MessageQueue. This change should allow for unit tests to be easier to create as the context for the tests can more easily be controlled.

Also implemented K01-FR29 - return an error when Smart Charging is not supported when receiving a ChargePoint::handle_set_charging_profile_req. 

Update the status doc to reflect current state.


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

