### PR TITLE
Fix segmentation fault in test cases

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -418,12 +418,12 @@ public:
 class ChargePoint : public ChargePointInterface, private ocpp::ChargingStationBase {
 
 private:
+    std::shared_ptr<DeviceModel> device_model;
     std::unique_ptr<EvseManager> evse_manager;
     std::unique_ptr<ConnectivityManager> connectivity_manager;
 
     // utility
     std::shared_ptr<MessageQueue<v201::MessageType>> message_queue;
-    std::shared_ptr<DeviceModel> device_model;
     std::shared_ptr<DatabaseHandler> database_handler;
 
     std::map<int32_t, AvailabilityChange> scheduled_change_availability_requests;


### PR DESCRIPTION
## Describe your changes
With the introduction of the connectivity_manager in https://github.com/EVerest/libocpp/pull/748 the `connectivity_manager` was defined before the `device_model` in the `ChargePoint` class.

```
class ChargePoint : public ChargePointInterface, private ocpp::ChargingStationBase {
private:
    std::unique_ptr<ConnectivityManager> connectivity_manager;
    std::shared_ptr<DeviceModel> device_model;
    ...
}
```

This caused the destructor of the `device_model` to be executed before the destructor of the `connectivity_manager`.

```
DeviceModel::~
ConnectivityManager::~
```

This can lead to a segmentation fault in test cases where the `ChargePointFixture` was used. The `websocket_disconnected_callback` makes use of the `device_model` which can aleady be null at this time: https://github.com/EVerest/libocpp/blob/main/lib/ocpp/v201/charge_point.cpp#L3834 

This PR changes the order of the definition of `device_model` and `connectivity_manager` so that the destructor of the `ConnectivityManager` is executed before the one of the `DeviceModel`.

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/770

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

