### PR TITLE
Testing: Updated test fixture names

### DIFF
--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -53,11 +53,11 @@ public:
     }
 };
 
-class ChargePointFixture : public DatabaseTestingUtils {
+class ChargepointTestFixtureV201 : public DatabaseTestingUtils {
 public:
-    ChargePointFixture() {
+    ChargepointTestFixtureV201() {
     }
-    ~ChargePointFixture() {
+    ~ChargepointTestFixtureV201() {
     }
 
     void SetUp() override {
@@ -278,7 +278,7 @@ public:
     ocpp::v201::Callbacks callbacks;
 };
 
-TEST_F(ChargePointFixture, CreateChargePoint) {
+TEST_F(ChargepointTestFixtureV201, CreateChargePoint) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
@@ -289,7 +289,7 @@ TEST_F(ChargePointFixture, CreateChargePoint) {
                                             "/tmp", evse_security, callbacks));
 }
 
-TEST_F(ChargePointFixture, CreateChargePoint_InitializeInCorrectOrder) {
+TEST_F(ChargepointTestFixtureV201, CreateChargePoint_InitializeInCorrectOrder) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     database_handler->open_connection();
@@ -315,7 +315,7 @@ TEST_F(ChargePointFixture, CreateChargePoint_InitializeInCorrectOrder) {
     charge_point.stop();
 }
 
-TEST_F(ChargePointFixture, CreateChargePoint_EVSEConnectorStructureDefinedBadly_ThrowsDeviceModelStorageError) {
+TEST_F(ChargepointTestFixtureV201, CreateChargePoint_EVSEConnectorStructureDefinedBadly_ThrowsDeviceModelStorageError) {
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
     configure_callbacks_with_mocks();
@@ -328,7 +328,7 @@ TEST_F(ChargePointFixture, CreateChargePoint_EVSEConnectorStructureDefinedBadly_
                  DeviceModelStorageError);
 }
 
-TEST_F(ChargePointFixture, CreateChargePoint_MissingDeviceModel_ThrowsInvalidArgument) {
+TEST_F(ChargepointTestFixtureV201, CreateChargePoint_MissingDeviceModel_ThrowsInvalidArgument) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
@@ -341,7 +341,7 @@ TEST_F(ChargePointFixture, CreateChargePoint_MissingDeviceModel_ThrowsInvalidArg
                  std::invalid_argument);
 }
 
-TEST_F(ChargePointFixture, CreateChargePoint_MissingDatabaseHandler_ThrowsInvalidArgument) {
+TEST_F(ChargepointTestFixtureV201, CreateChargePoint_MissingDatabaseHandler_ThrowsInvalidArgument) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto evse_security = std::make_shared<EvseSecurityMock>();
     configure_callbacks_with_mocks();
@@ -355,7 +355,7 @@ TEST_F(ChargePointFixture, CreateChargePoint_MissingDatabaseHandler_ThrowsInvali
                  std::invalid_argument);
 }
 
-TEST_F(ChargePointFixture, CreateChargePoint_CallbacksNotValid_ThrowsInvalidArgument) {
+TEST_F(ChargepointTestFixtureV201, CreateChargePoint_CallbacksNotValid_ThrowsInvalidArgument) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
@@ -383,7 +383,7 @@ TEST_F(ChargePointFixture, CreateChargePoint_CallbacksNotValid_ThrowsInvalidArgu
  * is provided.
  */
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfSetChargingProfilesCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.set_charging_profiles_callback = nullptr;
 
@@ -395,93 +395,94 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSetChargingProfilesC
  * all_callbacks_valid.
  */
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksAreInvalidWhenNotProvided) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksAreInvalidWhenNotProvided) {
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksAreValidWhenAllRequiredCallbacksProvided) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksAreValidWhenAllRequiredCallbacksProvided) {
     configure_callbacks_with_mocks();
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfResetIsAllowedCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfResetIsAllowedCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.is_reset_allowed_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfResetCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfResetCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.reset_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfStopTransactionCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfStopTransactionCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.stop_transaction_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfPauseChargingCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfPauseChargingCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.pause_charging_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfConnectorEffectiveOperativeStatusChangedCallbackExists) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfConnectorEffectiveOperativeStatusChangedCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.connector_effective_operative_status_changed_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfGetLogRequestCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfGetLogRequestCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.get_log_request_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfUnlockConnectorCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfUnlockConnectorCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.unlock_connector_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfRemoteStartTransactionCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfRemoteStartTransactionCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.remote_start_transaction_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfIsReservationForTokenCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfIsReservationForTokenCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.is_reservation_for_token_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfUpdateFirmwareRequestCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.update_firmware_request_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfSecurityEventCallbackExists) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfSecurityEventCallbackExists) {
     configure_callbacks_with_mocks();
     callbacks.security_event_callback = nullptr;
 
     EXPECT_FALSE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableChangedCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfOptionalVariableChangedCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.variable_changed_callback = nullptr;
@@ -492,7 +493,8 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableChan
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableNetworkProfileCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalVariableNetworkProfileCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.validate_network_profile_callback = nullptr;
@@ -505,7 +507,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalVariableNetw
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture,
+TEST_F(ChargepointTestFixtureV201,
        K01FR02_CallbacksValidityChecksIfOptionalConfigureNetworkConnectionProfileCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
@@ -519,7 +521,7 @@ TEST_F(ChargePointFixture,
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfOptionalTimeSyncCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.time_sync_callback = nullptr;
@@ -530,7 +532,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTimeSyncCall
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalBootNotificationCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfOptionalBootNotificationCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.boot_notification_callback = nullptr;
@@ -541,7 +543,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalBootNotifica
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalOCPPMessagesCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfOptionalOCPPMessagesCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.ocpp_messages_callback = nullptr;
@@ -552,7 +554,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalOCPPMessages
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture,
+TEST_F(ChargepointTestFixtureV201,
        K01FR02_CallbacksValidityChecksIfOptionalCSEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
@@ -566,7 +568,7 @@ TEST_F(ChargePointFixture,
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture,
+TEST_F(ChargepointTestFixtureV201,
        K01FR02_CallbacksValidityChecksIfOptionalEvseEffectiveOperativeStatusChangedCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
@@ -580,7 +582,8 @@ TEST_F(ChargePointFixture,
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalGetCustomerInformationCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalGetCustomerInformationCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.get_customer_information_callback = nullptr;
@@ -594,7 +597,8 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalGetCustomerI
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalClearCustomerInformationCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalClearCustomerInformationCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.clear_customer_information_callback = nullptr;
@@ -608,7 +612,8 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalClearCustome
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalAllConnectorsUnavailableCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalAllConnectorsUnavailableCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.all_connectors_unavailable_callback = nullptr;
@@ -619,7 +624,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalAllConnector
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalDataTransferCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfOptionalDataTransferCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.data_transfer_callback = nullptr;
@@ -630,7 +635,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalDataTransfer
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionEventCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201, K01FR02_CallbacksValidityChecksIfOptionalTransactionEventCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.transaction_event_callback = nullptr;
@@ -641,7 +646,8 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionE
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionEventResponseCallbackIsNotSetOrNotNull) {
+TEST_F(ChargepointTestFixtureV201,
+       K01FR02_CallbacksValidityChecksIfOptionalTransactionEventResponseCallbackIsNotSetOrNotNull) {
     configure_callbacks_with_mocks();
 
     callbacks.transaction_event_response_callback = nullptr;
@@ -654,7 +660,7 @@ TEST_F(ChargePointFixture, K01FR02_CallbacksValidityChecksIfOptionalTransactionE
     EXPECT_TRUE(callbacks.all_callbacks_valid());
 }
 
-TEST_F(ChargePointFixture, K01_SetChargingProfileRequest_ValidatesAndAddsProfile) {
+TEST_F(ChargepointTestFixtureV201, K01_SetChargingProfileRequest_ValidatesAndAddsProfile) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -674,7 +680,7 @@ TEST_F(ChargePointFixture, K01_SetChargingProfileRequest_ValidatesAndAddsProfile
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_TriggersCallbackWhenValid) {
+TEST_F(ChargepointTestFixtureV201, K01FR07_SetChargingProfileRequest_TriggersCallbackWhenValid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -697,7 +703,7 @@ TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_TriggersCallbackWhe
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_DoesNotTriggerCallbackWhenInvalid) {
+TEST_F(ChargepointTestFixtureV201, K01FR07_SetChargingProfileRequest_DoesNotTriggerCallbackWhenInvalid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -725,7 +731,7 @@ TEST_F(ChargePointFixture, K01FR07_SetChargingProfileRequest_DoesNotTriggerCallb
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR22_SetChargingProfileRequest_RejectsChargingStationExternalConstraints) {
+TEST_F(ChargepointTestFixtureV201, K01FR22_SetChargingProfileRequest_RejectsChargingStationExternalConstraints) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -745,7 +751,7 @@ TEST_F(ChargePointFixture, K01FR22_SetChargingProfileRequest_RejectsChargingStat
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCallError) {
+TEST_F(ChargepointTestFixtureV201, K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCallError) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
@@ -771,7 +777,8 @@ TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsFalse_RespondsCa
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K05FR05_RequestStartTransactionRequest_SmartChargingCtrlrEnabledTrue_ValidatesTxProfiles) {
+TEST_F(ChargepointTestFixtureV201,
+       K05FR05_RequestStartTransactionRequest_SmartChargingCtrlrEnabledTrue_ValidatesTxProfiles) {
     const auto cv = ControllerComponentVariables::SmartChargingCtrlrEnabled;
     this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "true", "TEST", true);
 
@@ -794,7 +801,7 @@ TEST_F(ChargePointFixture, K05FR05_RequestStartTransactionRequest_SmartChargingC
     charge_point->handle_message(start_transaction_req);
 }
 
-TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsTrue_CallsValidateAndAddProfile) {
+TEST_F(ChargepointTestFixtureV201, K01FR29_SmartChargingCtrlrAvailableIsTrue_CallsValidateAndAddProfile) {
     auto evse_connector_structure = create_evse_connector_structure();
     auto database_handler = create_database_handler();
     auto evse_security = std::make_shared<EvseSecurityMock>();
@@ -820,7 +827,7 @@ TEST_F(ChargePointFixture, K01FR29_SmartChargingCtrlrAvailableIsTrue_CallsValida
     charge_point->handle_message(set_charging_profile_req);
 }
 
-TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeSchedule) {
+TEST_F(ChargepointTestFixtureV201, K08_GetCompositeSchedule_CallsCalculateGetCompositeSchedule) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID;
     req.chargingRateUnit = ChargingRateUnitEnum::W;
@@ -834,7 +841,7 @@ TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeSc
     charge_point->handle_message(get_composite_schedule_req);
 }
 
-TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeScheduleWithValidProfiles) {
+TEST_F(ChargepointTestFixtureV201, K08_GetCompositeSchedule_CallsCalculateGetCompositeScheduleWithValidProfiles) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID;
     req.chargingRateUnit = ChargingRateUnitEnum::W;
@@ -857,7 +864,7 @@ TEST_F(ChargePointFixture, K08_GetCompositeSchedule_CallsCalculateGetCompositeSc
     charge_point->handle_message(get_composite_schedule_req);
 }
 
-TEST_F(ChargePointFixture, K08FR05_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForNonexistentEVSE) {
+TEST_F(ChargepointTestFixtureV201, K08FR05_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForNonexistentEVSE) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID + 3;
     req.chargingRateUnit = ChargingRateUnitEnum::W;
@@ -873,7 +880,8 @@ TEST_F(ChargePointFixture, K08FR05_GetCompositeSchedule_DoesNotCalculateComposit
     charge_point->handle_message(get_composite_schedule_req);
 }
 
-TEST_F(ChargePointFixture, K08FR07_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForIncorrectChargingRateUnit) {
+TEST_F(ChargepointTestFixtureV201,
+       K08FR07_GetCompositeSchedule_DoesNotCalculateCompositeScheduleForIncorrectChargingRateUnit) {
     GetCompositeScheduleRequest req;
     req.evseId = DEFAULT_EVSE_ID;
     req.chargingRateUnit = ChargingRateUnitEnum::W;
@@ -893,7 +901,7 @@ TEST_F(ChargePointFixture, K08FR07_GetCompositeSchedule_DoesNotCalculateComposit
     charge_point->handle_message(get_composite_schedule_req);
 }
 
-TEST_F(ChargePointFixture,
+TEST_F(ChargepointTestFixtureV201,
        K05FR04_RequestStartTransactionRequest_SmartChargingCtrlrEnabledFalse_DoesNotValidateTxProfiles) {
     const auto cv = ControllerComponentVariables::SmartChargingCtrlrEnabled;
     this->device_model->set_value(cv.component, cv.variable.value(), AttributeEnum::Actual, "false", "TEST", true);
@@ -917,7 +925,7 @@ TEST_F(ChargePointFixture,
     charge_point->handle_message(start_transaction_req);
 }
 
-TEST_F(ChargePointFixture, K02FR05_TransactionEnds_WillDeleteTxProfilesWithTransactionID) {
+TEST_F(ChargepointTestFixtureV201, K02FR05_TransactionEnds_WillDeleteTxProfilesWithTransactionID) {
     auto database_handler = create_database_handler();
     database_handler->open_connection();
     const auto cv = ControllerComponentVariables::ResumeTransactionsOnBoot;

--- a/tests/lib/ocpp/v201/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v201/test_composite_schedule.cpp
@@ -47,7 +47,7 @@ static const int DEFAULT_PROFILE_ID = 1;
 static const int DEFAULT_STACK_LEVEL = 1;
 static const std::string DEFAULT_TX_ID = "10c75ff7-74f5-44f5-9d01-f649f3ac7b78";
 const static std::string MIGRATION_FILES_PATH = "./resources/v201/device_model_migration_files";
-const static std::string SCHEMAS_PATH = "./resources/example_config/v201/component_schemas";
+const static std::string SCHEMAS_PATH = "./resources/example_config/v201/component_config";
 const static std::string CONFIG_PATH = "./resources/example_config/v201/config.json";
 const static std::string DEVICE_MODEL_DB_IN_MEMORY_PATH = "file::memory:?cache=shared";
 
@@ -62,7 +62,7 @@ public:
     using SmartChargingHandler::SmartChargingHandler;
 };
 
-class ChargepointTestFixtureV201 : public DatabaseTestingUtils {
+class CompositeScheduleTestFixtureV201 : public DatabaseTestingUtils {
 protected:
     void SetUp() override {
     }
@@ -208,7 +208,7 @@ protected:
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
 };
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_FoundationTest_Grid) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_FoundationTest_Grid) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/grid/");
     const DateTime start_time = ocpp::DateTime("2024-01-17T00:00:00");
@@ -346,7 +346,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_FoundationTest
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredTest_SameStartTime) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredTest_SameStartTime) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/layered/");
 
@@ -435,7 +435,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredTest_Sa
     }
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredRecurringTest_FutureStartTime) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredRecurringTest_FutureStartTime) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/layered_recurring/");
 
@@ -460,7 +460,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredRecurri
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredTest_PreviousStartTime) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredTest_PreviousStartTime) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_file("singles/TXProfile_Absolute_Start18-04.json");
     const DateTime start_time = ocpp::DateTime("2024-01-17T18:00:00");
@@ -489,7 +489,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredTest_Pr
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredRecurringTest_PreviousStartTime) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredRecurringTest_PreviousStartTime) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/layered_recurring/");
     const DateTime start_time = ocpp::DateTime("2024-02-19T18:00:00");
@@ -531,7 +531,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_LayeredRecurri
 /**
  * Calculate Composite Schedule
  */
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_ValidateBaselineProfileVector) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_ValidateBaselineProfileVector) {
     const DateTime start_time = ocpp::DateTime("2024-01-17T18:01:00");
     const DateTime end_time = ocpp::DateTime("2024-01-18T06:00:00");
     std::vector<ChargingProfile> profiles = SmartChargingTestUtils::get_baseline_profile_vector();
@@ -563,7 +563,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_ValidateBaseli
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_RelativeProfile_minutia) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_RelativeProfile_minutia) {
     const DateTime start_time = ocpp::DateTime("2024-05-17T05:00:00");
     const DateTime end_time = ocpp::DateTime("2024-05-17T06:00:00");
 
@@ -592,7 +592,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_RelativeProfil
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_RelativeProfile_e2e) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_RelativeProfile_e2e) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/relative/");
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, profiles.at(0).transactionId.value());
@@ -626,7 +626,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_RelativeProfil
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_DemoCaseOne_17th) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_DemoCaseOne_17th) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/case_one/");
     ChargingProfile relative_profile = profiles.front();
@@ -663,7 +663,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_DemoCaseOne_17
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_DemoCaseOne_19th) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_DemoCaseOne_19th) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/case_one/");
     ChargingProfile first_profile = profiles.front();
@@ -697,7 +697,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_DemoCaseOne_19
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridesHigherLimits) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridesHigherLimits) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/max/");
 
@@ -726,7 +726,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridesHi
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridenByLowerLimits) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridenByLowerLimits) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/max/");
 
