### PR TITLE
Fix: Include all evse_ids in get_all_composite_schedules

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -4067,7 +4067,7 @@ std::vector<CompositeSchedule> ChargePoint::get_all_composite_schedules(const in
 
     const auto number_of_evses = this->evse_manager->get_number_of_evses();
     // get all composite schedules including the one for evse_id == 0
-    for (int32_t evse_id = 0; evse_id < number_of_evses; evse_id++) {
+    for (int32_t evse_id = 0; evse_id <= number_of_evses; evse_id++) {
         GetCompositeScheduleRequest request;
         request.duration = duration_s;
         request.evseId = evse_id;


### PR DESCRIPTION
## Describe your changes
Change for loop in get_all_composite_schedules to include all evses including 0

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

