### PR TITLE
Add critical and timestamp parameters to on_security_event functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.16.2
+    VERSION 0.17.0
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -311,11 +311,17 @@ public:
     /// be called when an EV is plugged in but the authorization is present within the specified ConnectionTimeout
     void on_plugin_timeout(int32_t connector);
 
-    // \brief Notifies chargepoint that a SecurityEvent occurs. This will send a SecurityEventNotification.req to the
+    /// \brief Notifies chargepoint that a SecurityEvent occurs. This will send a SecurityEventNotification.req to the
     /// CSMS
-    /// \param type type of the security event
+    /// \param event_type type of the security event
     /// \param tech_info additional info of the security event
-    void on_security_event(const std::string& type, const std::string& tech_info);
+    /// \param critical if set this overwrites the default criticality recommended in the OCPP 1.6 security whitepaper.
+    /// A critical security event is transmitted as a message to the CSMS, a non-critical one is just written to the
+    /// security log
+    /// \param timestamp when this security event occured, if absent the current datetime is assumed
+    void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                           const std::optional<bool>& critical = std::nullopt,
+                           const std::optional<DateTime>& timestamp = std::nullopt);
 
     /// \brief Handles an internal ChangeAvailabilityRequest (in the same way as if it was emitted by the CSMS).
     /// \param request

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -337,8 +337,9 @@ private:
     void handleInstallCertificateRequest(Call<InstallCertificateRequest> call);
     void handleGetLogRequest(Call<GetLogRequest> call);
     void handleSignedUpdateFirmware(Call<SignedUpdateFirmwareRequest> call);
-    void securityEventNotification(const std::string& type, const std::string& tech_info,
-                                   const bool triggered_internally);
+    void securityEventNotification(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                                   const bool triggered_internally, const std::optional<bool>& critical = std::nullopt,
+                                   const std::optional<DateTime>& timestamp = std::nullopt);
     void switchSecurityProfile(int32_t new_security_profile, int32_t max_connection_attempts);
     // Local Authorization List profile
     void handleSendLocalListRequest(Call<SendLocalListRequest> call);
@@ -647,9 +648,15 @@ public:
 
     /// \brief Notifies chargepoint that a SecurityEvent occurs. This will send a SecurityEventNotification.req to the
     /// CSMS
-    /// \param type type of the security event
+    /// \param event_type type of the security event
     /// \param tech_info additional info of the security event
-    void on_security_event(const std::string& type, const std::string& tech_info);
+    /// \param critical if set this overwrites the default criticality recommended in the OCPP 1.6 security whitepaper.
+    /// A critical security event is transmitted as a message to the CSMS, a non-critical one is just written to the
+    /// security log
+    /// \param timestamp when this security event occured, if absent the current datetime is assumed
+    void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                           const std::optional<bool>& critical = std::nullopt,
+                           const std::optional<DateTime>& timestamp = std::nullopt);
 
     /// \brief Handles an internal ChangeAvailabilityRequest (in the same way as if it was emitted by the CSMS).
     /// \param request

--- a/include/ocpp/v16/utils.hpp
+++ b/include/ocpp/v16/utils.hpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+#ifndef V16_UTILS_HPP
+#define V16_UTILS_HPP
 
 #include <ocpp/common/call_types.hpp>
+#include <ocpp/v16/messages/StopTransaction.hpp>
 #include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/types.hpp>
 
@@ -9,20 +12,17 @@ namespace ocpp {
 namespace v16 {
 namespace utils {
 
-size_t get_message_size(const ocpp::Call<StopTransactionRequest>& call) {
-    return json(call).at(CALL_PAYLOAD).dump().length();
-}
+size_t get_message_size(const ocpp::Call<StopTransactionRequest>& call);
 
 /// \brief Drops every second entry from transactionData as long as the message size of the \p call is greater than the
 /// \p max_message_size
-void drop_transaction_data(size_t max_message_size, ocpp::Call<StopTransactionRequest>& call) {
-    auto& transaction_data = call.msg.transactionData.value();
-    while (get_message_size(call) > max_message_size && transaction_data.size() > 2) {
-        for (size_t i = 1; i < transaction_data.size() - 1; i = i + 2) {
-            transaction_data.erase(transaction_data.begin() + i);
-        }
-    }
-}
+void drop_transaction_data(size_t max_message_size, ocpp::Call<StopTransactionRequest>& call);
+
+/// \brief Determines if a given \p security_event is critical as defined in the OCPP 1.6 security whitepaper
+bool is_critical(const std::string& security_event);
+
 } // namespace utils
 } // namespace v16
 } // namespace ocpp