@@ -755,7 +755,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverridenBy
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_ExternalOverridesHigherLimits) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_ExternalOverridesHigherLimits) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/external/");
 
@@ -784,7 +784,7 @@ TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_ExternalOverri
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_CalculateCompositeSchedule_ExternalOverridenByLowerLimits) {
+TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_ExternalOverridenByLowerLimits) {
     std::vector<ChargingProfile> profiles =
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/external/");
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -58,7 +58,7 @@ public:
     using SmartChargingHandler::SmartChargingHandler;
 };
 
-class ChargepointTestFixtureV201 : public DatabaseTestingUtils {
+class SmartChargingHandlerTestFixtureV201 : public DatabaseTestingUtils {
 protected:
     void SetUp() override {
     }
@@ -270,7 +270,7 @@ protected:
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
 };
 
-TEST_F(ChargepointTestFixtureV201, K01FR03_IfTxProfileIsMissingTransactionId_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR03_IfTxProfileIsMissingTransactionId_ThenProfileIsInvalid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), {});
     auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);
@@ -278,7 +278,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR03_IfTxProfileIsMissingTransactionId_The
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR05_IfExistingChargingProfileWithSameIdIsChargingStationExternalConstraints_ThenProfileIsInvalid) {
     auto external_constraints =
         create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationExternalConstraints,
@@ -292,7 +292,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ExistingChargingStationExternalConstraints));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR16_IfTxProfileHasEvseIdNotGreaterThanZero_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR16_IfTxProfileHasEvseIdNotGreaterThanZero_ThenProfileIsInvalid) {
     auto wrong_evse_id = STATION_WIDE_ID;
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
@@ -301,7 +301,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR16_IfTxProfileHasEvseIdNotGreaterThanZer
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseIdNotGreaterThanZero));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR33_IfTxProfileTransactionIsNotOnEvse_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR33_IfTxProfileTransactionIsNotOnEvse_ThenProfileIsInvalid) {
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, "wrong transaction id");
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
@@ -310,7 +310,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR33_IfTxProfileTransactionIsNotOnEvse_The
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileTransactionNotOnEvse));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction_ThenProfileIsInvalid) {
     auto connector_id = 1;
     auto meter_start = MeterValue();
     auto id_token = IdToken();
@@ -322,7 +322,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTransaction
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR48FR19_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 0, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -334,8 +334,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR48FR19_NumberPhasesOtherThan1AndPhaseToU
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodInvalidPhaseToUse));
 }
 
