### PR TITLE
Defect: ChargePoint init evse_manager before smart_charging_handler

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -957,8 +957,6 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
                              const std::string& message_log_path) {
     this->device_model->check_integrity(evse_connector_structure);
     this->database_handler->open_connection();
-    this->smart_charging_handler =
-        std::make_shared<SmartChargingHandler>(*this->evse_manager, this->device_model, this->database_handler);
     this->component_state_manager = std::make_shared<ComponentStateManager>(
         evse_connector_structure, database_handler,
         [this](auto evse_id, auto connector_id, auto status, bool initiated_by_trigger_message) {
@@ -1013,6 +1011,9 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
     this->evse_manager = std::make_unique<EvseManager>(
         evse_connector_structure, *this->device_model, this->database_handler, component_state_manager,
         transaction_meter_value_callback, this->callbacks.pause_charging_callback);
+
+    this->smart_charging_handler =
+        std::make_shared<SmartChargingHandler>(*this->evse_manager, this->device_model, this->database_handler);
 
     this->configure_message_logging_format(message_log_path);
     this->monitoring_updater.start_monitoring();


### PR DESCRIPTION
Initializing the evse_manager needs to happen before the reference is passed to smart_charging_handler.

Otherwise, smart_charging_handler will try to access a null object and cause a segfault.

The unit test exhibits the crash if the order of initialization is not fixed. However, this test may also fail if the fixture's TestChargePoint deletion also has a conflict somehow. This potential defect is captured in https://github.com/US-JOET/base-camp/issues/189 and not in scope for this PR. 

Valgrind output before the fix:

`[2024-08-29 13:34:57.439262] [0x0000000004036100] [info]    Found 1 evse in the database
==69923== Thread 1:
==69923== Invalid read of size 8
==69923==    at 0x661C88: ocpp::v201::SmartChargingHandler::validate_evse_exists(int) const (smart_charging.cpp:280)
==69923==    by 0x661AEF: ocpp::v201::SmartChargingHandler::validate_profile(ocpp::v201::ChargingProfile&, int) (smart_charging.cpp:237)
==69923==    by 0x5D4777: ocpp::v201::ChargePoint::load_charging_profiles() (charge_point.cpp:4101)
==69923==    by 0x5B2FEB: ocpp::v201::ChargePoint::start(ocpp::v201::BootReasonEnum) (charge_point.cpp:199)
==69923==    by 0x2E67F7: ocpp::v201::ChargePointFixture_CreateChargePoint_InitializeInCorrectOrder_Test::TestBody() (test_charge_point.cpp:305)
==69923==    by 0x88F293: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2599)
==69923==    by 0x889327: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2635)
==69923==    by 0x86BD27: testing::Test::Run() (gtest.cc:2674)
==69923==    by 0x86C62B: testing::TestInfo::Run() (gtest.cc:2853)
==69923==    by 0x86CDEF: testing::TestSuite::Run() (gtest.cc:3012)
==69923==    by 0x879DA7: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:5870)
==69923==    by 0x88FF5B: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2599)
==69923==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==69923== 
==69923== 
==69923== Process terminating with default action of signal 11 (SIGSEGV)
==69923==  Access not within mapped region at address 0x0`

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

