### PR TITLE
Feature for SmartCharging Offline Behavior

### DIFF
--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -197,6 +197,11 @@
                 "TxProfile"
             ]
         },
+        "IgnoredProfilePurposesOffline": {
+            "$comment": "Allows configuration of comma seperated list of ChargingProfilePurposes that are ignored in the composite schedule caluclation when offline.",
+            "type": "string",
+            "readOnly": true
+        },
         "MaxCompositeScheduleDuration": {
             "$comment": "Maximum duration in seconds of GetCompositeSchedule.req. For GetCompositeSchedule.req with a greater duration the schedule for only the MaxCompositeScheduleDuration will be calculated",
             "type": "integer",

--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -200,7 +200,7 @@
         "IgnoredProfilePurposesOffline": {
             "$comment": "Allows configuration of comma seperated list of ChargingProfilePurposes that are ignored in the composite schedule caluclation when offline.",
             "type": "string",
-            "readOnly": true
+            "readOnly": false
         },
         "MaxCompositeScheduleDuration": {
             "$comment": "Maximum duration in seconds of GetCompositeSchedule.req. For GetCompositeSchedule.req with a greater duration the schedule for only the MaxCompositeScheduleDuration will be calculated",

--- a/config/v201/component_config/standardized/SmartChargingCtrlr.json
+++ b/config/v201/component_config/standardized/SmartChargingCtrlr.json
@@ -253,6 +253,23 @@
       "description": "Supply voltage of the grid. This value is only used in case a conversion between smart charging amp and watt limits is required"   
     }
   },