-TEST_F(ChargepointTestFixtureV201,
-       K01FR48FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedUndefined_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedUndefined_ThenProfileIsInvalid) {
     // As a device model with ac switching supported default set to 'true', we want to create a new database with the
     // ac switching support not set. But this is an in memory database, which is kept open until all handles to it are
     // closed. So we close all connections to the database.
@@ -359,7 +359,8 @@ TEST_F(ChargepointTestFixtureV201,
                 testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR48FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedFalse_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedFalse_ThenProfileIsInvalid) {
     // As a device model with ac switching supported default set to 'true', we want to create a new database with the
     // ac switching support not set. But this is an in memory database, which is kept open until all handles to it are
     // closed. So we close all connections to the database.
@@ -383,8 +384,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR48FR20_IfPhaseToUseSetAndACPhaseSwitchin
                 testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodPhaseToUseACPhaseSwitchingUnsupported));
 }
 
-TEST_F(ChargepointTestFixtureV201,
-       K01FR48FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedTrue_ThenProfileIsNotInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedTrue_ThenProfileIsNotInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -396,7 +397,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Not(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR26_IfChargingRateUnitIsNotInChargingScheduleChargingRateUnits_ThenProfileIsInvalid) {
     const auto& charging_rate_unit_cv = ControllerComponentVariables::ChargingScheduleChargingRateUnit;
     device_model->set_value(charging_rate_unit_cv.component, charging_rate_unit_cv.variable.value(),
@@ -413,7 +414,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingScheduleChargingRateUnitUnsupported));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_IfChargingSchedulePeriodsAreMissing_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_IfChargingSchedulePeriodsAreMissing_ThenProfileIsInvalid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
 
@@ -422,7 +423,8 @@ TEST_F(ChargepointTestFixtureV201, K01_IfChargingSchedulePeriodsAreMissing_ThenP
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingProfileNoChargingSchedulePeriods));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR31_IfStartPeriodOfFirstChargingSchedulePeriodIsNotZero_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR31_IfStartPeriodOfFirstChargingSchedulePeriodIsNotZero_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(1);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A, periods), DEFAULT_TX_ID);
@@ -432,7 +434,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR31_IfStartPeriodOfFirstChargingScheduleP
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingProfileFirstStartScheduleIsNotZero));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR35_IfChargingSchedulePeriodsAreNotInChonologicalOrder_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR35_IfChargingSchedulePeriodsAreNotInChonologicalOrder_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods({0, 2, 1});
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A, periods), DEFAULT_TX_ID);
@@ -442,7 +445,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR35_IfChargingSchedulePeriodsAreNotInChon
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodsOutOfOrder));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChargingStationMaxProfile_Invalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01_ValidateChargingStationMaxProfile_NotChargingStationMaxProfile_Invalid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A));
@@ -452,7 +456,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateChargingStationMaxProfile_NotChar
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::InvalidProfileType));
 }
 
