### PR TITLE
Notify consumer about charging profile update when a transaction stops

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2340,6 +2340,11 @@ void ChargePointImpl::handleClearChargingProfileRequest(ocpp::Call<ClearCharging
 
     ocpp::CallResult<ClearChargingProfileResponse> call_result(response, call.uniqueId);
     this->send<ClearChargingProfileResponse>(call_result);
+
+    if (response.status == ClearChargingProfileStatus::Accepted and
+        this->signal_set_charging_profiles_callback != nullptr) {
+        this->signal_set_charging_profiles_callback();
+    }
 }
 
 void ChargePointImpl::handleTriggerMessageRequest(ocpp::Call<TriggerMessageRequest> call) {
@@ -4096,9 +4101,10 @@ void ChargePointImpl::on_transaction_stopped(const int32_t connector, const std:
     this->status->submit_event(connector, FSMEvent::TransactionStoppedAndUserActionRequired, ocpp::DateTime());
     this->stop_transaction(connector, reason, id_tag_end);
     this->transaction_handler->remove_active_transaction(connector);
-    this->smart_charging_handler->clear_all_profiles_with_filter(std::nullopt, connector, std::nullopt,
-                                                                 ChargingProfilePurposeType::TxProfile, false);
-    if (this->signal_set_charging_profiles_callback != nullptr) {
+
+    const auto profile_cleared = this->smart_charging_handler->clear_all_profiles_with_filter(
+        std::nullopt, connector, std::nullopt, ChargingProfilePurposeType::TxProfile, false);
+    if (if profile_cleared and this->signal_set_charging_profiles_callback != nullptr) {
         this->signal_set_charging_profiles_callback();
     }
     reset_pricing_triggers(connector);

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -4098,7 +4098,9 @@ void ChargePointImpl::on_transaction_stopped(const int32_t connector, const std:
     this->transaction_handler->remove_active_transaction(connector);
     this->smart_charging_handler->clear_all_profiles_with_filter(std::nullopt, connector, std::nullopt,
                                                                  ChargingProfilePurposeType::TxProfile, false);
-
+    if (this->signal_set_charging_profiles_callback != nullptr) {
+        this->signal_set_charging_profiles_callback();
+    }
     reset_pricing_triggers(connector);
 }
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -4104,7 +4104,7 @@ void ChargePointImpl::on_transaction_stopped(const int32_t connector, const std:
 
     const auto profile_cleared = this->smart_charging_handler->clear_all_profiles_with_filter(
         std::nullopt, connector, std::nullopt, ChargingProfilePurposeType::TxProfile, false);
-    if (if profile_cleared and this->signal_set_charging_profiles_callback != nullptr) {
+    if (profile_cleared and this->signal_set_charging_profiles_callback != nullptr) {
         this->signal_set_charging_profiles_callback();
     }
     reset_pricing_triggers(connector);


### PR DESCRIPTION
## Describe your changes
This PR adds executing `signal_set_charging_profiles_callback` when a transaction is stopped to notify the consumer. The stopped transaction might have removed previously reported TxProfiles (as part of the composite schedule) which could influence the load balancing / charging power of the EVSEs.

Remark: Looking at how the `signal_set_charging_profiles_callback` and also `set_charging_profiles_callback` (of ocpp201) I would suggest to change the name of these variables to better represent their purpose. A libocpp user should get notified in case profiles are added / removed which leads to a change of the composite schedule. This can happen when charging profiles are added by `SetChargingProfile.req` but also when transactions stop (because TxProfiles) might be removed. A more appropriate name would e.g. be `charging_profiles_updated_callback`.

I covered that in [this issue](https://github.com/EVerest/libocpp/issues/787).

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