+  "IgnoredProfilePurposesOffline": {
+    "variable_name": "IgnoredProfilePurposesOffline",
+      "characteristics": {
+        "valuesList": "ChargingStationMaxProfile,TxDefaultProfile,TxProfile",
+        "supportsMonitoring": true,
+        "dataType": "MemberList"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadOnly",
+          "value": ""
+        }
+      ],
+      "description": "Allows configuration of comma seperated list of ChargingProfilePurposes that are ignored in the composite schedule caluclation when offline.",
+      "type": "string"
+  },
   "required": [
     "ChargingProfileMaxStackLevel",
     "ChargingScheduleChargingRateUnit",

--- a/config/v201/component_config/standardized/SmartChargingCtrlr.json
+++ b/config/v201/component_config/standardized/SmartChargingCtrlr.json
@@ -263,7 +263,7 @@
       "attributes": [
         {
           "type": "Actual",
-          "mutability": "ReadOnly",
+          "mutability": "ReadWrite",
           "value": ""
         }
       ],

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -86,6 +86,7 @@ public:
     KeyValue getSupportedChargingProfilePurposeTypesKeyValue();
     std::vector<ChargingProfilePurposeType> getIgnoredProfilePurposesOffline();
     std::optional<KeyValue> getIgnoredProfilePurposesOfflineKeyValue();
+    bool setIgnoredProfilePurposesOffline(const std::string& ignored_profile_purposes_offline);
     int32_t getMaxCompositeScheduleDuration();
     KeyValue getMaxCompositeScheduleDurationKeyValue();
     std::optional<int32_t> getCompositeScheduleDefaultLimitAmps();

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -84,6 +84,8 @@ public:
     KeyValue getLogRotationMaximumFileCountKeyValue();
     std::vector<ChargingProfilePurposeType> getSupportedChargingProfilePurposeTypes();
     KeyValue getSupportedChargingProfilePurposeTypesKeyValue();
+    std::vector<ChargingProfilePurposeType> getIgnoredProfilePurposesOffline();
+    std::optional<KeyValue> getIgnoredProfilePurposesOfflineKeyValue();
     int32_t getMaxCompositeScheduleDuration();
     KeyValue getMaxCompositeScheduleDurationKeyValue();
     std::optional<int32_t> getCompositeScheduleDefaultLimitAmps();

--- a/include/ocpp/v16/smart_charging.hpp
+++ b/include/ocpp/v16/smart_charging.hpp
@@ -98,11 +98,12 @@ public:
     void clear_all_profiles();
 
     ///
-    /// \brief Gets all valid profiles within the given absoulte \p start_time and absolute \p end_time for the given \p
-    /// connector_id
+    /// \brief Gets all valid profiles within the given absoulte \p start_time and absolute \p end_time for the given
+    /// \p connector_id . Only profiles that are not contained in \p purposes_to_ignore are included in the response.
     ///
-    std::vector<ChargingProfile> get_valid_profiles(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time,
-                                                    const int connector_id);
+    std::vector<ChargingProfile>
+    get_valid_profiles(const ocpp::DateTime& start_time, const ocpp::DateTime& end_time, const int connector_id,
+                       const std::set<ChargingProfilePurposeType>& purposes_to_ignore = {});
     ///
     /// \brief Calculates the enhanced composite schedule for the given \p valid_profiles and the given \p connector_id
     ///

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -471,7 +471,9 @@ private:
 
     void trigger_authorization_cache_cleanup();
     void cache_cleanup_handler();
-    GetCompositeScheduleResponse get_composite_schedule_internal(const GetCompositeScheduleRequest& request);
+    GetCompositeScheduleResponse
+    get_composite_schedule_internal(const GetCompositeScheduleRequest& request,
+                                    const std::set<ChargingProfilePurposeEnum>& profiles_to_ignore = {});
 
     /// \brief Removes all network connection profiles below the actual security profile and stores the new list in the
     /// device model

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -216,6 +216,7 @@ extern const RequiredComponentVariable& SupplyVoltage;
 extern const ComponentVariable& Phases3to1;
 extern const RequiredComponentVariable& ChargingProfileMaxStackLevel;
 extern const RequiredComponentVariable& ChargingScheduleChargingRateUnit;
+extern const ComponentVariable& IgnoredProfilePurposesOffline;
 extern const ComponentVariable& TariffCostCtrlrAvailableTariff;
 extern const ComponentVariable& TariffCostCtrlrAvailableCost;
 extern const RequiredComponentVariable& TariffCostCtrlrCurrency;

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -91,7 +91,8 @@ public:
 
     virtual std::vector<ReportedChargingProfile>
     get_reported_profiles(const GetChargingProfilesRequest& request) const = 0;
-    virtual std::vector<ChargingProfile> get_valid_profiles(int32_t evse_id) = 0;
+    virtual std::vector<ChargingProfile>
+    get_valid_profiles(int32_t evse_id, const std::set<ChargingProfilePurposeEnum>& purposes_to_ignore = {}) = 0;
 
     virtual CompositeSchedule calculate_composite_schedule(std::vector<ChargingProfile>& valid_profiles,
                                                            const ocpp::DateTime& start_time,
@@ -153,9 +154,12 @@ public:
     std::vector<ReportedChargingProfile>
     get_reported_profiles(const GetChargingProfilesRequest& request) const override;
 
-    /// \brief Retrieves all profiles that should be considered for calculating the composite schedule.
+    /// \brief Retrieves all profiles that should be considered for calculating the composite schedule. Only profiles
+    /// that belong to the given \p evse_id and that are not contained in \p purposes_to_ignore are included in the
+    /// response.
     ///
-    std::vector<ChargingProfile> get_valid_profiles(int32_t evse_id) override;
+    std::vector<ChargingProfile>
+    get_valid_profiles(int32_t evse_id, const std::set<ChargingProfilePurposeEnum>& purposes_to_ignore = {}) override;
 
     ///
     /// \brief Calculates the composite schedule for the given \p valid_profiles and the given \p connector_id
@@ -215,7 +219,8 @@ protected:
 private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;
     std::vector<ChargingProfile> get_station_wide_tx_default_profiles() const;
-    std::vector<ChargingProfile> get_valid_profiles_for_evse(int32_t evse_id);
+    std::vector<ChargingProfile>
+    get_valid_profiles_for_evse(int32_t evse_id, const std::set<ChargingProfilePurposeEnum>& purposes_to_ignore = {});
     void conform_schedule_number_phases(int32_t profile_id, ChargingSchedulePeriod& charging_schedule_period) const;
     void conform_validity_periods(ChargingProfile& profile) const;
     CurrentPhaseType get_current_phase_type(const std::optional<EvseInterface*> evse_opt) const;

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -3,6 +3,8 @@
 #ifndef V201_UTILS_HPP
 #define V201_UTILS_HPP
 
+#include <set>
+
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/types.hpp>
 namespace ocpp {
@@ -70,6 +72,9 @@ std::optional<float> get_total_power_active_import(const MeterValue& meter_value
 
 /// \brief Determines if a given \p security_event is critical as defined in the OCPP 2.0.1 appendix
 bool is_critical(const std::string& security_event);
+
+/// \brief Converts the given \p csl of ChargingProfilePurpose strings into a std::set<ChargingProfilePurposeEnum>
+std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string &csl, const bool is_offline);
 
 } // namespace utils
 } // namespace v201

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -74,7 +74,7 @@ std::optional<float> get_total_power_active_import(const MeterValue& meter_value
 bool is_critical(const std::string& security_event);
 
 /// \brief Converts the given \p csl of ChargingProfilePurpose strings into a std::set<ChargingProfilePurposeEnum>
-std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string &csl, const bool is_offline);
+std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string& csl, const bool is_offline);
 
 } // namespace utils
 } // namespace v201

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -346,6 +346,19 @@ std::vector<ChargingProfilePurposeType> ChargePointConfiguration::getSupportedCh
     return supported_purpose_types;
 }
 