-TEST_F(ChargepointTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_EvseIDgt0_Invalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_EvseIDgt0_Invalid) {
     const int EVSE_ID_1 = DEFAULT_EVSE_ID;
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
@@ -463,7 +467,8 @@ TEST_F(ChargepointTestFixtureV201, K04FR03_ValidateChargingStationMaxProfile_Evs
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsAbsolute_Valid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsAbsolute_Valid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A));
 
@@ -472,7 +477,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRecurring_Valid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRecurring_Valid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), {},
                                            ChargingProfileKindEnum::Recurring);
@@ -482,7 +488,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRelative_Invalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR38_ChargingProfilePurposeIsChargingStationMaxProfile_KindIsRelative_Invalid) {
     auto profile =
         create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                 create_charge_schedule(ChargingRateUnitEnum::A), {}, ChargingProfileKindEnum::Relative);
@@ -492,7 +499,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR38_ChargingProfilePurposeIsChargingStati
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileCannotBeRelative));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR39_IfTxProfileHasSameTransactionAndStackLevelAsAnotherTxProfile_ThenProfileIsInvalid) {
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
 
@@ -509,7 +516,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileConflictingStackLevel));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR39_IfTxProfileHasDifferentTransactionButSameStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
     std::string different_transaction_id = uuid();
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
@@ -527,7 +534,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR39_IfTxProfileHasSameTransactionButDifferentStackLevelAsAnotherTxProfile_ThenProfileIsValid) {
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
 
@@ -547,7 +554,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K05_IfTxProfileHasNoTransactionIdButAddChargingProfileSourceIsRequestRemoteStartTransaction_ThenProfileIsValid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), {});
@@ -557,7 +564,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR40_IfChargingProfileKindIsAbsoluteAndStartScheduleDoesNotExist_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -569,7 +576,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingProfileMissingRequiredStartSchedule));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR40_IfChargingProfileKindIsRecurringAndStartScheduleDoesNotExist_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -581,7 +588,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingProfileMissingRequiredStartSchedule));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR41_IfChargingProfileKindIsRelativeAndStartScheduleDoesExist_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
@@ -594,12 +601,12 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingProfileExtraneousStartSchedule));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR28_WhenEvseDoesNotExistThenReject) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR28_WhenEvseDoesNotExistThenReject) {
     auto sut = handler.validate_evse_exists(NR_OF_EVSES + 1);
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::EvseDoesNotExist));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR28_WhenEvseDoesExistThenAccept) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR28_WhenEvseDoesExistThenAccept) {
     auto sut = handler.validate_evse_exists(DEFAULT_EVSE_ID);
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -611,11 +618,12 @@ TEST_F(ChargepointTestFixtureV201, K01FR28_WhenEvseDoesExistThenAccept) {
  *  and a new profile with the same stack level and different profile ID will be associated with an EVSE.
  * 2-7 - We return Valid for any other case, such as using the same EVSE or using the same profile ID.
  */
-class ChargepointTestFixtureV201_FR52
-    : public ChargepointTestFixtureV201,
+class SmartChargingHandlerTestFixtureV201_FR52
+    : public SmartChargingHandlerTestFixtureV201,
       public ::testing::WithParamInterface<std::tuple<int, int, ProfileValidationResultEnum>> {};
 
-INSTANTIATE_TEST_SUITE_P(TxDefaultProfileValidationV201_Param_Test_Instantiate_FR52, ChargepointTestFixtureV201_FR52,
+INSTANTIATE_TEST_SUITE_P(TxDefaultProfileValidationV201_Param_Test_Instantiate_FR52,
+                         SmartChargingHandlerTestFixtureV201_FR52,
                          testing::Values(std::make_tuple(DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL,
                                                          ProfileValidationResultEnum::DuplicateTxDefaultProfileFound),
                                          std::make_tuple(DEFAULT_PROFILE_ID, DEFAULT_STACK_LEVEL,
@@ -623,7 +631,7 @@ INSTANTIATE_TEST_SUITE_P(TxDefaultProfileValidationV201_Param_Test_Instantiate_F
                                          std::make_tuple(DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL + 1,
                                                          ProfileValidationResultEnum::Valid)));
 
-TEST_P(ChargepointTestFixtureV201_FR52, K01FR52_TxDefaultProfileValidationV201Tests) {
+TEST_P(SmartChargingHandlerTestFixtureV201_FR52, K01FR52_TxDefaultProfileValidationV201Tests) {
     auto [added_profile_id, added_stack_level, expected] = GetParam();
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
@@ -635,11 +643,12 @@ TEST_P(ChargepointTestFixtureV201_FR52, K01FR52_TxDefaultProfileValidationV201Te
     EXPECT_THAT(sut, testing::Eq(expected));
 }
 
-class ChargepointTestFixtureV201_FR53
-    : public ChargepointTestFixtureV201,
+class SmartChargingHandlerTestFixtureV201_FR53
+    : public SmartChargingHandlerTestFixtureV201,
       public ::testing::WithParamInterface<std::tuple<int, int, ProfileValidationResultEnum>> {};
 
-INSTANTIATE_TEST_SUITE_P(TxDefaultProfileValidationV201_Param_Test_Instantiate_FR53, ChargepointTestFixtureV201_FR53,
+INSTANTIATE_TEST_SUITE_P(TxDefaultProfileValidationV201_Param_Test_Instantiate_FR53,
+                         SmartChargingHandlerTestFixtureV201_FR53,
                          testing::Values(std::make_tuple(DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL,
                                                          ProfileValidationResultEnum::DuplicateTxDefaultProfileFound),
                                          std::make_tuple(DEFAULT_PROFILE_ID, DEFAULT_STACK_LEVEL,
@@ -647,7 +656,7 @@ INSTANTIATE_TEST_SUITE_P(TxDefaultProfileValidationV201_Param_Test_Instantiate_F
                                          std::make_tuple(DEFAULT_PROFILE_ID + 1, DEFAULT_STACK_LEVEL + 1,
                                                          ProfileValidationResultEnum::Valid)));
 
-TEST_P(ChargepointTestFixtureV201_FR53, K01FR53_TxDefaultProfileValidationV201Tests) {
+TEST_P(SmartChargingHandlerTestFixtureV201_FR53, K01FR53_TxDefaultProfileValidationV201Tests) {
     auto [added_profile_id, added_stack_level, expected] = GetParam();
     install_profile_on_evse(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
 
@@ -659,7 +668,7 @@ TEST_P(ChargepointTestFixtureV201_FR53, K01FR53_TxDefaultProfileValidationV201Te
     EXPECT_THAT(sut, testing::Eq(expected));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR52_TxDefaultProfileValidIfAppliedToWholeSystemAgain) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR52_TxDefaultProfileValidIfAppliedToWholeSystemAgain) {
     install_profile_on_evse(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
@@ -670,7 +679,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR52_TxDefaultProfileValidIfAppliedToWhole
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToExistingEvseAgain) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToExistingEvseAgain) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
@@ -681,7 +690,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToExist
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToDifferentEvse) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToDifferentEvse) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxDefaultProfile,
@@ -692,7 +701,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR53_TxDefaultProfileValidIfAppliedToDiffe
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCEVSE_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCEVSE_ThenProfileIsInvalid) {
     auto mock_evse = testing::NiceMock<EvseMock>();
     ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::DC));
 
@@ -706,7 +715,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCEVSE_ThenP
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCEVSE_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCEVSE_ThenProfileIsInvalid) {
     auto mock_evse = testing::NiceMock<EvseMock>();
     ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::DC));
 
@@ -720,7 +729,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCEVSE_ThenPro
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCChargingStation_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCChargingStation_ThenProfileIsInvalid) {
     device_model->set_value(ControllerComponentVariables::ChargingStationSupplyPhases.component,
                             ControllerComponentVariables::ChargingStationSupplyPhases.variable.value(),
                             AttributeEnum::Actual, std::to_string(0), "test", true);
@@ -735,7 +744,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfNumberPhasesProvidedForDCChargingSt
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCChargingStation_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCChargingStation_ThenProfileIsInvalid) {
     device_model->set_value(ControllerComponentVariables::ChargingStationSupplyPhases.component,
                             ControllerComponentVariables::ChargingStationSupplyPhases.variable.value(),
                             AttributeEnum::Actual, std::to_string(0), "test", true);
@@ -750,7 +759,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR44_IfPhaseToUseProvidedForDCChargingStat
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodExtraneousPhaseValues));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR45_IfNumberPhasesGreaterThanChargingStationSupplyPhasesForACEVSE_ThenProfileIsInvalid) {
     device_model->set_value(ControllerComponentVariables::ChargingStationSupplyPhases.component,
                             ControllerComponentVariables::ChargingStationSupplyPhases.variable.value(),
@@ -768,7 +777,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedNumberPhases));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR45_IfNumberPhasesGreaterThanChargingStationSupplyPhasesForACChargingStation_ThenProfileIsInvalid) {
     device_model->set_value(ControllerComponentVariables::ChargingStationSupplyPhases.component,
                             ControllerComponentVariables::ChargingStationSupplyPhases.variable.value(),
@@ -784,7 +793,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedNumberPhases));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACEVSE_ThenSetNumberPhasesToThree) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR49_IfNumberPhasesMissingForACEVSE_ThenSetNumberPhasesToThree) {
     auto mock_evse = testing::NiceMock<EvseMock>();
     ON_CALL(mock_evse, get_current_phase_type).WillByDefault(testing::Return(CurrentPhaseType::AC));
 
@@ -801,7 +810,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACEVSE_ThenSe
     EXPECT_THAT(numberPhases, testing::Eq(3));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACChargingStation_ThenSetNumberPhasesToThree) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR49_IfNumberPhasesMissingForACChargingStation_ThenSetNumberPhasesToThree) {
     device_model->set_value(ControllerComponentVariables::ChargingStationSupplyPhases.component,
                             ControllerComponentVariables::ChargingStationSupplyPhases.variable.value(),
                             AttributeEnum::Actual, std::to_string(3), "test", true);
@@ -819,7 +829,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR49_IfNumberPhasesMissingForACChargingSta
     EXPECT_THAT(numberPhases, testing::Eq(3));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR06_ExistingProfileLastsForever_RejectIncoming) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR06_ExistingProfileLastsForever_RejectIncoming) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime(date::utc_clock::time_point::min()),
                             ocpp::DateTime(date::utc_clock::time_point::max()));
 
