### PR TITLE
refactor: Replace get_vector_from_csv with split_string

### DIFF
--- a/include/ocpp/common/utils.hpp
+++ b/include/ocpp/common/utils.hpp
@@ -12,8 +12,6 @@ namespace ocpp {
 /// \brief Case insensitive compare for a case insensitive (Ci)String
 bool iequals(const std::string& lhs, const std::string rhs);
 
-std::vector<std::string> get_vector_from_csv(const std::string& csv_str);
-
 bool is_integer(const std::string& value);
 std::tuple<bool, int> is_positive_integer(const std::string& value);
 bool is_decimal_number(const std::string& value);

--- a/lib/ocpp/common/utils.cpp
+++ b/lib/ocpp/common/utils.cpp
@@ -14,16 +14,6 @@ bool iequals(const std::string& lhs, const std::string rhs) {
     return boost::algorithm::iequals(lhs, rhs);
 }
 
-std::vector<std::string> get_vector_from_csv(const std::string& csv_str) {
-    std::vector<std::string> csv;
-    std::string str;
-    std::stringstream ss(csv_str);
-    while (std::getline(ss, str, ',')) {
-        csv.push_back(str);
-    }
-    return csv;
-}
-
 bool is_integer(const std::string& value) {
     if (value.empty()) {
         return false;

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -210,7 +210,7 @@ std::string to_csl(const std::vector<std::string>& vec) {
 }
 
 void ChargePointConfiguration::init_supported_measurands() {
-    const auto _supported_measurands = ocpp::get_vector_from_csv(this->config["Internal"]["SupportedMeasurands"]);
+    const auto _supported_measurands = ocpp::split_string(this->config["Internal"]["SupportedMeasurands"], ',');
     for (const auto& measurand : _supported_measurands) {
         try {
             const auto _measurand = conversions::string_to_measurand(measurand);

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -4165,7 +4165,7 @@ void ChargePointImpl::stop_transaction(int32_t connector, Reason reason, std::op
 
 std::vector<Measurand> ChargePointImpl::get_measurands_vec(const std::string& measurands_csv) {
     std::vector<Measurand> measurands;
-    std::vector<std::string> measurands_strings = ocpp::get_vector_from_csv(measurands_csv);
+    std::vector<std::string> measurands_strings = ocpp::split_string(measurands_csv, ',');
 
     for (const auto& measurand_string : measurands_strings) {
         try {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1078,8 +1078,8 @@ void ChargePoint::remove_network_connection_profiles_below_actual_security_profi
                                   VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
 
     // Update the NetworkConfigurationPriority so only remaining profiles are in there
-    const auto network_priority = ocpp::get_vector_from_csv(
-        this->device_model->get_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority));
+    const auto network_priority = ocpp::split_string(
+        this->device_model->get_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority), ',');
 
     auto in_network_profiles = [&network_connection_profiles](const std::string& item) {
         auto is_same_slot = [&item](const SetNetworkProfileRequest& profile) {
@@ -1679,7 +1679,7 @@ void ChargePoint::handle_variables_changed(const std::map<SetVariableData, SetVa
 bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data) {
     ComponentVariable cv = {set_variable_data.component, std::nullopt, set_variable_data.variable};
     if (cv == ControllerComponentVariables::NetworkConfigurationPriority) {
-        const auto network_configuration_priorities = ocpp::get_vector_from_csv(set_variable_data.attributeValue.get());
+        const auto network_configuration_priorities = ocpp::split_string(set_variable_data.attributeValue.get(), ',');
         const auto active_security_profile =
             this->device_model->get_value<int>(ControllerComponentVariables::SecurityProfile);
         for (const auto configuration_slot : network_configuration_priorities) {

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -267,8 +267,8 @@ void ConnectivityManager::cache_network_connection_profiles() {
     this->network_connection_profiles =
         json::parse(this->device_model.get_value<std::string>(ControllerComponentVariables::NetworkConnectionProfiles));
 
-    this->network_connection_priorities = ocpp::get_vector_from_csv(
-        this->device_model.get_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority));
+    this->network_connection_priorities = ocpp::split_string(
+        this->device_model.get_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority), ',');
 
     if (this->network_connection_priorities.empty()) {
         EVLOG_AND_THROW(std::runtime_error("NetworkConfigurationPriority must not be empty"));

--- a/lib/ocpp/v201/device_model.cpp
+++ b/lib/ocpp/v201/device_model.cpp
@@ -175,7 +175,7 @@ bool validate_value(const VariableCharacteristics& characteristics, const std::s
         if (!characteristics.valuesList.has_value()) {
             return true;
         }
-        const auto values_list = ocpp::get_vector_from_csv(characteristics.valuesList.value().get());
+        const auto values_list = ocpp::split_string(characteristics.valuesList.value().get(), ',');
         return std::find(values_list.begin(), values_list.end(), value) != values_list.end();
     }
     default: // same validation for MemberList or SequenceList
@@ -186,8 +186,8 @@ bool validate_value(const VariableCharacteristics& characteristics, const std::s
             if (!characteristics.valuesList.has_value()) {
                 return true;
             }
-            const auto values_list = ocpp::get_vector_from_csv(characteristics.valuesList.value().get());
-            const auto value_csv = get_vector_from_csv(value);
+            const auto values_list = ocpp::split_string(characteristics.valuesList.value().get(), ',');
+            const auto value_csv = ocpp::split_string(value, ',');
             for (const auto& v : value_csv) {
                 if (std::find(values_list.begin(), values_list.end(), v) == values_list.end()) {
                     return false;

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -16,7 +16,7 @@ namespace utils {
 
 std::vector<MeasurandEnum> get_measurands_vec(const std::string& measurands_csv) {
     std::vector<MeasurandEnum> measurands;
-    std::vector<std::string> measurands_strings = ocpp::get_vector_from_csv(measurands_csv);
+    std::vector<std::string> measurands_strings = ocpp::split_string(measurands_csv, ',');
 
     for (const auto& measurand_string : measurands_strings) {
         try {


### PR DESCRIPTION
Removed references to get_vector_from_csv by split_string since this last method is more extensible / reusable.

## Describe your changes

## Issue ticket number and link
Issue #721 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

