### PR TITLE
Composite Schedule API

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -412,6 +412,21 @@ public:
     /// change
     virtual std::map<SetVariableData, SetVariableResult>
     set_variables(const std::vector<SetVariableData>& set_variable_data_vector, const std::string& source) = 0;
+
+    /// \brief Gets a composite schedule based on the given \p request
+    /// \param request specifies different options for the request
+    /// \return GetCompositeScheduleResponse containing the status of the operation and the composite schedule if the
+    /// operation was successful
+    virtual GetCompositeScheduleResponse get_composite_schedule(const GetCompositeScheduleRequest& request) = 0;
+
+    /// \brief Gets composite schedules for all evse_ids (including 0) for the given \p duration and \p unit . If no
+    /// valid profiles are given for an evse for the specified period, the composite schedule will be empty for this
+    /// evse.
+    /// \param duration of the request from. Composite schedules will be retrieved from now to (now + duration)
+    /// \param unit of the period entries of the composite schedules
+    /// \return vector of composite schedules, one for each evse_id including 0.
+    virtual std::vector<CompositeSchedule> get_all_composite_schedules(const int32_t duration,
+                                                                       const ChargingRateUnitEnum& unit) = 0;
 };
 
 /// \brief Class implements OCPP2.0.1 Charging Station
@@ -518,6 +533,7 @@ private:
 
     void trigger_authorization_cache_cleanup();
     void cache_cleanup_handler();
+    GetCompositeScheduleResponse get_composite_schedule_internal(const GetCompositeScheduleRequest& request);
 
     /// \brief Removes all network connection profiles below the actual security profile and stores the new list in the
     /// device model
@@ -953,6 +969,11 @@ public:
 
     std::map<SetVariableData, SetVariableResult>
     set_variables(const std::vector<SetVariableData>& set_variable_data_vector, const std::string& source) override;
+
+    GetCompositeScheduleResponse get_composite_schedule(const GetCompositeScheduleRequest& request) override;
+
+    std::vector<CompositeSchedule> get_all_composite_schedules(const int32_t duration,
+                                                               const ChargingRateUnitEnum& unit) override;
 
     /// \brief Requests a value of a VariableAttribute specified by combination of \p component_id and \p variable_id
     /// from the device model

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -44,6 +44,9 @@ public:
     /// \brief Check if an evse with \p id exists
     virtual bool does_evse_exist(int32_t id) const = 0;
 
+    /// \brief Get the number of evses
+    virtual size_t get_number_of_evses() const = 0;
+
     /// \brief Gets an iterator pointing to the first evse
     virtual EvseIterator begin() = 0;
     /// \brief Gets an iterator pointing past the last evse
@@ -66,6 +69,8 @@ public:
     const EvseInterface& get_evse(int32_t id) const override;
 
     bool does_evse_exist(int32_t id) const override;
