### PR TITLE
Config option to specify MessageTypesDiscardForQueueing

### DIFF
--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -277,6 +277,11 @@
             "type": "boolean",
             "readOnly": true
         },
+        "MessageTypesDiscardForQueueing": {
+            "$comment": "Comma seperated list of message types that shall not be queued (when offline) even in case QueueAllMessages is true. If QueueAllMessages is false, the configuration of this paramater has no effect.",
+            "type": "string",
+            "readOnly": true   
+        },
         "MessageQueueSizeThreshold": {
             "$comment": "Threshold for the size of in-memory message queues used to buffer messages (and store e.g. while offline). If threshold is exceeded, messages  will be dropped according to OCPP specification to avoid memory issues.",
             "type": "integer",

--- a/config/v201/component_config/standardized/OCPPCommCtrlr.json
+++ b/config/v201/component_config/standardized/OCPPCommCtrlr.json
@@ -209,6 +209,21 @@
       "description": "When this variable is set to true, the Charging Station will queue all message until they are delivered to the CSMS.",
       "type": "boolean"
     },
+    "MessageTypesDiscardForQueueing": {
+      "variable_name": "MessageTypesDiscardForQueueing",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "SequenceList"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadOnly"
+        }
+      ],
+      "description": "Comma seperated list of message types that shall not be queued (when offline) even in case QueueAllMessages is true. If QueueAllMessages is false, the configuration of this paramater has no effect.",
+      "type": "string"
+    },
     "ResetRetries": {
       "variable_name": "ResetRetries",
       "characteristics": {

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -133,6 +133,9 @@ public:
     std::optional<bool> getQueueAllMessages();
     std::optional<KeyValue> getQueueAllMessagesKeyValue();
 
+    std::optional<std::string> getMessageTypesDiscardForQueueing();
+    std::optional<KeyValue> getMessageTypesDiscardForQueueingKeyValue();
+
     std::optional<int> getMessageQueueSizeThreshold();
     std::optional<KeyValue> getMessageQueueSizeThresholdKeyValue();
 

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -165,6 +165,7 @@ extern const RequiredComponentVariable& NetworkConfigurationPriority;
 extern const RequiredComponentVariable& NetworkProfileConnectionAttempts;
 extern const RequiredComponentVariable& OfflineThreshold;
 extern const ComponentVariable& QueueAllMessages;
+extern const ComponentVariable& MessageTypesDiscardForQueueing;
 extern const RequiredComponentVariable& ResetRetries;
 extern const RequiredComponentVariable& RetryBackOffRandomRange;
 extern const RequiredComponentVariable& RetryBackOffRepeatTimes;

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -856,6 +856,26 @@ std::optional<KeyValue> ChargePointConfiguration::getQueueAllMessagesKeyValue() 
     return queue_all_messages_kv;
 }
 
+std::optional<std::string> ChargePointConfiguration::getMessageTypesDiscardForQueueing() {
+    if (this->config["Internal"].contains("MessageTypesDiscardForQueueing")) {
+        return this->config["Internal"]["MessageTypesDiscardForQueueing"];
+    }
+    return std::nullopt;
+}
+
+std::optional<KeyValue> ChargePointConfiguration::getMessageTypesDiscardForQueueingKeyValue() {
+    std::optional<KeyValue> message_types_discard_for_queueing_kv = std::nullopt;
+    auto message_types_discard_for_queueing = this->getMessageTypesDiscardForQueueing();
+    if (message_types_discard_for_queueing.has_value()) {
+        KeyValue kv;
+        kv.key = "MessageTypesDiscardForQueueing";
+        kv.readonly = true;
+        kv.value.emplace(message_types_discard_for_queueing.value());
+        message_types_discard_for_queueing_kv.emplace(kv);
+    }
+    return message_types_discard_for_queueing_kv;
+}
+
 std::optional<int> ChargePointConfiguration::getMessageQueueSizeThreshold() {
     std::optional<int> message_queue_size_threshold = std::nullopt;
     if (this->config["Internal"].contains("MessageQueueSizeThreshold")) {
@@ -2861,6 +2881,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     }
     if (key == "QueueAllMessages") {
         return this->getQueueAllMessagesKeyValue();
+    }
+    if (key == "MessageTypesDiscardForQueueing") {
+        return this->getMessageTypesDiscardForQueueingKeyValue();
     }
     if (key == "MessageQueueSizeThreshold") {
         return this->getMessageQueueSizeThresholdKeyValue();

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -878,6 +878,13 @@ const ComponentVariable& QueueAllMessages = {
         "QueueAllMessages",
     }),
 };
+const ComponentVariable& MessageTypesDiscardForQueueing = {
+    ControllerComponents::OCPPCommCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "MessageTypesDiscardForQueueing",
+    }),
+};
 const RequiredComponentVariable& ResetRetries = {
     ControllerComponents::OCPPCommCtrlr,
     std::nullopt,

--- a/tests/lib/ocpp/common/test_message_queue.cpp
+++ b/tests/lib/ocpp/common/test_message_queue.cpp
@@ -154,7 +154,7 @@ class MessageQueueTest : public ::testing::Test {
     int call_count{0};
 
 protected:
-    MessageQueueConfig config{};
+    MessageQueueConfig<TestMessageType> config{};
     std::shared_ptr<DatabaseHandlerBaseMock> db;
     std::mutex call_marker_mutex;
     std::condition_variable call_marker_cond_var;
@@ -225,7 +225,7 @@ protected:
 
     void SetUp() override {
         call_count = 0;
-        config = MessageQueueConfig{1, 1, 2, false};
+        config = MessageQueueConfig<TestMessageType>{1, 1, 2, false};
         db = std::make_shared<DatabaseHandlerBaseMock>();
         init_message_queue();
     }

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -190,13 +190,14 @@ public:
         const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
         return std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
             [this](json message) -> bool { return false; },
-            MessageQueueConfig{
+            MessageQueueConfig<v201::MessageType>{
                 this->device_model->get_value<int>(ControllerComponentVariables::MessageAttempts),
                 this->device_model->get_value<int>(ControllerComponentVariables::MessageAttemptInterval),
                 this->device_model->get_optional_value<int>(ControllerComponentVariables::MessageQueueSizeThreshold)
                     .value_or(DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD),
                 this->device_model->get_optional_value<bool>(ControllerComponentVariables::QueueAllMessages)
                     .value_or(false),
+                {},
                 this->device_model->get_value<int>(ControllerComponentVariables::MessageTimeout)},
             database_handler);
     }
@@ -326,7 +327,7 @@ TEST_F(ChargePointFixture, CreateChargePoint_MissingDeviceModel_ThrowsInvalidArg
     auto evse_security = std::make_shared<EvseSecurityMock>();
     configure_callbacks_with_mocks();
     auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
-        [this](json message) -> bool { return false; }, MessageQueueConfig{}, database_handler);
+        [this](json message) -> bool { return false; }, MessageQueueConfig<v201::MessageType>{}, database_handler);
 
     EXPECT_THROW(ocpp::v201::ChargePoint(evse_connector_structure, nullptr, database_handler, message_queue, "/tmp",
                                          evse_security, callbacks),
@@ -338,7 +339,7 @@ TEST_F(ChargePointFixture, CreateChargePoint_MissingDatabaseHandler_ThrowsInvali
     auto evse_security = std::make_shared<EvseSecurityMock>();
     configure_callbacks_with_mocks();
     auto message_queue = std::make_shared<ocpp::MessageQueue<v201::MessageType>>(
-        [this](json message) -> bool { return false; }, MessageQueueConfig{}, nullptr);
+        [this](json message) -> bool { return false; }, MessageQueueConfig<v201::MessageType>{}, nullptr);
 
     auto database_handler = nullptr;
 


### PR DESCRIPTION
## Describe your changes
This PR implements a feature and additional config option in addtion to QueueAllMessages.

A new config option *MessageTypesDiscardForQueueing* has been introduced. It is a comma seperated list of message types that shall not be queued (when offline) even in case QueueAllMessages is true. If QueueAllMessages is false, the configuration of this paramater has no effect. The message queue will discard all message type listed as part of this value except for transaction-related message types. This feature has been implemented for OCPP1.6 and OCPP2.0.1.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