+
+#endif

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -352,8 +352,10 @@ public:
     /// \param critical if set this overwrites the default criticality recommended in the OCPP 2.0.1 appendix. A
     /// critical security event is transmitted as a message to the CSMS, a non-critical one is just written to the
     /// security log
+    /// \param timestamp when this security event occured, if absent the current datetime is assumed
     virtual void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
-                                   const std::optional<bool>& critical = std::nullopt) = 0;
+                                   const std::optional<bool>& critical = std::nullopt,
+                                   const std::optional<DateTime>& timestamp = std::nullopt) = 0;
 
     /// \brief Event handler that will update the variable internally when it has been changed on the fly.
     /// \param set_variable_data contains data of the variable to set
@@ -662,7 +664,8 @@ private:
 
     // Functional Block A: Security
     void security_event_notification_req(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
-                                         const bool triggered_internally, const bool critical);
+                                         const bool triggered_internally, const bool critical,
+                                         const std::optional<DateTime>& timestamp = std::nullopt);
     void sign_certificate_req(const ocpp::CertificateSigningUseEnum& certificate_signing_use,
                               const bool initiated_by_trigger_message = false);
 
@@ -944,7 +947,8 @@ public:
     void on_log_status_notification(UploadLogStatusEnum status, int32_t requestId) override;
 
     void on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
-                           const std::optional<bool>& critical = std::nullopt) override;
+                           const std::optional<bool>& critical = std::nullopt,
+                           const std::optional<DateTime>& timestamp = std::nullopt) override;
 
     void on_variable_changed(const SetVariableData& set_variable_data) override;
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,6 +46,7 @@ if(LIBOCPP_ENABLE_V16)
             ocpp/v16/ocpp_enums.cpp
             ocpp/v16/ocpp_types.cpp
             ocpp/v16/types.cpp
+            ocpp/v16/utils.cpp
     )
     add_subdirectory(ocpp/v16/messages)
 endif()

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -172,8 +172,9 @@ void ChargePoint::on_plugin_timeout(int32_t connector) {
     this->charge_point->on_plugin_timeout(connector);
 }
 
-void ChargePoint::on_security_event(const std::string& type, const std::string& tech_info) {
-    this->charge_point->on_security_event(type, tech_info);
+void ChargePoint::on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                                    const std::optional<bool>& critical, const std::optional<DateTime>& timestamp) {
+    this->charge_point->on_security_event(event_type, tech_info, critical, timestamp);
 }
 
 ChangeAvailabilityResponse ChargePoint::on_change_availability(const ChangeAvailabilityRequest& request) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1053,16 +1053,19 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
 
     switch (bootreason) {
     case BootReasonEnum::RemoteReset:
-        this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
-                                        "Charging Station rebooted due to requested remote reset!", true);
+        this->securityEventNotification(
+            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+            std::optional<CiString<255>>("Charging Station rebooted due to requested remote reset!"), true);
         break;
     case BootReasonEnum::ScheduledReset:
-        this->securityEventNotification(CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
-                                        "Charging Station rebooted due to a scheduled reset!", true);
+        this->securityEventNotification(
+            CiString<50>(ocpp::security_events::RESET_OR_REBOOT),
+            std::optional<CiString<255>>("Charging Station rebooted due to a scheduled reset!"), true);
         break;
     case BootReasonEnum::FirmwareUpdate:
-        this->securityEventNotification(CiString<50>(ocpp::security_events::FIRMWARE_UPDATED),
-                                        "Charging Station rebooted due to firmware update!", true);
+        this->securityEventNotification(
+            CiString<50>(ocpp::security_events::FIRMWARE_UPDATED),
+            std::optional<CiString<255>>("Charging Station rebooted due to firmware update!"), true);
         break;
     case BootReasonEnum::ApplicationReset:
     case BootReasonEnum::LocalReset:
