### PR TITLE
[janitorial]: fix enum warning in connector,  typo fixes

### DIFF
--- a/include/ocpp/common/aligned_timer.hpp
+++ b/include/ocpp/common/aligned_timer.hpp
@@ -25,7 +25,7 @@ private:
         auto now = std::chrono::system_clock::now();
         auto diff = now - this->start_point;
         auto time_to_next = 0s;
-        // Only calculate next time if it is positve. Otherwise we would end up before the start point
+        // Only calculate next time if it is positive. Otherwise we would end up before the start point
         if (diff > 0s) {
             time_to_next = ((std::chrono::duration_cast<std::chrono::seconds>(diff) / this->call_interval) + 1) *
                            this->call_interval;

--- a/include/ocpp/v201/enums.hpp
+++ b/include/ocpp/v201/enums.hpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
-// Manually added enums for OCPP, for the aut-generated ones see 'ocpp_enums.hpp'
+// Manually added enums for OCPP, for the auto-generated ones see 'ocpp_enums.hpp'
 
 #ifndef OCPP_V201_ENUMS_HPP
 #define OCPP_V201_ENUMS_HPP

--- a/lib/ocpp/v201/connector.cpp
+++ b/lib/ocpp/v201/connector.cpp
@@ -28,6 +28,10 @@ std::string connector_event_to_string(ConnectorEvent e) {
         return "Error";
     case ConnectorEvent::ErrorCleared:
         return "ErrorCleared";
+    case ConnectorEvent::Unavailable:
+        return "Unavailable";
+    case ConnectorEvent::UnavailableCleared:
+        return "UnavailableCleared";
     }
 
     throw EnumToStringException{e, "ConnectorEvent"};

--- a/src/code_generator/common/generate_cpp.py
+++ b/src/code_generator/common/generate_cpp.py
@@ -235,7 +235,7 @@ def parse_property(prop_name: str, prop: Dict, depends_on: List[str], ob_name=No
     - number
     - boolean
     - array
-    - object (will be parsed recursivly)
+    - object (will be parsed recursively)
     """
 
     prop_type = None


### PR DESCRIPTION
## Describe your changes

Some rather minor, janitorial changes I made when reading through the code. One fixes a compiler warning (and improves string conversion of an enum), and some typo fixes in comments.

## Issue ticket number and link

n/a, minor changes.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