+std::vector<ChargingProfilePurposeType> ChargePointConfiguration::getIgnoredProfilePurposesOffline() {
+    if (not this->config["Internal"].contains("IgnoredProfilePurposesOffline")) {
+        return {};
+    }
+
+    std::vector<ChargingProfilePurposeType> purpose_types;
+    const auto str_list = this->config["Internal"]["IgnoredProfilePurposesOffline"];
+    for (const auto& str : str_list) {
+        purpose_types.push_back(conversions::string_to_charging_profile_purpose_type(str));
+    }
+    return purpose_types;
+}
+
 int32_t ChargePointConfiguration::getMaxCompositeScheduleDuration() {
     return this->config["Internal"]["MaxCompositeScheduleDuration"];
 }
@@ -664,6 +677,22 @@ KeyValue ChargePointConfiguration::getSupportedChargingProfilePurposeTypesKeyVal
     kv.readonly = true;
     std::vector<std::string> purpose_types;
     for (const auto& entry : this->getSupportedChargingProfilePurposeTypes()) {
+        purpose_types.push_back(conversions::charging_profile_purpose_type_to_string(entry));
+    }
+    kv.value.emplace(to_csl(purpose_types));
+    return kv;
+}
+
+std::optional<KeyValue> ChargePointConfiguration::getIgnoredProfilePurposesOfflineKeyValue() {
+    if (this->getIgnoredProfilePurposesOffline().empty()) {
+        return std::nullopt;
+    }
+
+    KeyValue kv;
+    kv.key = "IgnoredProfilePurposesOfflineKeyValue";
+    kv.readonly = true;
+    std::vector<std::string> purpose_types;
+    for (const auto& entry : this->getIgnoredProfilePurposesOffline()) {
         purpose_types.push_back(conversions::charging_profile_purpose_type_to_string(entry));
     }
     kv.value.emplace(to_csl(purpose_types));
@@ -2941,6 +2970,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     }
     if (key == "SupportedChargingProfilePurposeTypes") {
         return this->getSupportedChargingProfilePurposeTypesKeyValue();
+    }
+    if (key == "IgnoredProfilePurposesOffline") {
+        return this->getIgnoredProfilePurposesOfflineKeyValue();
     }
     if (key == "MaxCompositeScheduleDuration") {
         return this->getMaxCompositeScheduleDurationKeyValue();

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3353,6 +3353,12 @@ std::map<int32_t, ChargingSchedule> ChargePointImpl::get_all_composite_charging_
                                                                                           const ChargingRateUnit unit) {
 
     std::map<int32_t, ChargingSchedule> charging_schedules;
+    std::set<ChargingProfilePurposeType> purposes_to_ignore;
+
+    if (not this->websocket->is_connected()) {
+        const auto purposes_to_ignore_vec = this->configuration->getIgnoredProfilePurposesOffline();
+        purposes_to_ignore.insert(purposes_to_ignore_vec.begin(), purposes_to_ignore_vec.end());
+    }
 
     for (int connector_id = 0; connector_id <= this->configuration->getNumberOfConnectors(); connector_id++) {
         const auto start_time = ocpp::DateTime();
@@ -3360,7 +3366,7 @@ std::map<int32_t, ChargingSchedule> ChargePointImpl::get_all_composite_charging_
         const auto end_time = ocpp::DateTime(start_time.to_time_point() + duration);
 
         const auto valid_profiles =
-            this->smart_charging_handler->get_valid_profiles(start_time, end_time, connector_id);
+            this->smart_charging_handler->get_valid_profiles(start_time, end_time, connector_id, purposes_to_ignore);
         const auto composite_schedule = this->smart_charging_handler->calculate_composite_schedule(
             valid_profiles, start_time, end_time, connector_id, unit);
         charging_schedules[connector_id] = composite_schedule;
@@ -3373,6 +3379,12 @@ std::map<int32_t, EnhancedChargingSchedule>
 ChargePointImpl::get_all_enhanced_composite_charging_schedules(const int32_t duration_s, const ChargingRateUnit unit) {
 
     std::map<int32_t, EnhancedChargingSchedule> charging_schedules;
+    std::set<ChargingProfilePurposeType> purposes_to_ignore;
+
+    if (not this->websocket->is_connected()) {
+        const auto purposes_to_ignore_vec = this->configuration->getIgnoredProfilePurposesOffline();
+        purposes_to_ignore.insert(purposes_to_ignore_vec.begin(), purposes_to_ignore_vec.end());
+    }
 
     for (int connector_id = 0; connector_id <= this->configuration->getNumberOfConnectors(); connector_id++) {
         const auto start_time = ocpp::DateTime();
@@ -3380,7 +3392,7 @@ ChargePointImpl::get_all_enhanced_composite_charging_schedules(const int32_t dur
         const auto end_time = ocpp::DateTime(start_time.to_time_point() + duration);
 
         const auto valid_profiles =
-            this->smart_charging_handler->get_valid_profiles(start_time, end_time, connector_id);
+            this->smart_charging_handler->get_valid_profiles(start_time, end_time, connector_id, purposes_to_ignore);
         const auto composite_schedule = this->smart_charging_handler->calculate_enhanced_composite_schedule(
             valid_profiles, start_time, end_time, connector_id, unit);
         charging_schedules[connector_id] = composite_schedule;

--- a/lib/ocpp/v16/smart_charging.cpp
+++ b/lib/ocpp/v16/smart_charging.cpp
@@ -396,7 +396,7 @@ SmartChargingHandler::get_valid_profiles(const ocpp::DateTime& start_time, const
         std::lock_guard<std::mutex> lk(charge_point_max_profiles_map_mutex);
 
         if (std::find(std::begin(purposes_to_ignore), std::end(purposes_to_ignore),
-                      ChargingProfilePurposeType::ChargePointMaxProfile) != std::end(purposes_to_ignore)) {
+                      ChargingProfilePurposeType::ChargePointMaxProfile) == std::end(purposes_to_ignore)) {
             for (const auto& [stack_level, profile] : stack_level_charge_point_max_profiles_map) {
                 valid_profiles.push_back(profile);
             }
@@ -418,7 +418,8 @@ SmartChargingHandler::get_valid_profiles(const ocpp::DateTime& start_time, const
             std::lock_guard<std::mutex> lk_txd(tx_default_profiles_map_mutex);
             std::lock_guard<std::mutex> lk_tx(tx_profiles_map_mutex);
 
-            if (not purposes_to_ignore.count(ChargingProfilePurposeType::TxProfile)) {
+            if (std::find(std::begin(purposes_to_ignore), std::end(purposes_to_ignore),
+                          ChargingProfilePurposeType::TxProfile) == std::end(purposes_to_ignore)) {
                 for (const auto& [stack_level, profile] : itt->second->stack_level_tx_profiles_map) {
                     // only include profiles that match the transactionId (when there is one)
                     bool b_add{false};
@@ -438,7 +439,8 @@ SmartChargingHandler::get_valid_profiles(const ocpp::DateTime& start_time, const
                     }
                 }
             }
-            if (not purposes_to_ignore.count(ChargingProfilePurposeType::TxDefaultProfile)) {
+            if (std::find(std::begin(purposes_to_ignore), std::end(purposes_to_ignore),
+                          ChargingProfilePurposeType::TxDefaultProfile) == std::end(purposes_to_ignore)) {
                 for (const auto& [stack_level, profile] : itt->second->stack_level_tx_default_profiles_map) {
                     valid_profiles.push_back(profile);
                 }

--- a/lib/ocpp/v16/smart_charging.cpp
+++ b/lib/ocpp/v16/smart_charging.cpp
@@ -395,7 +395,8 @@ SmartChargingHandler::get_valid_profiles(const ocpp::DateTime& start_time, const
     {
         std::lock_guard<std::mutex> lk(charge_point_max_profiles_map_mutex);
 
-        if (not purposes_to_ignore.count(ChargingProfilePurposeType::ChargePointMaxProfile)) {
+        if (std::find(std::begin(purposes_to_ignore), std::end(purposes_to_ignore),
+                      ChargingProfilePurposeType::ChargePointMaxProfile) != std::end(purposes_to_ignore)) {
             for (const auto& [stack_level, profile] : stack_level_charge_point_max_profiles_map) {
                 valid_profiles.push_back(profile);
             }

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -1211,6 +1211,13 @@ const RequiredComponentVariable& ChargingScheduleChargingRateUnit = {
         "RateUnit",
     }),
 };
+const ComponentVariable& IgnoredProfilePurposesOffline = {
+    ControllerComponents::SmartChargingCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "IgnoredProfilePurposesOffline",
+    }),
+};
 const ComponentVariable& TariffCostCtrlrAvailableTariff = {
     ControllerComponents::TariffCostCtrlr,
     std::nullopt,

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -459,12 +459,15 @@ SmartChargingHandler::get_reported_profiles(const GetChargingProfilesRequest& re
     return this->database_handler->get_charging_profiles_matching_criteria(request.evseId, request.chargingProfile);
 }
 
-std::vector<ChargingProfile> SmartChargingHandler::get_valid_profiles_for_evse(int32_t evse_id) {
+std::vector<ChargingProfile>
+SmartChargingHandler::get_valid_profiles_for_evse(int32_t evse_id,
+                                                  const std::set<ChargingProfilePurposeEnum>& purposes_to_ignore) {
     std::vector<ChargingProfile> valid_profiles;
 
     auto evse_profiles = this->database_handler->get_charging_profiles_for_evse(evse_id);
     for (auto profile : evse_profiles) {
-        if (this->conform_and_validate_profile(profile, evse_id) == ProfileValidationResultEnum::Valid) {
+        if (this->conform_and_validate_profile(profile, evse_id) == ProfileValidationResultEnum::Valid and
+            not purposes_to_ignore.count(profile.chargingProfilePurpose)) {
             valid_profiles.push_back(profile);
         }
     }
@@ -472,11 +475,13 @@ std::vector<ChargingProfile> SmartChargingHandler::get_valid_profiles_for_evse(i
     return valid_profiles;
 }
 
-std::vector<ChargingProfile> SmartChargingHandler::get_valid_profiles(int32_t evse_id) {
-    std::vector<ChargingProfile> valid_profiles = get_valid_profiles_for_evse(evse_id);
+std::vector<ChargingProfile>
+SmartChargingHandler::get_valid_profiles(int32_t evse_id,
+                                         const std::set<ChargingProfilePurposeEnum>& purposes_to_ignore) {
+    std::vector<ChargingProfile> valid_profiles = get_valid_profiles_for_evse(evse_id, purposes_to_ignore);
 
     if (evse_id != STATION_WIDE_ID) {
-        auto station_wide_profiles = get_valid_profiles_for_evse(STATION_WIDE_ID);
+        auto station_wide_profiles = get_valid_profiles_for_evse(STATION_WIDE_ID, purposes_to_ignore);
         valid_profiles.insert(valid_profiles.end(), station_wide_profiles.begin(), station_wide_profiles.end());
     }
 

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -467,7 +467,8 @@ SmartChargingHandler::get_valid_profiles_for_evse(int32_t evse_id,
     auto evse_profiles = this->database_handler->get_charging_profiles_for_evse(evse_id);
     for (auto profile : evse_profiles) {
         if (this->conform_and_validate_profile(profile, evse_id) == ProfileValidationResultEnum::Valid and
-            not purposes_to_ignore.count(profile.chargingProfilePurpose)) {
+            std::find(std::begin(purposes_to_ignore), std::end(purposes_to_ignore), profile.chargingProfilePurpose) ==
+                std::end(purposes_to_ignore)) {
             valid_profiles.push_back(profile);
         }
     }

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -193,13 +193,10 @@ bool is_critical(const std::string& security_event) {
 }
 
 std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string& csl, const bool is_offline) {
-    if (not is_offline) {
+    if (not is_offline or csl.empty()) {
         return {};
     }
 
-    if (csl.empty()) {
-        return {};
-    }
     std::set<ChargingProfilePurposeEnum> purposes_to_ignore;
     const auto purposes_to_ignore_vec = split_string(csl, ',');
 

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -196,7 +196,7 @@ std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string& c
     if (not is_offline) {
         return {};
     }
-    
+
     if (csl.empty()) {
         return {};
     }

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -192,6 +192,27 @@ bool is_critical(const std::string& security_event) {
     return false;
 }
 
+std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string& csl, const bool is_offline) {
+    if (not is_offline) {
+        return {};
+    }
+    
+    if (csl.empty()) {
+        return {};
+    }
+    std::set<ChargingProfilePurposeEnum> purposes_to_ignore;
+    const auto purposes_to_ignore_vec = split_string(csl, ',');
+
+    for (const auto purpose : purposes_to_ignore_vec) {
+        try {
+            purposes_to_ignore.insert(conversions::string_to_charging_profile_purpose_enum(purpose));
+        } catch (std::out_of_range& e) {
+            EVLOG_warning << "Error while converting charging profile purpose to ignore: " << purpose;
+        }
+    }
+    return purposes_to_ignore;
+}
+
 } // namespace utils
 } // namespace v201
 } // namespace ocpp

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -23,7 +23,8 @@ public:
     MOCK_METHOD(ClearChargingProfileResponse, clear_profiles, (const ClearChargingProfileRequest& request), (override));
     MOCK_METHOD(std::vector<ReportedChargingProfile>, get_reported_profiles,
                 (const GetChargingProfilesRequest& request), (const, override));
-    MOCK_METHOD(std::vector<ChargingProfile>, get_valid_profiles, (int32_t evse_id));
+    MOCK_METHOD(std::vector<ChargingProfile>, get_valid_profiles,
+                (int32_t evse_id, const std::set<ChargingProfilePurposeEnum>&));
     MOCK_METHOD(CompositeSchedule, calculate_composite_schedule,
                 (std::vector<ChargingProfile> & valid_profiles, const ocpp::DateTime& start_time,
                  const ocpp::DateTime& end_time, const int32_t evse_id,

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -850,7 +850,8 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
                                 DEFAULT_TX_ID),
     };
 
-    ON_CALL(*smart_charging_handler, get_valid_profiles(DEFAULT_EVSE_ID)).WillByDefault(testing::Return(profiles));
+    ON_CALL(*smart_charging_handler, get_valid_profiles(DEFAULT_EVSE_ID, testing::_))
+        .WillByDefault(testing::Return(profiles));
     EXPECT_CALL(*smart_charging_handler,
                 calculate_composite_schedule(profiles, testing::_, testing::_, DEFAULT_EVSE_ID, req.chargingRateUnit));
 
@@ -866,7 +867,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
     auto get_composite_schedule_req =
         request_to_enhanced_message<GetCompositeScheduleRequest, MessageType::GetCompositeSchedule>(req);
 
-    EXPECT_CALL(*smart_charging_handler, get_valid_profiles(testing::_)).Times(0);
+    EXPECT_CALL(*smart_charging_handler, get_valid_profiles(testing::_, testing::_)).Times(0);
     EXPECT_CALL(*smart_charging_handler,
                 calculate_composite_schedule(testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(0);
@@ -887,7 +888,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
     device_model->set_value(charging_rate_unit_cv.component, charging_rate_unit_cv.variable.value(),
                             AttributeEnum::Actual, "A", "test", true);
 
-    EXPECT_CALL(*smart_charging_handler, get_valid_profiles(testing::_)).Times(0);
+    EXPECT_CALL(*smart_charging_handler, get_valid_profiles(testing::_, testing::_)).Times(0);
     EXPECT_CALL(*smart_charging_handler,
                 calculate_composite_schedule(testing::_, testing::_, testing::_, testing::_, testing::_))
         .Times(0);


### PR DESCRIPTION
## Describe your changes
Added configuration variable to 1.6 and 2.0.1 to allow ignoring profile in case the charging station is offline when the composite schedules are calculated by requests of a libocpp consumer application

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/781

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