@@ -1072,7 +1075,7 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     case BootReasonEnum::Watchdog:
     default:
         this->securityEventNotification(CiString<50>(ocpp::security_events::STARTUP_OF_THE_DEVICE),
-                                        "The Charge Point has booted", true);
+                                        std::optional<CiString<255>>("The Charge Point has booted"), true);
         break;
     }
 
@@ -1310,13 +1313,15 @@ void ChargePointImpl::message_callback(const std::string& message) {
         if (json_message.is_array() && json_message.size() > MESSAGE_ID) {
             auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}, true));
             this->send(call_error);
-            this->securityEventNotification(ocpp::security_events::INVALIDMESSAGES, message, true);
+            this->securityEventNotification(ocpp::security_events::INVALIDMESSAGES,
+                                            std::optional<CiString<255>>(message), true);
         }
     } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}, true));
         this->send(call_error);
-        this->securityEventNotification(ocpp::security_events::INVALIDMESSAGES, message, true);
+        this->securityEventNotification(ocpp::security_events::INVALIDMESSAGES, std::optional<CiString<255>>(message),
+                                        true);
     }
 }
 
@@ -2565,7 +2570,8 @@ void ChargePointImpl::sign_certificate(const ocpp::CertificateSigningUseEnum& ce
         std::string gen_error =
             "Sign certificate failed due to:" +
             ocpp::conversions::generate_certificate_signing_request_status_to_string(response.status);
-        this->securityEventNotification(ocpp::security_events::CSRGENERATIONFAILED, gen_error, true);
+        this->securityEventNotification(ocpp::security_events::CSRGENERATIONFAILED,
+                                        std::optional<CiString<255>>(gen_error), true);
 
         return;
     }
@@ -2621,8 +2627,9 @@ void ChargePointImpl::handleCertificateSignedRequest(ocpp::Call<CertificateSigne
     this->send<CertificateSignedResponse>(call_result);
 
     if (response.status == CertificateSignedStatusEnumType::Rejected) {
-        this->securityEventNotification(ocpp::security_events::INVALIDCHARGEPOINTCERTIFICATE,
-                                        ocpp::conversions::install_certificate_result_to_string(result), true);
+        this->securityEventNotification(
+            ocpp::security_events::INVALIDCHARGEPOINTCERTIFICATE,
+            std::optional<CiString<255>>(ocpp::conversions::install_certificate_result_to_string(result)), true);
     }
 
     // reconnect with new certificate if valid and security profile is 3
@@ -2705,8 +2712,9 @@ void ChargePointImpl::handleInstallCertificateRequest(ocpp::Call<InstallCertific
     this->send<InstallCertificateResponse>(call_result);
 
     if (response.status == InstallCertificateStatusEnumType::Rejected) {
-        this->securityEventNotification(ocpp::security_events::INVALIDCENTRALSYSTEMCERTIFICATE,
-                                        ocpp::conversions::install_certificate_result_to_string(result), true);
+        this->securityEventNotification(
+            ocpp::security_events::INVALIDCENTRALSYSTEMCERTIFICATE,
+            std::optional<CiString<255>>(ocpp::conversions::install_certificate_result_to_string(result)), true);
     }
 }
 
@@ -2742,27 +2750,39 @@ void ChargePointImpl::handleSignedUpdateFirmware(ocpp::Call<SignedUpdateFirmware
 
     if (response.status == UpdateFirmwareStatusEnumType::InvalidCertificate) {
         this->securityEventNotification(ocpp::security_events::INVALIDFIRMWARESIGNINGCERTIFICATE,
-                                        "Certificate is invalid.", true);
+                                        std::optional<CiString<255>>("Certificate is invalid."), true);
     }
 }
 