@@ -835,7 +845,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExistingProfileLastsForever_RejectInc
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidFromIncomingValidToOverlaps_RejectIncoming) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR06_ExisitingProfileHasValidFromIncomingValidToOverlaps_RejectIncoming) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime("2024-01-01T13:00:00"),
                             ocpp::DateTime(date::utc_clock::time_point::max()));
 
@@ -850,7 +861,8 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidFromIncomingV
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidToIncomingValidFromOverlaps_RejectIncoming) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01FR06_ExisitingProfileHasValidToIncomingValidFromOverlaps_RejectIncoming) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime("2024-02-01T13:00:00"),
                             ocpp::DateTime(date::utc_clock::time_point::max()));
 
@@ -865,7 +877,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidToIncomingVal
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomingIsNowToMax_RejectIncoming) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomingIsNowToMax_RejectIncoming) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID,
                             ocpp::DateTime(date::utc_clock::now() - std::chrono::hours(5 * 24)),
                             ocpp::DateTime(date::utc_clock::now() + std::chrono::hours(5 * 24)));
@@ -881,7 +893,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomin
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomingOverlaps_RejectIncoming) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomingOverlaps_RejectIncoming) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID, ocpp::DateTime("2024-01-01T13:00:00"),
                             ocpp::DateTime("2024-02-01T13:00:00"));
 
