### PR TITLE
Feature/k02 05 cumulative

### DIFF
--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1286,7 +1286,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K02.FR.02 | ❎     | This should be handled by the user of `libocpp`. |
 | K02.FR.03 | ❎     |                                                  |
 | K02.FR.04 |        |                                                  |
-| K02.FR.05 |        |                                                  |
+| K02.FR.05 | ✅     |                                                  |
 | K02.FR.06 |        | The same as K01.FR.21                            |
 | K02.FR.07 |        | The same as K01.FR.22                            |
 | K02.FR.08 |        |                                                  |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1266,7 +1266,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K01.FR.40 | ✅     | `Absolute`/`Recurring` profiles without `startSchedule` fields are rejected.                    |
 | K01.FR.41 | ✅     | `Relative` profiles with `startSchedule` fields are rejected.                                   |
 | K01.FR.42 | ⛽️     |                                                                                                 |
-| K01.FR.43 |        |  Open question to OCA - https://oca.causewaynow.com/wg/OCA-TWG/mail/thread/4254                 |
+| K01.FR.43 |        |  Open question to OCA - https://oca.causewaynow.com/wg/OCA-TWG/mail/thread/4254                |
 | K01.FR.44 | ✅     | We reject invalid profiles instead of modifying and accepting them.                             |
 | K01.FR.45 | ✅     | We reject invalid profiles instead of modifying and accepting them.                             |
 | K01.FR.46 | ⛽️     | K08                                                                                             |
@@ -1285,7 +1285,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | K02.FR.01 | ❎     |                                                  |
 | K02.FR.02 | ❎     | This should be handled by the user of `libocpp`. |
 | K02.FR.03 | ❎     |                                                  |
-| K02.FR.04 |        |                                                  |
+| K02.FR.04 | ✅     |                                                  |
 | K02.FR.05 | ✅     |                                                  |
 | K02.FR.06 |        | The same as K01.FR.21                            |
 | K02.FR.07 |        | The same as K01.FR.22                            |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1308,7 +1308,7 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 
 | ID        | Status | Remark                                           |
 |-----------|--------|--------------------------------------------------|
-| K04.FR.01 |        |                                                  |
+| K04.FR.01 | ✅     |                                                  |
 | K04.FR.02 |        |                                                  |
 | K04.FR.03 | ✅     |                                                  |
 | K04.FR.04 |        | The same as K01.FR.21                            |

--- a/doc/ocpp_201_status.md
+++ b/doc/ocpp_201_status.md
@@ -1319,10 +1319,10 @@ This document contains the status of which OCPP 2.0.1 numbered functional requir
 | ID        | Status | Remark |
 |-----------|--------|--------|
 | K05.FR.01 | ❎     |        |
-| K05.FR.02 |        |        |
-| K05.FR.03 |        |        |
-| K05.FR.04 |        |        |
-| K05.FR.05 |        |        |
+| K05.FR.02 | ✅     |        |
+| K05.FR.03 | ✅     |        |
+| K05.FR.04 | ✅     |        |
+| K05.FR.05 | ✅     |        |
 
 ## SmartCharging - Offline Behavior Smart Charging During Transaction
 

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -196,6 +196,11 @@ protected:
     ///
     ProfileValidationResultEnum verify_no_conflicting_external_constraints_id(const ChargingProfile& profile) const;
 
+    ///
+    /// \brief Retrieves existing profiles on the EVSE \p evse_id
+    ///
+    std::vector<ChargingProfile> get_profiles_on_evse(int32_t evse_id) const;
+
 private:
     std::vector<ChargingProfile> get_station_wide_profiles() const;
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -44,7 +44,8 @@ enum class ProfileValidationResultEnum {
     ChargingStationMaxProfileCannotBeRelative,
     ChargingStationMaxProfileEvseIdGreaterThanZero,
     DuplicateTxDefaultProfileFound,
-    DuplicateProfileValidityPeriod
+    DuplicateProfileValidityPeriod,
+    RequestStartTransactionNonTxProfile
 };
 
 /// \brief This enhances the ChargingProfile type by additional paramaters that are required in the