-void ChargePointImpl::securityEventNotification(const std::string& type, const std::string& tech_info,
-                                                const bool triggered_internally) {
-
+void ChargePointImpl::securityEventNotification(const CiString<50>& event_type,
+                                                const std::optional<CiString<255>>& tech_info,
+                                                const bool triggered_internally, const std::optional<bool>& critical,
+                                                const std::optional<DateTime>& timestamp) {
     SecurityEventNotificationRequest req;
-    req.type = type;
-    req.techInfo.emplace(tech_info);
-    req.timestamp = ocpp::DateTime();
+    req.type = event_type;
+    req.techInfo = tech_info;
+    if (timestamp.has_value()) {
+        req.timestamp = timestamp.value();
+    } else {
+        req.timestamp = ocpp::DateTime();
+    }
 
     this->logging->security(json(req).dump());
 
-    if (!this->configuration->getDisableSecurityEventNotifications()) {
+    auto critical_security_event = true;
+    if (critical.has_value()) {
+        critical_security_event = critical.value();
+    } else {
+        critical_security_event = utils::is_critical(event_type);
+    }
+
+    if (critical_security_event and !this->configuration->getDisableSecurityEventNotifications()) {
         ocpp::Call<SecurityEventNotificationRequest> call(req, this->message_queue->createMessageId());
         this->send<SecurityEventNotificationRequest>(call);
     }
 
     if (triggered_internally and this->security_event_callback != nullptr) {
-        this->security_event_callback(type, tech_info);
+        this->security_event_callback(event_type.get(), tech_info.value_or(CiString<255>("")).get());
     }
 }
 
@@ -2809,7 +2829,7 @@ void ChargePointImpl::signed_firmware_update_status_notification(FirmwareStatusE
     this->send<SignedFirmwareStatusNotificationRequest>(call, initiated_by_trigger_message);
 
     if (status == FirmwareStatusEnumType::InvalidSignature) {
-        this->securityEventNotification(ocpp::security_events::INVALIDFIRMWARESIGNATURE, "", true);
+        this->securityEventNotification(ocpp::security_events::INVALIDFIRMWARESIGNATURE, std::nullopt, true);
     }
 
     if (this->firmware_update_is_pending) {
@@ -3539,7 +3559,8 @@ void ChargePointImpl::data_transfer_pnc_sign_certificate() {
 
         std::string gen_error = "Data transfer pnc csr failed due to:" +
                                 ocpp::conversions::generate_certificate_signing_request_status_to_string(result.status);
-        this->securityEventNotification(ocpp::security_events::CSRGENERATIONFAILED, gen_error, true);
+        this->securityEventNotification(ocpp::security_events::CSRGENERATIONFAILED,
+                                        std::optional<CiString<255>>(gen_error), true);
 
         return;
     }
@@ -3748,7 +3769,8 @@ void ChargePointImpl::handle_data_transfer_pnc_certificate_signed(Call<DataTrans
         this->send<DataTransferResponse>(call_result);
 
         if (certificate_response.status == CertificateSignedStatusEnumType::Rejected) {
-            this->securityEventNotification(ocpp::security_events::INVALIDCHARGEPOINTCERTIFICATE, tech_info, true);
+            this->securityEventNotification(ocpp::security_events::INVALIDCHARGEPOINTCERTIFICATE,
+                                            std::optional<CiString<255>>(tech_info), true);
         }
     } catch (const json::exception& e) {
         EVLOG_warning << "Could not parse data of DataTransfer message CertificateSigned.req: " << e.what();
@@ -4278,7 +4300,8 @@ void ChargePointImpl::on_firmware_update_status_notification(int32_t request_id,
     }
 
     if (firmware_update_status == FirmwareStatusNotification::Installed) {
-        this->securityEventNotification(ocpp::security_events::FIRMWARE_UPDATED, "Firmware update was installed", true);
+        this->securityEventNotification(ocpp::security_events::FIRMWARE_UPDATED,
+                                        std::optional<CiString<255>>("Firmware update was installed"), true);
     }
 }
 
@@ -4492,8 +4515,9 @@ void ChargePointImpl::on_plugin_timeout(int32_t connector) {
                                "ConnectionTimeout");
 }
 
-void ChargePointImpl::on_security_event(const std::string& type, const std::string& tech_info) {
-    this->securityEventNotification(type, tech_info, false);
+void ChargePointImpl::on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
+                                        const std::optional<bool>& critical, const std::optional<DateTime>& timestamp) {
+    this->securityEventNotification(event_type, tech_info, false, critical, timestamp);
 }
 
 ChangeAvailabilityResponse ChargePointImpl::on_change_availability(const ChangeAvailabilityRequest& request) {

--- a/lib/ocpp/v16/utils.cpp
+++ b/lib/ocpp/v16/utils.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/common/utils.hpp>
+#include <ocpp/v16/utils.hpp>
+
+namespace ocpp {
+namespace v16 {
+namespace utils {
+
+size_t get_message_size(const ocpp::Call<StopTransactionRequest>& call) {
+    return json(call).at(CALL_PAYLOAD).dump().length();
+}
+
+void drop_transaction_data(size_t max_message_size, ocpp::Call<StopTransactionRequest>& call) {
+    auto& transaction_data = call.msg.transactionData.value();
+    while (get_message_size(call) > max_message_size && transaction_data.size() > 2) {
+        for (size_t i = 1; i < transaction_data.size() - 1; i = i + 2) {
+            transaction_data.erase(transaction_data.begin() + i);
+        }
+    }
+}
+
+bool is_critical(const std::string& security_event) {
+    if (security_event == ocpp::security_events::FIRMWARE_UPDATED) {
+        return true;
+    } else if (security_event == ocpp::security_events::SETTINGSYSTEMTIME) {
+        return true;
+    } else if (security_event == ocpp::security_events::STARTUP_OF_THE_DEVICE) {
+        return true;
+    } else if (security_event == ocpp::security_events::RESET_OR_REBOOT) {
+        return true;
+    } else if (security_event == ocpp::security_events::SECURITYLOGWASCLEARED) {
+        return true;
+    } else if (security_event == ocpp::security_events::MEMORYEXHAUSTION) {
+        return true;
+    } else if (security_event == ocpp::security_events::TAMPERDETECTIONACTIVATED) {
+        return true;
+    }
+
+    return false;
+}
+
+} // namespace utils
+} // namespace v16
+} // namespace ocpp

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -933,14 +933,14 @@ void ChargePoint::on_log_status_notification(UploadLogStatusEnum status, int32_t
 }
 
 void ChargePoint::on_security_event(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info,
-                                    const std::optional<bool>& critical) {
+                                    const std::optional<bool>& critical, const std::optional<DateTime>& timestamp) {
     auto critical_security_event = true;
     if (critical.has_value()) {
         critical_security_event = critical.value();
     } else {
         critical_security_event = utils::is_critical(event_type);
     }
-    this->security_event_notification_req(event_type, tech_info, false, critical_security_event);
+    this->security_event_notification_req(event_type, tech_info, false, critical_security_event, timestamp);
 }
 
 void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) {
@@ -1815,12 +1815,17 @@ bool ChargePoint::is_offline() {
 
 void ChargePoint::security_event_notification_req(const CiString<50>& event_type,
                                                   const std::optional<CiString<255>>& tech_info,
-                                                  const bool triggered_internally, const bool critical) {
+                                                  const bool triggered_internally, const bool critical,
+                                                  const std::optional<DateTime>& timestamp) {
     EVLOG_debug << "Sending SecurityEventNotification";
     SecurityEventNotificationRequest req;
 
     req.type = event_type;
-    req.timestamp = DateTime().to_rfc3339();
+    if (timestamp.has_value()) {
+        req.timestamp = timestamp.value().to_rfc3339();
+    } else {
+        req.timestamp = DateTime().to_rfc3339();
+    }
     req.techInfo = tech_info;
     this->logging->security(json(req).dump());
     if (critical) {


### PR DESCRIPTION
This adds "critical" and "timestamp" parameters to the on_security_event functions for OCPP 1.6 and 2.0.1

Criticality is by default determined based on the 1.6 security whitepaper, but can be overwritten externally

By default the current datetime is used for the timestamp, but this can also be overwritten externally (for example if the event occured earlier)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