@@ -897,7 +909,7 @@ TEST_F(ChargepointTestFixtureV201, K01FR06_ExisitingProfileHasValidPeriodIncomin
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfEvseDoesNotExist_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfEvseDoesNotExist_ThenProfileIsInvalid) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
 
@@ -906,7 +918,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfEvseDoesNotExist_ThenPr
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::EvseDoesNotExist));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfScheduleIsInvalid_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfScheduleIsInvalid_ThenProfileIsInvalid) {
     auto extraneous_start_schedule = ocpp::DateTime("2024-01-17T17:00:00");
     auto periods = create_charging_schedule_periods(0);
     auto profile =
@@ -919,7 +931,8 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfScheduleIsInvalid_ThenP
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingProfileExtraneousStartSchedule));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfileIsInvalid_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K01_ValidateProfile_IfChargeStationMaxProfileIsInvalid_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
@@ -930,7 +943,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfile
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01_ValidateProfile_IfDuplicateTxDefaultProfileFoundOnEVSE_IsInvalid_ThenProfileIsInvalid) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
@@ -945,7 +958,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateTxDefaultProfileFound));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01_ValidateProfile_IfDuplicateTxDefaultProfileFoundOnChargingStation_IsInvalid_ThenProfileIsInvalid) {
     install_profile_on_evse(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
 
@@ -960,7 +973,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateTxDefaultProfileFound));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsInvalid_ThenProfileIsInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfTxProfileIsInvalid_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -970,7 +983,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsInvalid_Then
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsValid_ThenProfileIsValid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfTxProfileIsValid_ThenProfileIsValid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
@@ -983,7 +996,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxProfileIsValid_ThenPr
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxDefaultProfileIsValid_ThenProfileIsValid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfTxDefaultProfileIsValid_ThenProfileIsValid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -994,7 +1007,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfTxDefaultProfileIsValid
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfileIsValid_ThenProfileIsValid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfileIsValid_ThenProfileIsValid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
@@ -1006,7 +1019,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateProfile_IfChargeStationMaxProfile
 }
 
 TEST_F(
-    ChargepointTestFixtureV201,
+    SmartChargingHandlerTestFixtureV201,
     K01_ValidateProfile_IfExistingChargingProfileWithSameIdIsChargingStationExternalConstraints_ThenProfileIsInvalid) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
     auto external_constraints =
