### PR TITLE
Add "critical" optional parameter to on_security_event()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.16.0
+    VERSION 0.16.1
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 #ifndef OCPP_COMMON_TYPES_HPP
 #define OCPP_COMMON_TYPES_HPP
 
@@ -774,6 +774,8 @@ inline const std::string INVALIDCHARGINGSTATIONCERTIFICATE = "InvalidChargingSta
 inline const std::string INVALIDCHARGEPOINTCERTIFICATE = "InvalidChargePointCertificate"; // for OCPP1.6
 inline const std::string INVALIDTLSVERSION = "InvalidTLSVersion";
 inline const std::string INVALIDTLSCIPHERSUITE = "InvalidTLSCipherSuite";
+inline const std::string MAINTENANCELOGINACCEPTED = "MaintenanceLoginAccepted";
+inline const std::string MAINTENANCELOGINFAILED = "MaintenanceLoginFailed";
 } // namespace security_events
 
 enum class MessageDirection {

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 
 #pragma once
 
@@ -354,7 +354,11 @@ public:
     /// CSMS
     /// \param type type of the security event
     /// \param tech_info additional info of the security event
-    virtual void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info) = 0;
+    /// \param critical if set this overwrites the default criticality recommended in the OCPP 2.0.1 appendix. A
+    /// critical security event is transmitted as a message to the CSMS, a non-critical one is just written to the
+    /// security log
+    virtual void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                                   const std::optional<bool>& critical = std::nullopt) = 0;
 
     /// \brief Event handler that will update the variable internally when it has been changed on the fly.
     /// \param set_variable_data contains data of the variable to set
@@ -937,7 +941,8 @@ public:
 
     void on_log_status_notification(UploadLogStatusEnum status, int32_t requestId) override;
 
-    void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info) override;
+    void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                           const std::optional<bool>& critical = std::nullopt) override;
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
 

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 #ifndef V201_UTILS_HPP
 #define V201_UTILS_HPP
 
@@ -59,6 +59,9 @@ ocpp::DateTime align_timestamp(const DateTime timestamp, std::chrono::seconds al
 
 /// \brief Returns the total Power_Active_Import value from the \p meter_value or std::nullopt if it is not present
 std::optional<float> get_total_power_active_import(const MeterValue& meter_value);
+
+/// \brief Determines if a given \p security_event is critical as defined in the OCPP 2.0.1 appendix
+bool is_critical(const std::string& security_event);
 
 } // namespace utils
 } // namespace v201

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -933,8 +933,15 @@ void ChargePoint::on_log_status_notification(UploadLogStatusEnum status, int32_t
     this->send<LogStatusNotificationRequest>(call);
 }
 
-void ChargePoint::on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info) {
-    this->security_event_notification_req(event_type, tech_info, false, false);
+void ChargePoint::on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                                    const std::optional<bool>& critical) {
+    auto critical_security_event = true;
+    if (critical.has_value()) {
+        critical_security_event = critical.value();
+    } else {
+        critical_security_event = utils::is_critical(event_type);
+    }
+    this->security_event_notification_req(event_type, tech_info, false, critical_security_event);
 }
 
 void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) {

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright Pionix GmbH and Contributors to EVerest
 
 #include <everest/logging.hpp>
 
@@ -145,6 +145,42 @@ std::optional<float> get_total_power_active_import(const MeterValue& meter_value
         }
     }
     return std::nullopt;
+}
+
+bool is_critical(const std::string& security_event) {
+    if (security_event == ocpp::security_events::FIRMWARE_UPDATED) {
+        return true;
+    } else if (security_event == ocpp::security_events::SETTINGSYSTEMTIME) {
+        return true;
+    } else if (security_event == ocpp::security_events::STARTUP_OF_THE_DEVICE) {
+        return true;
+    } else if (security_event == ocpp::security_events::RESET_OR_REBOOT) {
+        return true;
+    } else if (security_event == ocpp::security_events::SECURITYLOGWASCLEARED) {
+        return true;
+    } else if (security_event == ocpp::security_events::MEMORYEXHAUSTION) {
+        return true;
+    } else if (security_event == ocpp::security_events::TAMPERDETECTIONACTIVATED) {
+        return true;
+    } else if (security_event == ocpp::security_events::INVALIDFIRMWARESIGNATURE) {
+        return true;
+    } else if (security_event == ocpp::security_events::INVALIDFIRMWARESIGNINGCERTIFICATE) {
+        return true;
+    } else if (security_event == ocpp::security_events::INVALIDCSMSCERTIFICATE) {
+        return true;
+    } else if (security_event == ocpp::security_events::INVALIDCHARGINGSTATIONCERTIFICATE) {
+        return true;
+    } else if (security_event == ocpp::security_events::INVALIDTLSVERSION) {
+        return true;
+    } else if (security_event == ocpp::security_events::INVALIDTLSCIPHERSUITE) {
+        return true;
+    } else if (security_event == ocpp::security_events::MAINTENANCELOGINACCEPTED) {
+        return true;
+    } else if (security_event == ocpp::security_events::MAINTENANCELOGINFAILED) {
+        return true;
+    }
+
+    return false;
 }
 
 } // namespace utils

--- a/tests/lib/ocpp/v201/utils_tests.cpp
+++ b/tests/lib/ocpp/v201/utils_tests.cpp
@@ -47,5 +47,29 @@ TEST_F(V201UtilsTest, test_valid_generate_token_hash) {
               ocpp::v201::utils::generate_token_hash(valid_iso15693_token));
 }
 
+TEST_F(V201UtilsTest, test_is_critical_security_event) {
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::FIRMWARE_UPDATED));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::SETTINGSYSTEMTIME));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::STARTUP_OF_THE_DEVICE));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::RESET_OR_REBOOT));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::SECURITYLOGWASCLEARED));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::MEMORYEXHAUSTION));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::TAMPERDETECTIONACTIVATED));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::INVALIDFIRMWARESIGNATURE));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::INVALIDFIRMWARESIGNINGCERTIFICATE));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::INVALIDCSMSCERTIFICATE));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::INVALIDCHARGINGSTATIONCERTIFICATE));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::INVALIDTLSVERSION));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::INVALIDTLSCIPHERSUITE));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::MAINTENANCELOGINACCEPTED));
+    EXPECT_TRUE(ocpp::v201::utils::is_critical(ocpp::security_events::MAINTENANCELOGINFAILED));
+
+    EXPECT_FALSE(ocpp::v201::utils::is_critical(ocpp::security_events::FAILEDTOAUTHENTICATEATCSMS));
+    EXPECT_FALSE(ocpp::v201::utils::is_critical(ocpp::security_events::CSMSFAILEDTOAUTHENTICATE));
+    EXPECT_FALSE(ocpp::v201::utils::is_critical(ocpp::security_events::RECONFIGURATIONOFSECURITYPARAMETERS));
+    EXPECT_FALSE(ocpp::v201::utils::is_critical(ocpp::security_events::INVALIDMESSAGES));
+    EXPECT_FALSE(ocpp::v201::utils::is_critical(ocpp::security_events::ATTEMPTEDREPLAYATTACKS));
+}
+
 } // namespace common
 } // namespace ocpp


### PR DESCRIPTION
If this is set and true the event is treated as a critical security event and transmitted to the csms

If this is not set a fallback is_critical() function is called that performs a lookup based on the recommendations in the OCPP 2.0.1 appendix

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

