### PR TITLE
Add missing conversion to uint64_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.16.1
+    VERSION 0.16.2
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/v201/device_model.hpp
+++ b/include/ocpp/v201/device_model.hpp
@@ -27,7 +27,8 @@ template <typename T> struct RequestDeviceModelResponse {
 template <typename T> T to_specific_type(const std::string& value) {
     static_assert(std::is_same<T, std::string>::value || std::is_same<T, int>::value ||
                       std::is_same<T, double>::value || std::is_same<T, size_t>::value ||
-                      std::is_same<T, DateTime>::value || std::is_same<T, bool>::value,
+                      std::is_same<T, DateTime>::value || std::is_same<T, bool>::value ||
+                      std::is_same<T, uint64_t>::value,
                   "Requested unknown datatype");
 
     if constexpr (std::is_same<T, std::string>::value) {
@@ -43,6 +44,8 @@ template <typename T> T to_specific_type(const std::string& value) {
         return DateTime(value);
     } else if constexpr (std::is_same<T, bool>::value) {
         return ocpp::conversions::string_to_bool(value);
+    } else if constexpr (std::is_same<T, uint64_t>::value) {
+        return std::stoull(value);
     }
 }
 


### PR DESCRIPTION
This can cause problems with some compilers

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