+
+    size_t get_number_of_evses() const override;
 
     EvseIterator begin() override;
     EvseIterator end() override;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3205,35 +3205,7 @@ void ChargePoint::handle_get_charging_profiles_req(Call<GetChargingProfilesReque
 
 void ChargePoint::handle_get_composite_schedule_req(Call<GetCompositeScheduleRequest> call) {
     EVLOG_debug << "Received GetCompositeScheduleRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
-    auto msg = call.msg;
-    GetCompositeScheduleResponse response;
-    response.status = GenericStatusEnum::Rejected;
-
-    auto supported_charging_rate_units =
-        this->device_model->get_value<std::string>(ControllerComponentVariables::ChargingScheduleChargingRateUnit);
-    auto unit_supported = supported_charging_rate_units.find(conversions::charging_rate_unit_enum_to_string(
-                              msg.chargingRateUnit.value())) != supported_charging_rate_units.npos;
-
-    // K01.FR.05 & K01.FR.07
-    if (this->evse_manager->does_evse_exist(msg.evseId) && unit_supported) {
-        auto start_time = ocpp::DateTime();
-        auto end_time = ocpp::DateTime(start_time.to_time_point() + std::chrono::seconds(msg.duration));
-
-        std::vector<ChargingProfile> valid_profiles = this->smart_charging_handler->get_valid_profiles(msg.evseId);
-        auto schedule = this->smart_charging_handler->calculate_composite_schedule(valid_profiles, start_time, end_time,
-                                                                                   msg.evseId, msg.chargingRateUnit);
-
-        response.status = GenericStatusEnum::Accepted;
-        response.schedule = schedule;
-    } else {
-        auto reason = unit_supported ? ProfileValidationResultEnum::EvseDoesNotExist
-                                     : ProfileValidationResultEnum::ChargingScheduleChargingRateUnitUnsupported;
-        response.statusInfo = StatusInfo();
-        response.statusInfo->reasonCode = conversions::profile_validation_result_to_reason_code(reason);
-        response.statusInfo->additionalInfo = conversions::profile_validation_result_to_string(reason);
-        EVLOG_debug << "Rejecting SetChargingProfileRequest:\n reasonCode: " << response.statusInfo->reasonCode.get()
-                    << "\nadditionalInfo: " << response.statusInfo->additionalInfo->get();
-    }
+    const auto response = this->get_composite_schedule_internal(call.msg);
 
     ocpp::CallResult<GetCompositeScheduleResponse> call_result(response, call.uniqueId);
     this->send<GetCompositeScheduleResponse>(call_result);
@@ -3904,6 +3876,39 @@ void ChargePoint::cache_cleanup_handler() {
     }
 }
 
+GetCompositeScheduleResponse ChargePoint::get_composite_schedule_internal(const GetCompositeScheduleRequest& request) {
+    GetCompositeScheduleResponse response;
+    response.status = GenericStatusEnum::Rejected;
+
+    auto supported_charging_rate_units =
+        this->device_model->get_value<std::string>(ControllerComponentVariables::ChargingScheduleChargingRateUnit);
+    auto unit_supported = supported_charging_rate_units.find(conversions::charging_rate_unit_enum_to_string(
+                              request.chargingRateUnit.value())) != supported_charging_rate_units.npos;
+
+    // K01.FR.05 & K01.FR.07
+    if (this->evse_manager->does_evse_exist(request.evseId) && unit_supported) {
+        auto start_time = ocpp::DateTime();
+        auto end_time = ocpp::DateTime(start_time.to_time_point() + std::chrono::seconds(request.duration));
+
+        std::vector<ChargingProfile> valid_profiles = this->smart_charging_handler->get_valid_profiles(request.evseId);
+
+        auto schedule = this->smart_charging_handler->calculate_composite_schedule(
+            valid_profiles, start_time, end_time, request.evseId, request.chargingRateUnit);
+
+        response.schedule = schedule;
+        response.status = GenericStatusEnum::Accepted;
+    } else {
+        auto reason = unit_supported ? ProfileValidationResultEnum::EvseDoesNotExist
+                                     : ProfileValidationResultEnum::ChargingScheduleChargingRateUnitUnsupported;
+        response.statusInfo = StatusInfo();
+        response.statusInfo->reasonCode = conversions::profile_validation_result_to_reason_code(reason);
+        response.statusInfo->additionalInfo = conversions::profile_validation_result_to_string(reason);
+        EVLOG_debug << "Rejecting SetChargingProfileRequest:\n reasonCode: " << response.statusInfo->reasonCode.get()
+                    << "\nadditionalInfo: " << response.statusInfo->additionalInfo->get();
+    }
+    return response;
+}
+
 void ChargePoint::update_dm_availability_state(const int32_t evse_id, const int32_t connector_id,
                                                const ConnectorStatusEnum status) {
     ComponentVariable charging_station = ControllerComponentVariables::ChargingStationAvailabilityState;
@@ -4040,6 +4045,33 @@ ChargePoint::set_variables(const std::vector<SetVariableData>& set_variable_data
     const auto response = this->set_variables_internal(set_variable_data_vector, source, true);
     this->handle_variables_changed(response);
     return response;
+}
+
+GetCompositeScheduleResponse ChargePoint::get_composite_schedule(const GetCompositeScheduleRequest& request) {
+    return this->get_composite_schedule_internal(request);
+}
+
+std::vector<CompositeSchedule> ChargePoint::get_all_composite_schedules(const int32_t duration_s,
+                                                                        const ChargingRateUnitEnum& unit) {
+    std::vector<CompositeSchedule> composite_schedules;
+
+    const auto number_of_evses = this->evse_manager->get_number_of_evses();
+    // get all composite schedules including the one for evse_id == 0
+    for (int32_t evse_id = 0; evse_id < number_of_evses; evse_id++) {
+        GetCompositeScheduleRequest request;
+        request.duration = duration_s;
+        request.evseId = evse_id;
+        request.chargingRateUnit = unit;
+        auto composite_schedule_response = this->get_composite_schedule_internal(request);
+        if (composite_schedule_response.status == GenericStatusEnum::Accepted and
+            composite_schedule_response.schedule.has_value()) {
+            composite_schedules.push_back(composite_schedule_response.schedule.value());
+        } else {
+            EVLOG_warning << "Could not internally retrieve composite schedule: " << composite_schedule_response;
+        }
+    }
+
+    return composite_schedules;
 }
 
 } // namespace v201

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -47,5 +47,9 @@ bool EvseManager::does_evse_exist(int32_t id) const {
     return id <= this->evses.size();
 }
 
+size_t EvseManager::get_number_of_evses() const {
+    return this->evses.size();
+}
+
 } // namespace v201
 } // namespace ocpp

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -56,6 +56,10 @@ public:
         return id <= this->evses.size();
     }
 
+    size_t get_number_of_evses() const override {
+        return this->evses.size();
+    }
+
     void open_transaction(int evse_id, const std::string& transaction_id) {
         auto& transaction = this->transactions.at(evse_id - 1);
         transaction = std::make_unique<EnhancedTransaction>(db_handler, false);


### PR DESCRIPTION
## Describe your changes
This PR adds the API for composite schedules for OCPP2.0.1:
* `get_composite_schedule` reflects what the CSMS can request using a `GetCompositeSchedule.req`
* `get_all_composite_schedules` is a convenience function that returns the composite schedules for every single evse_id including 0
* EvseManagerInterface was extended to be able to easily retrieve the number of evses
* `get_composite_schedule_internal` was introduced to be able to reuse the code

## Issue ticket number and link
[This PR](https://github.com/EVerest/everest-core/pull/854) in everest-core makes use of the API to integrate the smart charging functionality in EVerest.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

