### PR TITLE
Fix issue that connectivity_manager was only initialized in a single constructor

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -158,18 +158,6 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
 
     initialize(evse_connector_structure, message_log_path);
 
-    this->connectivity_manager->set_websocket_connected_callback(
-        std::bind(&ChargePoint::websocket_connected_callback, this, std::placeholders::_1));
-    this->connectivity_manager->set_websocket_disconnected_callback(
-        std::bind(&ChargePoint::websocket_disconnected_callback, this));
-    this->connectivity_manager->set_websocket_connection_failed_callback(
-        std::bind(&ChargePoint::websocket_connection_failed, this, std::placeholders::_1));
-
-    if (this->callbacks.configure_network_connection_profile_callback.has_value()) {
-        this->connectivity_manager->set_configure_network_connection_profile_callback(
-            this->callbacks.configure_network_connection_profile_callback.value());
-    }
-
     this->message_queue = std::make_unique<ocpp::MessageQueue<v201::MessageType>>(
         [this](json message) -> bool { return this->connectivity_manager->send_to_websocket(message.dump()); },
         MessageQueueConfig{
@@ -1015,6 +1003,18 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
     this->connectivity_manager =
         std::make_unique<ConnectivityManager>(*this->device_model, this->evse_security, this->logging,
                                               std::bind(&ChargePoint::message_callback, this, std::placeholders::_1));
+
+    this->connectivity_manager->set_websocket_connected_callback(
+        std::bind(&ChargePoint::websocket_connected_callback, this, std::placeholders::_1));
+    this->connectivity_manager->set_websocket_disconnected_callback(
+        std::bind(&ChargePoint::websocket_disconnected_callback, this));
+    this->connectivity_manager->set_websocket_connection_failed_callback(
+        std::bind(&ChargePoint::websocket_connection_failed, this, std::placeholders::_1));
+
+    if (this->callbacks.configure_network_connection_profile_callback.has_value()) {
+        this->connectivity_manager->set_configure_network_connection_profile_callback(
+            this->callbacks.configure_network_connection_profile_callback.value());
+    }
 }
 
 void ChargePoint::init_certificate_expiration_check_timers() {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -158,10 +158,6 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
 
     initialize(evse_connector_structure, message_log_path);
 
-    this->connectivity_manager =
-        std::make_unique<ConnectivityManager>(*this->device_model, this->evse_security, this->logging,
-                                              std::bind(&ChargePoint::message_callback, this, std::placeholders::_1));
-
     this->connectivity_manager->set_websocket_connected_callback(
         std::bind(&ChargePoint::websocket_connected_callback, this, std::placeholders::_1));
     this->connectivity_manager->set_websocket_disconnected_callback(
@@ -1015,6 +1011,10 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
     this->monitoring_updater.start_monitoring();
 
     this->auth_cache_cleanup_thread = std::thread(&ChargePoint::cache_cleanup_handler, this);
+
+    this->connectivity_manager =
+        std::make_unique<ConnectivityManager>(*this->device_model, this->evse_security, this->logging,
+                                              std::bind(&ChargePoint::message_callback, this, std::placeholders::_1));
 }
 
 void ChargePoint::init_certificate_expiration_check_timers() {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

