### PR TITLE
Fix missing forward slash in URI if not filled in network profile

### DIFF
--- a/lib/ocpp/common/websocket/websocket_uri.cpp
+++ b/lib/ocpp/common/websocket/websocket_uri.cpp
@@ -86,6 +86,10 @@ Uri Uri::parse_and_validate(std::string uri, std::string chargepoint_id, int sec
         path = path_without_base;
     }
 
+    if (path.back() != '/') {
+        path.push_back('/');
+    }
+
     return Uri(uri_temp.get_secure(), uri_temp.get_host(), uri_temp.get_port(), path, chargepoint_id);
 }
 

--- a/tests/lib/ocpp/common/CMakeLists.txt
+++ b/tests/lib/ocpp/common/CMakeLists.txt
@@ -3,5 +3,6 @@ target_sources(libocpp_unit_tests PRIVATE
     test_database_migration_files.cpp
     test_database_schema_updater.cpp
     test_message_queue.cpp
+    test_websocket_uri.cpp
     utils_tests.cpp
 )

--- a/tests/lib/ocpp/common/test_websocket_uri.cpp
+++ b/tests/lib/ocpp/common/test_websocket_uri.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "ocpp/common/websocket/websocket_uri.hpp"
+
+using namespace ocpp;
+
+TEST(WebsocketUriTest, EmptyStrings) {
+    EXPECT_THROW(Uri::parse_and_validate("", "cp0001", 1), std::invalid_argument);
+    EXPECT_THROW(Uri::parse_and_validate("ws://test.uri.com", "", 1), std::invalid_argument);
+}
+
+TEST(WebsocketUriTest, UriInvalid) {
+    EXPECT_THROW(Uri::parse_and_validate("://invalid", "cp0001", 1), std::invalid_argument);
+    EXPECT_THROW(Uri::parse_and_validate("ws:test.uri.com", "cp0001", 1), std::invalid_argument);
+}
+
+TEST(WebsocketUriTest, InvalidSecurityLevel) {
+    EXPECT_THROW(Uri::parse_and_validate("wss://test.uri.com", "cp0001", 4), std::invalid_argument);
+}
+
+TEST(WebsocketUriTest, SecurityLevelMismatch) {
+    EXPECT_THROW(Uri::parse_and_validate("wss://test.uri.com", "cp0001", 0), std::invalid_argument);
+    EXPECT_THROW(Uri::parse_and_validate("wss://test.uri.com", "cp0001", 1), std::invalid_argument);
+    EXPECT_THROW(Uri::parse_and_validate("ws://test.uri.com", "cp0001", 2), std::invalid_argument);
+    EXPECT_THROW(Uri::parse_and_validate("ws://test.uri.com", "cp0001", 3), std::invalid_argument);
+}
+
+TEST(WebsocketUriTest, AppendingIdentity) {
+    EXPECT_EQ(Uri::parse_and_validate("ws://test.uri.com/path", "cp0001", 1).string(), "ws://test.uri.com/path/cp0001");
+    EXPECT_EQ(Uri::parse_and_validate("ws://test.uri.com/path/", "cp0001", 1).string(),
+              "ws://test.uri.com/path/cp0001");
+    EXPECT_EQ(Uri::parse_and_validate("ws://test.uri.com/path/cp0001", "cp0001", 1).string(),
+              "ws://test.uri.com/path/cp0001");
+}


### PR DESCRIPTION
## Describe your changes

If the slash was missing in the CSMS URL we would just append the identity without the slash. This makes sure we add the slash if needed. Also adds unit tests for this function.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

