### PR TITLE
ChargePoint: add support for SecurityEventNotification `FirmwareUpdated` after reboot

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -239,6 +239,12 @@ void ChargePoint::start(BootReasonEnum bootreason) {
             this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
         this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
                                               std::optional<CiString<255>>(startup_message), true, true);
+    } else if (this->bootreason == BootReasonEnum::FirmwareUpdate) {
+        std::string startup_message = "Charging station reboot after firmware update. Firmware version: ";
+        startup_message.append(
+            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+        this->security_event_notification_req(CiString<50>(ocpp::security_events::FIRMWARE_UPDATED),
+                                              std::optional<CiString<255>>(startup_message), true, true);
     } else {
         std::string startup_message = "Charging station reset or reboot. Firmware version: ";
         startup_message.append(

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -225,6 +225,9 @@ void ChargePoint::start(BootReasonEnum bootreason) {
     this->load_charging_profiles();
     this->start_websocket();
 
+    const std::string firmware_version =
+        this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion);
+
     if (this->bootreason == BootReasonEnum::RemoteReset) {
         this->security_event_notification_req(
             CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
@@ -234,21 +237,16 @@ void ChargePoint::start(BootReasonEnum bootreason) {
             CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
             std::optional<CiString<255>>("Charging Station rebooted due to a scheduled reset!"), true, true);
     } else if (this->bootreason == BootReasonEnum::PowerUp) {
-        std::string startup_message = "Charging Station powered up! Firmware version: ";
-        startup_message.append(
-            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+        std::string startup_message = "Charging Station powered up! Firmware version: " + firmware_version;
         this->security_event_notification_req(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
                                               std::optional<CiString<255>>(startup_message), true, true);
     } else if (this->bootreason == BootReasonEnum::FirmwareUpdate) {
-        std::string startup_message = "Charging station reboot after firmware update. Firmware version: ";
-        startup_message.append(
-            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+        std::string startup_message =
+            "Charging station reboot after firmware update. Firmware version: " + firmware_version;
         this->security_event_notification_req(CiString<50>(ocpp::security_events::FIRMWARE_UPDATED),
                                               std::optional<CiString<255>>(startup_message), true, true);
     } else {
-        std::string startup_message = "Charging station reset or reboot. Firmware version: ";
-        startup_message.append(
-            this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion));
+        std::string startup_message = "Charging station reset or reboot. Firmware version: " + firmware_version;
         this->security_event_notification_req(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
                                               std::optional<CiString<255>>(startup_message), true, true);
     }


### PR DESCRIPTION
## Describe your changes
Requirement L01.FR.31 prescribes a SecurityEventNotification `FirmwareUpdated` after the firmware update.

If the `system` interface notifies a FirmwareStatus `Installed` without a reboot, this is already handled correctly in `on_firmware_update_status_notification()`. Yet if the `system` interface notifies a FirmwareStatus `InstallRebooting` and continues to reboot, the OCPP module needs to send this SecurityEventNotification after startup.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

