### PR TITLE
Ensure that connector stays in bounds of status notification callback

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -124,6 +124,12 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
         [this](const int32_t connector, const ChargePointErrorCode errorCode, const ChargePointStatus status,
                const ocpp::DateTime& timestamp, const std::optional<CiString<50>>& info,
                const std::optional<CiString<255>>& vendor_id, const std::optional<CiString<50>>& vendor_error_code) {
+            if (connector >= this->status_notification_timers.size() or connector >= this->connectors.size()) {
+                EVLOG_error << "Attempting to stop status notification timer for connector " << connector
+                            << " when there are only " << this->status_notification_timers.size() << " timers and "
+                            << this->connectors.size() << " connectors including connector 0.";
+                return;
+            }
             this->status_notification_timers.at(connector)->stop();
             this->status_notification_timers.at(connector)->timeout(
                 [this, connector, errorCode, status, timestamp, info, vendor_id, vendor_error_code]() {


### PR DESCRIPTION
Due to misconfiguration it could happen that status notification timers and connectors that do not exist are accessed in this callback resulting in an out-of-bounds error

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