@@ -201,6 +202,10 @@ protected:
     /// we set it to the default value (3).
     ProfileValidationResultEnum validate_profile_schedules(ChargingProfile& profile,
                                                            std::optional<EvseInterface*> evse_opt = std::nullopt) const;
+
+    /// \brief validates that the given \p profile from a RequestStartTransactionRequest is of the correct type
+    /// TxProfile
+    ProfileValidationResultEnum validate_request_start_transaction_profile(const ChargingProfile& profile) const;
 
     ///
     /// \brief Checks a given \p profile and associated \p evse_id validFrom and validTo range

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -61,8 +61,7 @@ struct ReportedChargingProfile {
 };
 enum class AddChargingProfileSource {
     SetChargingProfile,
-    RequestStartTransactionRequest,
-    Unknown
+    RequestStartTransactionRequest
 };
 
 namespace conversions {
@@ -81,13 +80,13 @@ class SmartChargingHandlerInterface {
 public:
     virtual ~SmartChargingHandlerInterface() = default;
 
-    virtual SetChargingProfileResponse
-    validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
-                             AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) = 0;
+    virtual SetChargingProfileResponse validate_and_add_profile(
+        ChargingProfile& profile, int32_t evse_id,
+        AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
 
     virtual ProfileValidationResultEnum
     validate_profile(ChargingProfile& profile, int32_t evse_id,
-                     AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) = 0;
+                     AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
 
     virtual SetChargingProfileResponse add_profile(ChargingProfile& profile, int32_t evse_id) = 0;
 
@@ -122,18 +121,18 @@ public:
     /// \brief validates the given \p profile according to the specification,
     /// adding it to our stored list of profiles if valid.
     ///
-    SetChargingProfileResponse
-    validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
-                             AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) override;
+    SetChargingProfileResponse validate_and_add_profile(
+        ChargingProfile& profile, int32_t evse_id,
+        AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) override;
 
     ///
     /// \brief validates the given \p profile according to the specification.
     /// If a profile does not have validFrom or validTo set, we conform the values
     /// to a representation that fits the spec.
     ///
-    ProfileValidationResultEnum
-    validate_profile(ChargingProfile& profile, int32_t evse_id,
-                     AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) override;
+    ProfileValidationResultEnum validate_profile(
+        ChargingProfile& profile, int32_t evse_id,
+        AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) override;
 
     ///
     /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles
@@ -189,9 +188,9 @@ protected:
     ///
     /// \brief validates the given \p profile according to the specification
     ///
-    ProfileValidationResultEnum
-    validate_tx_profile(const ChargingProfile& profile, int32_t evse_id,
-                        AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) const;
+    ProfileValidationResultEnum validate_tx_profile(
+        const ChargingProfile& profile, int32_t evse_id,
+        AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) const;
 
     /// \brief validates that the given \p profile has valid charging schedules.
     /// If a profiles charging schedule period does not have a valid numberPhases,

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -59,6 +59,11 @@ struct ReportedChargingProfile {
         profile(profile), evse_id(evse_id), source(source) {
     }
 };
+enum class AddChargingProfileSource {
+    SetChargingProfile,
+    RequestStartTransactionRequest,
+    Unknown
+};
 
 namespace conversions {
 /// \brief Converts the given ProfileValidationResultEnum \p e to human readable string
@@ -76,9 +81,13 @@ class SmartChargingHandlerInterface {
 public:
     virtual ~SmartChargingHandlerInterface() = default;
 
-    virtual SetChargingProfileResponse validate_and_add_profile(ChargingProfile& profile, int32_t evse_id) = 0;
+    virtual SetChargingProfileResponse
+    validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
+                             AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) = 0;
 
-    virtual ProfileValidationResultEnum validate_profile(ChargingProfile& profile, int32_t evse_id) = 0;
+    virtual ProfileValidationResultEnum
+    validate_profile(ChargingProfile& profile, int32_t evse_id,
+                     AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) = 0;
 
     virtual SetChargingProfileResponse add_profile(ChargingProfile& profile, int32_t evse_id) = 0;
 
@@ -113,14 +122,18 @@ public:
     /// \brief validates the given \p profile according to the specification,
     /// adding it to our stored list of profiles if valid.
     ///
-    SetChargingProfileResponse validate_and_add_profile(ChargingProfile& profile, int32_t evse_id) override;
+    SetChargingProfileResponse
+    validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
+                             AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) override;
 
     ///
     /// \brief validates the given \p profile according to the specification.
     /// If a profile does not have validFrom or validTo set, we conform the values
     /// to a representation that fits the spec.
     ///
-    ProfileValidationResultEnum validate_profile(ChargingProfile& profile, int32_t evse_id) override;
+    ProfileValidationResultEnum
+    validate_profile(ChargingProfile& profile, int32_t evse_id,
+                     AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) override;
 
     ///
     /// \brief Adds a given \p profile and associated \p evse_id to our stored list of profiles
@@ -176,7 +189,9 @@ protected:
     ///
     /// \brief validates the given \p profile according to the specification
     ///
-    ProfileValidationResultEnum validate_tx_profile(const ChargingProfile& profile, int32_t evse_id) const;
+    ProfileValidationResultEnum
+    validate_tx_profile(const ChargingProfile& profile, int32_t evse_id,
+                        AddChargingProfileSource source_of_request = AddChargingProfileSource::Unknown) const;
 
     /// \brief validates that the given \p profile has valid charging schedules.
     /// If a profiles charging schedule period does not have a valid numberPhases,

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -60,6 +60,9 @@ struct ReportedChargingProfile {
         profile(profile), evse_id(evse_id), source(source) {
     }
 };
+
+/// \brief This is used to associate charging profiles with a source.
+/// Based on the source a different validation path can be taken.
 enum class AddChargingProfileSource {
     SetChargingProfile,
     RequestStartTransactionRequest
@@ -120,6 +123,9 @@ public:
     SmartChargingHandler(EvseManagerInterface& evse_manager, std::shared_ptr<DeviceModel>& device_model,
                          std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler);
 
+    ///
+    /// \brief for the given \p transaction_id removes the associated charging profile.
+    ///
     void delete_transaction_tx_profiles(const std::string& transaction_id) override;
 
     ///

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -84,6 +84,8 @@ public:
         ChargingProfile& profile, int32_t evse_id,
         AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
 
+    virtual void delete_transaction_tx_profiles(const std::string& transaction_id) = 0;
+
     virtual ProfileValidationResultEnum
     validate_profile(ChargingProfile& profile, int32_t evse_id,
                      AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
@@ -116,6 +118,8 @@ private:
 public:
     SmartChargingHandler(EvseManagerInterface& evse_manager, std::shared_ptr<DeviceModel>& device_model,
                          std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler);
+
+    void delete_transaction_tx_profiles(const std::string& transaction_id) override;
 
     ///
     /// \brief validates the given \p profile according to the specification,

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -442,6 +442,8 @@ void ChargePoint::on_transaction_finished(const int32_t evse_id, const DateTime&
                                 trigger_reason, enhanced_transaction->get_seq_no(), std::nullopt, std::nullopt,
                                 transaction_id_token, meter_values, std::nullopt, this->is_offline(), std::nullopt);
 
+    // K02.FR.05 The transaction is over, so delete the TxProfiles associated with the transaction.
+    smart_charging_handler->delete_transaction_tx_profiles(enhanced_transaction->get_transaction().transactionId);
     evse_handle.release_transaction();
 
     bool send_reset = false;

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -489,14 +489,7 @@ SetChargingProfileResponse SmartChargingHandler::add_profile(ChargingProfile& pr
 }
 
 std::vector<ChargingProfile> SmartChargingHandler::get_station_wide_profiles() const {
-    std::vector<ChargingProfile> station_wide_profiles;
-    if (charging_profiles.count(STATION_WIDE_ID) > 0) {
-        station_wide_profiles = charging_profiles.at(STATION_WIDE_ID);
-    } else {
-        station_wide_profiles = {};
-    }
-
-    return station_wide_profiles;
+    return this->get_profiles_on_evse(STATION_WIDE_ID);
 }
 
 std::vector<ChargingProfile> SmartChargingHandler::get_profiles() const {

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -14,6 +14,7 @@
 #include "ocpp/v201/profile.hpp"
 #include "ocpp/v201/utils.hpp"
 #include <algorithm>
+#include <cstring>
 #include <iterator>
 #include <ocpp/common/constants.hpp>
 #include <ocpp/v201/smart_charging.hpp>
@@ -213,6 +214,20 @@ SmartChargingHandler::SmartChargingHandler(EvseManagerInterface& evse_manager,
                                            std::shared_ptr<DeviceModel>& device_model,
                                            std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler) :
     evse_manager(evse_manager), device_model(device_model), database_handler(database_handler) {
+}
+
+void SmartChargingHandler::delete_transaction_tx_profiles(const std::string& transaction_id) {
+    for (auto& [evse_id, profiles] : charging_profiles) {
+        auto iter = profiles.begin();
+        while (iter != profiles.end()) {
+            if (transaction_id.compare(iter->transactionId.value()) == 0) {
+                this->database_handler->delete_charging_profile(iter->id);
+                iter = profiles.erase(iter);
+            } else {
+                ++iter;
+            }
+        }
+    }
 }
 
 SetChargingProfileResponse SmartChargingHandler::validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -544,7 +544,14 @@ SmartChargingHandler::get_reported_profiles(const GetChargingProfilesRequest& re
             }
         }
     }
+    return profiles;
+}
 
+std::vector<ChargingProfile> SmartChargingHandler::get_profiles_on_evse(int32_t evse_id) const {
+    std::vector<ChargingProfile> profiles;
+    if (charging_profiles.count(evse_id)) {
+        profiles = charging_profiles.at(evse_id);
+    }
     return profiles;
 }
 

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -215,11 +215,12 @@ SmartChargingHandler::SmartChargingHandler(EvseManagerInterface& evse_manager,
     evse_manager(evse_manager), device_model(device_model), database_handler(database_handler) {
 }
 
-SetChargingProfileResponse SmartChargingHandler::validate_and_add_profile(ChargingProfile& profile, int32_t evse_id) {
+SetChargingProfileResponse SmartChargingHandler::validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
+                                                                          AddChargingProfileSource source_of_request) {
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatusEnum::Rejected;
 
-    auto result = this->validate_profile(profile, evse_id);
+    auto result = this->validate_profile(profile, evse_id, source_of_request);
     if (result == ProfileValidationResultEnum::Valid) {
         response = this->add_profile(profile, evse_id);
     } else {
@@ -231,7 +232,8 @@ SetChargingProfileResponse SmartChargingHandler::validate_and_add_profile(Chargi
     return response;
 }
 
-ProfileValidationResultEnum SmartChargingHandler::validate_profile(ChargingProfile& profile, int32_t evse_id) {
+ProfileValidationResultEnum SmartChargingHandler::validate_profile(ChargingProfile& profile, int32_t evse_id,
+                                                                   AddChargingProfileSource source_of_request) {
     conform_validity_periods(profile);
 
     auto result = ProfileValidationResultEnum::Valid;
@@ -265,7 +267,7 @@ ProfileValidationResultEnum SmartChargingHandler::validate_profile(ChargingProfi
         result = this->validate_tx_default_profile(profile, evse_id);
         break;
     case ChargingProfilePurposeEnum::TxProfile:
-        result = this->validate_tx_profile(profile, evse_id);
+        result = this->validate_tx_profile(profile, evse_id, source_of_request);
         break;
     case ChargingProfilePurposeEnum::ChargingStationExternalConstraints:
         // TODO: How do we check this? We shouldn't set it in
@@ -323,12 +325,9 @@ ProfileValidationResultEnum SmartChargingHandler::validate_tx_default_profile(Ch
     return ProfileValidationResultEnum::Valid;
 }
 
-ProfileValidationResultEnum SmartChargingHandler::validate_tx_profile(const ChargingProfile& profile,
-                                                                      int32_t evse_id) const {
-    if (!profile.transactionId.has_value()) {
-        return ProfileValidationResultEnum::TxProfileMissingTransactionId;
-    }
-
+ProfileValidationResultEnum
+SmartChargingHandler::validate_tx_profile(const ChargingProfile& profile, int32_t evse_id,
+                                          AddChargingProfileSource source_of_request) const {
     if (evse_id <= 0) {
         return ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero;
     }
@@ -337,6 +336,16 @@ ProfileValidationResultEnum SmartChargingHandler::validate_tx_profile(const Char
     auto result = this->validate_evse_exists(evse_id);
     if (result != ProfileValidationResultEnum::Valid) {
         return result;
+    }
+
+    // we can return valid here since the following checks verify the transactionId which is not given if the source is
+    // RequestStartTransactionRequest
+    if (source_of_request == AddChargingProfileSource::RequestStartTransactionRequest) {
+        return ProfileValidationResultEnum::Valid;
+    }
+
+    if (!profile.transactionId.has_value()) {
+        return ProfileValidationResultEnum::TxProfileMissingTransactionId;
     }
 
     auto& evse = evse_manager.get_evse(evse_id);

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -15,6 +15,7 @@ public:
                 (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
     MOCK_METHOD(ProfileValidationResultEnum, validate_profile,
                 (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
+    MOCK_METHOD(void, delete_transaction_tx_profiles, (const std::string& transaction_id));
     MOCK_METHOD(SetChargingProfileResponse, add_profile, (ChargingProfile & profile, int32_t evse_id));
     MOCK_METHOD(ClearChargingProfileResponse, clear_profiles, (const ClearChargingProfileRequest& request), (override));
     MOCK_METHOD(std::vector<ReportedChargingProfile>, get_reported_profiles,

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -11,8 +11,10 @@
 namespace ocpp::v201 {
 class SmartChargingHandlerMock : public SmartChargingHandlerInterface {
 public:
-    MOCK_METHOD(SetChargingProfileResponse, validate_and_add_profile, (ChargingProfile & profile, int32_t evse_id));
-    MOCK_METHOD(ProfileValidationResultEnum, validate_profile, (ChargingProfile & profile, int32_t evse_id));
+    MOCK_METHOD(SetChargingProfileResponse, validate_and_add_profile,
+                (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
+    MOCK_METHOD(ProfileValidationResultEnum, validate_profile,
+                (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
     MOCK_METHOD(SetChargingProfileResponse, add_profile, (ChargingProfile & profile, int32_t evse_id));
     MOCK_METHOD(ClearChargingProfileResponse, clear_profiles, (const ClearChargingProfileRequest& request), (override));
     MOCK_METHOD(std::vector<ReportedChargingProfile>, get_reported_profiles,

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -26,6 +26,8 @@
 static const int DEFAULT_EVSE_ID = 1;
 static const int DEFAULT_PROFILE_ID = 1;
 static const int DEFAULT_STACK_LEVEL = 1;
+static const ocpp::v201::AddChargingProfileSource DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE =
+    ocpp::v201::AddChargingProfileSource::Unknown;
 static const std::string TEMP_OUTPUT_PATH = "/tmp/ocpp201";
 const static std::string MIGRATION_FILES_PATH = "./resources/v201/device_model_migration_files";
 const static std::string SCHEMAS_PATH = "./resources/example_config/v201/component_config";
@@ -665,7 +667,8 @@ TEST_F(ChargePointFixture, K01_SetChargingProfileRequest_ValidatesAndAddsProfile
     auto set_charging_profile_req =
         request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
 
-    EXPECT_CALL(*smart_charging_handler, validate_and_add_profile(profile, DEFAULT_EVSE_ID));
+    EXPECT_CALL(*smart_charging_handler,
+                validate_and_add_profile(profile, DEFAULT_EVSE_ID, DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE));
 
     charge_point->handle_message(set_charging_profile_req);
 }

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -771,29 +771,6 @@ TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCa
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K05FR02_RequestStartTransactionRequest_SmartChargingCtrlrEnabledTrue_RejectsNonTxProfiles) {
-    const auto cv = ControllerComponentVariables::SmartChargingCtrlrEnabled;
-    this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true", "TEST", true);
-
-    auto periods = create_charging_schedule_periods({0, 1, 2});
-
-    auto profile = create_charging_profile(
-        DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
-        create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
-
-    RequestStartTransactionRequest req;
-    req.evseId = DEFAULT_EVSE_ID;
-    req.idToken = IdToken{.idToken = "Local", .type = IdTokenEnum::Local};
-    req.chargingProfile = profile;
-
-    auto start_transaction_req =
-        request_to_enhanced_message<RequestStartTransactionRequest, MessageType::RequestStartTransaction>(req);
-
-    EXPECT_CALL(*smart_charging_handler, validate_and_add_profile).Times(0);
-
-    charge_point->handle_message(start_transaction_req);
-}
-
 TEST_F(ChargePointFixture, K05FR05_RequestStartTransactionRequest_SmartChargingCtrlrEnabledTrue_ValidatesTxProfiles) {
     const auto cv = ControllerComponentVariables::SmartChargingCtrlrEnabled;
     this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true", "TEST", true);
@@ -917,7 +894,7 @@ TEST_F(ChargePointFixture, K08FR07_GetCompositeSchedule_DoesNotCalculateComposit
 }
 
 TEST_F(ChargePointFixture,
-       K02FR04_RequestStartTransactionRequest_SmartChargingCtrlrEnabledFalse_DoesNotValidateTxProfiles) {
+       K05FR04_RequestStartTransactionRequest_SmartChargingCtrlrEnabledFalse_DoesNotValidateTxProfiles) {
     const auto cv = ControllerComponentVariables::SmartChargingCtrlrEnabled;
     this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "false", "TEST", true);
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -548,6 +548,16 @@ TEST_F(ChargepointTestFixtureV201,
 }
 
 TEST_F(ChargepointTestFixtureV201,
+       K05_IfTxProfileHasNoTransactionIdButAddChargingProfileSourceIsRequestRemoteStartTransaction_ThenProfileIsValid) {
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A), {});
+    auto sut =
+        handler.validate_tx_profile(profile, DEFAULT_EVSE_ID, AddChargingProfileSource::RequestStartTransactionRequest);
+
+    EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
+}
+
+TEST_F(ChargepointTestFixtureV201,
        K01FR40_IfChargingProfileKindIsAbsoluteAndStartScheduleDoesNotExist_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1564,7 +1564,7 @@ TEST_F(ChargepointTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesT
 }
 
 TEST_F(ChargepointTestFixtureV201,
-       K02FR05_SmartChargingTransactionEnds_DoesNotDeleteTxProfilesWithDifferentTransactionId) {
+       K02FR05_DeleteTransactionTxProfiles_DoesNotDeleteTxProfilesWithDifferentTransactionId) {
     auto transaction_id = uuid();
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, transaction_id);
     auto other_transaction_id = uuid();

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1584,4 +1584,15 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(handler.get_profiles().size(), testing::Eq(1));
 }
 
+TEST_F(ChargepointTestFixtureV201, K05FR02_RequestStartTransactionRequest_ChargingProfileMustBeTxProfile) {
+    auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
+                                           create_charge_schedule(ChargingRateUnitEnum::A,
+                                                                  create_charging_schedule_periods({0, 1, 2}),
+                                                                  ocpp::DateTime("2024-01-17T17:00:00")));
+
+    auto sut =
+        handler.validate_profile(profile, DEFAULT_EVSE_ID, AddChargingProfileSource::RequestStartTransactionRequest);
+    ASSERT_THAT(sut, testing::Eq(ProfileValidationResultEnum::RequestStartTransactionNonTxProfile));
+}
+
 } // namespace ocpp::v201


### PR DESCRIPTION
## Describe your changes

- K04.FR.01 added `get_profiles_on_evse()` to verify that profiles are EVSE-specific and are only applied to that EVSE.
- Added `AddChargingProfileSource` to distinguish profile source for validation. Specifically, when `validate_and_add_profile` is called from `RequestStartTransactionRequest`.
- Removed `AddChargingProfileSource::Unknown` defaults to
`AddChargingProfileSource::SetChargingProfile` for the most validation
checks.
- Added a check on `SmartChargingCtrlrAvailableEnabled` for F01.FR26,
K05.FR04 and K05.FR05
- Added check for ChargingProfilePurposeEnum::TXProfile K05.FR02
- K02.FR.05 delete transaction-specific profile from database.


## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