@@ -1022,7 +1035,7 @@ TEST_F(
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ExistingChargingStationExternalConstraints));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR14_IfTxDefaultProfileWithSameStackLevelDoesNotExist_ThenApplyStationWideTxDefaultProfileToAllEvses) {
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
@@ -1035,7 +1048,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(handler.get_profiles(), testing::Contains(profile));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR15_IfTxDefaultProfileWithSameStackLevelDoesNotExist_ThenApplyTxDefaultProfileToEvse) {
 
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
@@ -1048,7 +1061,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(handler.get_profiles(), testing::Contains(profile));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR05_IfProfileWithSameIdExistsOnEVSEAndIsNotChargingStationExternalContraints_ThenProfileIsReplaced) {
 
     auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
@@ -1069,7 +1082,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile1)));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR05_IfProfileWithSameIdExistsOnChargingStationAndNewProfileIsOnEVSE_ThenProfileIsReplaced) {
     auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
                                             create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
@@ -1089,7 +1102,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile1)));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR05_IfProfileWithSameIdExistsOnAnyEVSEAndNewProfileIsOnEVSE_ThenProfileIsReplaced) {
     auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
                                             create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
@@ -1109,7 +1122,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile1)));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR05_IfProfileWithSameIdExistsOnAnyEVSEAndNewProfileIsOnChargingStation_ThenProfileIsReplaced) {
     auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                             create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
@@ -1129,7 +1142,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile1)));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR05_IfProfileWithSameIdExistsOnChargingStationAndNewProfileIsOnChargingStation_ThenProfileIsReplaced) {
     auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
                                             create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
@@ -1149,7 +1162,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile1)));
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K01FR05_ChargingStationWithMultipleProfilesAddProfileWithExistingProfileId_ThenProfileIsReplaced) {
     auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
                                             create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
@@ -1195,7 +1208,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(profiles, testing::Contains(profile5));
 }
 
-TEST_F(ChargepointTestFixtureV201, K04FR01_AddProfile_OnlyAddsToOneEVSE) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K04FR01_AddProfile_OnlyAddsToOneEVSE) {
     auto profile1 = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
                                             create_charge_schedule(ChargingRateUnitEnum::A), uuid(),
                                             ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL);
@@ -1219,7 +1232,7 @@ TEST_F(ChargepointTestFixtureV201, K04FR01_AddProfile_OnlyAddsToOneEVSE) {
     EXPECT_THAT(sut2, testing::Not(testing::Contains(profile1)));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_RejectsInvalidProfiles) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateAndAdd_RejectsInvalidProfiles) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -1239,7 +1252,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_RejectsInvalidProfiles) {
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile)));
 }
 
-TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
@@ -1256,7 +1269,7 @@ TEST_F(ChargepointTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles) {
     EXPECT_THAT(profiles, testing::Contains(profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseId) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseId) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile1 = create_charging_profile(
@@ -1287,7 +1300,7 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseId) {
     EXPECT_THAT(profile2, testing::Eq(reported_profile.profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_NoEvseId) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_NoEvseId) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile1 = create_charging_profile(
@@ -1311,7 +1324,7 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_NoEvseId) {
     EXPECT_THAT(profiles, testing::Contains(reported_profiles.at(1).profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_ProfileId) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_ProfileId) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile1 = create_charging_profile(
@@ -1335,7 +1348,7 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_ProfileId) {
     EXPECT_THAT(profile1, testing::Eq(reported_profiles.at(0).profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndStackLevel) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseIdAndStackLevel) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile1 = create_charging_profile(
@@ -1361,7 +1374,7 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndStackLevel) 
     EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSource) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSource) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -1387,7 +1400,7 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSource) {
     EXPECT_THAT(reported_profiles, testing::SizeIs(0));
 }
 
-TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndPurposeAndStackLevel) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseIdAndPurposeAndStackLevel) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile1 = create_charging_profile(
@@ -1419,7 +1432,7 @@ TEST_F(ChargepointTestFixtureV201, K09_GetChargingProfiles_EvseIdAndPurposeAndSt
     EXPECT_THAT(profile2, testing::Eq(reported_profiles.at(0).profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsId) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K10_ClearChargingProfile_ClearsId) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -1437,7 +1450,7 @@ TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsId) {
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile)));
 }
 
-TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsStackLevelPurposeCombination) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K10_ClearChargingProfile_ClearsStackLevelPurposeCombination) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
     auto profiles = handler.get_profiles();
@@ -1452,7 +1465,7 @@ TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_ClearsStackLevelPurp
     EXPECT_THAT(profiles, testing::IsEmpty());
 }
 
-TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownStackLevelPurposeCombination) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K10_ClearChargingProfile_UnknownStackLevelPurposeCombination) {
     install_profile_on_evse(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
 
     auto profiles = handler.get_profiles();
@@ -1467,7 +1480,7 @@ TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownStackLevelPur
     EXPECT_THAT(profiles, testing::Not(testing::IsEmpty()));
 }
 
-TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownId) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K10_ClearChargingProfile_UnknownId) {
     auto periods = create_charging_schedule_periods({0, 1, 2});
 
     auto profile = create_charging_profile(
@@ -1485,12 +1498,12 @@ TEST_F(ChargepointTestFixtureV201, K10_ClearChargingProfile_UnknownId) {
     EXPECT_THAT(profiles, testing::Contains(profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfNoProfiles_ThenNoValidProfilesReturned) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K08_GetValidProfiles_IfNoProfiles_ThenNoValidProfilesReturned) {
     auto profiles = handler.get_valid_profiles(DEFAULT_EVSE_ID);
     EXPECT_THAT(profiles, testing::IsEmpty());
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfEvseHasProfiles_ThenThoseProfilesReturned) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K08_GetValidProfiles_IfEvseHasProfiles_ThenThoseProfilesReturned) {
     auto profile = add_valid_profile_to(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
     ASSERT_TRUE(profile.has_value());
 
@@ -1498,7 +1511,8 @@ TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfEvseHasProfiles_ThenTh
     EXPECT_THAT(profiles, testing::Contains(profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfOtherEvseHasProfiles_ThenThoseProfilesAreNotReturned) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K08_GetValidProfiles_IfOtherEvseHasProfiles_ThenThoseProfilesAreNotReturned) {
     auto profile1 = add_valid_profile_to(DEFAULT_EVSE_ID, DEFAULT_PROFILE_ID);
     ASSERT_TRUE(profile1.has_value());
     auto profile2 = add_valid_profile_to(DEFAULT_EVSE_ID + 1, DEFAULT_PROFILE_ID + 1);
@@ -1509,7 +1523,8 @@ TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfOtherEvseHasProfiles_T
     EXPECT_THAT(profiles, testing::Not(testing::Contains(profile2)));
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfStationWideProfilesExist_ThenThoseProfilesAreReturned) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K08_GetValidProfiles_IfStationWideProfilesExist_ThenThoseProfilesAreReturned) {
     auto profile = add_valid_profile_to(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
     ASSERT_TRUE(profile.has_value());
 
@@ -1517,7 +1532,8 @@ TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfStationWideProfilesExi
     EXPECT_THAT(profiles, testing::Contains(profile));
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfStationWideProfilesExist_ThenThoseProfilesAreReturnedOnce) {
+TEST_F(SmartChargingHandlerTestFixtureV201,
+       K08_GetValidProfiles_IfStationWideProfilesExist_ThenThoseProfilesAreReturnedOnce) {
     auto profile = add_valid_profile_to(STATION_WIDE_ID, DEFAULT_PROFILE_ID);
     ASSERT_TRUE(profile.has_value());
 
@@ -1526,7 +1542,7 @@ TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfStationWideProfilesExi
     EXPECT_THAT(profiles.size(), testing::Eq(1));
 }
 
-TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfInvalidProfileExists_ThenThatProfileIsNotReturned) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K08_GetValidProfiles_IfInvalidProfileExists_ThenThatProfileIsNotReturned) {
     auto extraneous_start_schedule = ocpp::DateTime("2024-01-17T17:00:00");
     auto periods = create_charging_schedule_periods(0);
     auto invalid_profile =
@@ -1546,7 +1562,7 @@ TEST_F(ChargepointTestFixtureV201, K08_GetValidProfiles_IfInvalidProfileExists_T
     EXPECT_THAT(profiles, testing::Not(testing::Contains(invalid_station_wide_profile)));
 }
 
-TEST_F(ChargepointTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesTxProfilesByTransactionId) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesTxProfilesByTransactionId) {
     auto transaction_id = uuid();
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, transaction_id);
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -1563,7 +1579,7 @@ TEST_F(ChargepointTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesT
     EXPECT_THAT(handler.get_profiles(), testing::IsEmpty());
 }
 
-TEST_F(ChargepointTestFixtureV201,
+TEST_F(SmartChargingHandlerTestFixtureV201,
        K02FR05_DeleteTransactionTxProfiles_DoesNotDeleteTxProfilesWithDifferentTransactionId) {
     auto transaction_id = uuid();
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, transaction_id);
@@ -1584,7 +1600,7 @@ TEST_F(ChargepointTestFixtureV201,
     EXPECT_THAT(handler.get_profiles().size(), testing::Eq(1));
 }
 
-TEST_F(ChargepointTestFixtureV201, K05FR02_RequestStartTransactionRequest_ChargingProfileMustBeTxProfile) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K05FR02_RequestStartTransactionRequest_ChargingProfileMustBeTxProfile) {
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A,
                                                                   create_charging_schedule_periods({0, 1, 2}),

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1232,7 +1232,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K04FR01_AddProfile_OnlyAddsToOneEVSE
     EXPECT_THAT(sut2, testing::Not(testing::Contains(profile1)));
 }
 
-TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateAndAdd_RejectsInvalidProfiles) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateAndAdd_RejectsInvalidProfilesWithReasonCode) {
     auto periods = create_charging_schedule_periods(0);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -322,7 +322,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01FR09_IfTxProfileEvseHasNoActiveTr
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction));
 }
 
-TEST_F(SmartChargingHandlerTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
+TEST_F(SmartChargingHandlerTestFixtureV201, K01FR19AndFR48_NumberPhasesOtherThan1AndPhaseToUseSet_ThenProfileInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 0, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
@@ -335,7 +335,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01FR19_NumberPhasesOtherThan1AndPha
 }
 
 TEST_F(SmartChargingHandlerTestFixtureV201,
-       K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedUndefined_ThenProfileIsInvalid) {
+       K01FR20AndFR48_IfPhaseToUseSetAndACPhaseSwitchingSupportedUndefined_ThenProfileIsInvalid) {
     // As a device model with ac switching supported default set to 'true', we want to create a new database with the
     // ac switching support not set. But this is an in memory database, which is kept open until all handles to it are
     // closed. So we close all connections to the database.
@@ -360,7 +360,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
 }
 
 TEST_F(SmartChargingHandlerTestFixtureV201,
-       K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedFalse_ThenProfileIsInvalid) {
+       K01FR20AndFR48_IfPhaseToUseSetAndACPhaseSwitchingSupportedFalse_ThenProfileIsInvalid) {
     // As a device model with ac switching supported default set to 'true', we want to create a new database with the
     // ac switching support not set. But this is an in memory database, which is kept open until all handles to it are
     // closed. So we close all connections to the database.
@@ -385,7 +385,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
 }
 
 TEST_F(SmartChargingHandlerTestFixtureV201,
-       K01FR20_IfPhaseToUseSetAndACPhaseSwitchingSupportedTrue_ThenProfileIsNotInvalid) {
+       K01FR20AndFR48_IfPhaseToUseSetAndACPhaseSwitchingSupportedTrue_ThenProfileIsNotInvalid) {
     auto periods = create_charging_schedule_periods_with_phases(0, 1, 1);
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,


### PR DESCRIPTION
## Describe your changes

Renamed the test fixture for the SmartChargingHandler to SmartChargingHandlerTestFixtureV201

Renamed ChargePointFixture to ChargepointTestFixtureV201

Renamed ChargepointTestFixtureV201 to CompositeScheduleTestFixtureV201

Renamed K01_ValidateAndAdd_RejectsInvalidProfiles to K01_ValidateAndAdd_RejectsInvalidProfilesWithReasonCode

Small fix for database migrations in test_composite_schedule

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

