### PR TITLE
Use the last_used value from the auth cache database to check for cache lifetime when authorizing

### DIFF
--- a/include/ocpp/v201/database_handler.hpp
+++ b/include/ocpp/v201/database_handler.hpp
@@ -19,6 +19,7 @@
 namespace ocpp {
 namespace v201 {
 
+/// \brief Helper class for retrieving authorization cache entries from the database
 struct AuthorizationCacheEntry {
     IdTokenInfo id_token_info;
     DateTime last_used;

--- a/include/ocpp/v201/database_handler.hpp
+++ b/include/ocpp/v201/database_handler.hpp
@@ -19,6 +19,11 @@
 namespace ocpp {
 namespace v201 {
 
+struct AuthorizationCacheEntry {
+    IdTokenInfo id_token_info;
+    DateTime last_used;
+};
+
 class DatabaseHandler : public common::DatabaseHandlerCommon {
 private:
     void init_sql() override;
@@ -55,7 +60,7 @@ public:
     /// \brief Gets cache entry for given \p id_token_hash if present
     /// \param id_token_hash
     /// \return
-    std::optional<IdTokenInfo> authorization_cache_get_entry(const std::string& id_token_hash);
+    std::optional<AuthorizationCacheEntry> authorization_cache_get_entry(const std::string& id_token_hash);
 
     /// \brief Deletes the cache entry for the given \p id_token_hash
     /// \param id_token_hash

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -551,7 +551,7 @@ std::string ChargePoint::get_customer_information(const std::optional<Certificat
             const auto entry = this->database_handler->authorization_cache_get_entry(hashed_id_token);
             if (entry.has_value()) {
                 s << "Hashed id_token stored in cache: " + hashed_id_token + "\n";
-                s << "IdTokenInfo: " << entry.value();
+                s << "IdTokenInfo: " << entry->id_token_info;
             }
         } catch (const DatabaseException& e) {
             EVLOG_warning << "Could not get authorization cache entry from database";
@@ -850,25 +850,35 @@ AuthorizeResponse ChargePoint::validate_token(const IdToken id_token, const std:
         try {
             const auto cache_entry = this->database_handler->authorization_cache_get_entry(hashed_id_token);
             if (cache_entry.has_value()) {
-                if ((cache_entry.value().cacheExpiryDateTime.has_value() and
-                     cache_entry.value().cacheExpiryDateTime.value().to_time_point() < DateTime().to_time_point())) {
-                    EVLOG_info
-                        << "Found valid entry in AuthCache but expiry date passed: Removing from cache and sending "
-                           "new request";
+                const auto now = DateTime();
+                const IdTokenInfo& id_token_info = cache_entry->id_token_info;
+
+                const auto lifetime =
+                    this->device_model->get_optional_value<int>(ControllerComponentVariables::AuthCacheLifeTime);
+                const bool lifetime_expired =
+                    lifetime.has_value() && ((cache_entry->last_used.to_time_point() +
+                                              std::chrono::seconds(lifetime.value())) < now.to_time_point());
+                const bool cache_expiry_passed =
+                    id_token_info.cacheExpiryDateTime.has_value() and (id_token_info.cacheExpiryDateTime.value() < now);
+
+                if (lifetime_expired || cache_expiry_passed) {
+                    EVLOG_info << "Found valid entry in AuthCache but "
+                               << (lifetime_expired ? "lifetime expired" : "expiry date passed")
+                               << ": Removing from cache and sending new request";
                     this->database_handler->authorization_cache_delete_entry(hashed_id_token);
                     this->update_authorization_cache_size();
                 } else if (this->device_model->get_value<bool>(ControllerComponentVariables::LocalPreAuthorize) and
-                           cache_entry.value().status == AuthorizationStatusEnum::Accepted) {
+                           id_token_info.status == AuthorizationStatusEnum::Accepted) {
                     EVLOG_info << "Found valid entry in AuthCache";
                     this->database_handler->authorization_cache_update_last_used(hashed_id_token);
-                    response.idTokenInfo = cache_entry.value();
+                    response.idTokenInfo = id_token_info;
                     return response;
                 } else if (this->device_model
                                ->get_optional_value<bool>(ControllerComponentVariables::AuthCacheDisablePostAuthorize)
                                .value_or(false)) {
                     EVLOG_info << "Found invalid entry in AuthCache: Not sending new request because "
                                   "AuthCacheDisablePostAuthorize is enabled";
-                    response.idTokenInfo = cache_entry.value();
+                    response.idTokenInfo = id_token_info;
                     return response;
                 } else {
                     EVLOG_info << "Found invalid entry in AuthCache: Sending new request";

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -120,7 +120,8 @@ void DatabaseHandler::authorization_cache_update_last_used(const std::string& id
     }
 }
 
-std::optional<AuthorizationCacheEntry> DatabaseHandler::authorization_cache_get_entry(const std::string& id_token_hash) {
+std::optional<AuthorizationCacheEntry>
+DatabaseHandler::authorization_cache_get_entry(const std::string& id_token_hash) {
     std::string sql = "SELECT ID_TOKEN_INFO, LAST_USED FROM AUTH_CACHE WHERE ID_TOKEN_HASH = @id_token_hash";
     auto select_stmt = this->database->new_statement(sql);
 

--- a/lib/ocpp/v201/database_handler.cpp
+++ b/lib/ocpp/v201/database_handler.cpp
@@ -120,8 +120,8 @@ void DatabaseHandler::authorization_cache_update_last_used(const std::string& id
     }
 }
 
-std::optional<IdTokenInfo> DatabaseHandler::authorization_cache_get_entry(const std::string& id_token_hash) {
-    std::string sql = "SELECT ID_TOKEN_INFO FROM AUTH_CACHE WHERE ID_TOKEN_HASH = @id_token_hash";
+std::optional<AuthorizationCacheEntry> DatabaseHandler::authorization_cache_get_entry(const std::string& id_token_hash) {
+    std::string sql = "SELECT ID_TOKEN_INFO, LAST_USED FROM AUTH_CACHE WHERE ID_TOKEN_HASH = @id_token_hash";
     auto select_stmt = this->database->new_statement(sql);
 
     select_stmt->bind_text("@id_token_hash", id_token_hash);
@@ -133,7 +133,7 @@ std::optional<IdTokenInfo> DatabaseHandler::authorization_cache_get_entry(const 
     }
 
     if (status == SQLITE_ROW) {
-        return IdTokenInfo(json::parse(select_stmt->column_text(0)));
+        return AuthorizationCacheEntry{json::parse(select_stmt->column_text(0)), select_stmt->column_datetime(1)};
     }
 
     throw QueryExecutionException(this->database->get_error_message());


### PR DESCRIPTION
## Describe your changes

When trying to authorize a token that has passed its lifetime in the cache but is not cleaned up yet by the 15 minuted automatic clean up, it would still get accepted. This prevents that and removes it from the cache during the authorization.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

