### PR TITLE
Add optional TLS secrets logging (disabled by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.17.0
+    VERSION 0.17.1
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -300,6 +300,18 @@
             "readOnly": true,
             "minimum": 32000,
             "default": 65000
+        },
+        "TLSKeylogFile": {
+            "$comment": "The file to which the OCPP TLS keylog in SSLKEYLOGFILE format is written to.",
+            "type": "string",
+            "readOnly": true,
+            "default": "/tmp/ocpp_tls_keylog.txt"
+        },
+        "EnableTLSKeylog": {
+            "$comment": "If the TLS keylogging is enabled.",
+            "type": "boolean",
+            "readOnly": true,
+            "default": false
         }
     },
     "additionalProperties": false

--- a/config/v201/component_config/standardized/InternalCtrlr.json
+++ b/config/v201/component_config/standardized/InternalCtrlr.json
@@ -475,6 +475,36 @@
         "default": "",
         "type": "string"
       },
+      "EnableTLSKeylog": {
+        "variable_name": "EnableTLSKeylog",
+        "characteristics": {
+            "supportsMonitoring": false,
+            "dataType": "boolean"
+        },
+        "attributes": [
+            {
+                "type": "Actual",
+                "mutability": "ReadWrite"
+            }
+        ],
+        "default": false,
+        "type": "boolean"
+      },
+      "TLSKeylogFile": {
+        "variable_name": "TLSKeylogFile",
+        "characteristics": {
+            "supportsMonitoring": false,
+            "dataType": "string"
+        },
+        "attributes": [
+            {
+                "type": "Actual",
+                "mutability": "ReadOnly"
+            }
+        ],
+        "default": "/tmp/ocpp_tlskey.log",
+        "type": "string"
+      },
       "OcspRequestInterval": {
           "variable_name": "OcspRequestInterval",
           "characteristics": {

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -36,6 +36,8 @@ struct WebsocketConnectionOptions {
     bool use_tpm_tls;
     bool verify_csms_allow_wildcards;
     std::optional<std::string> iface; // Optional interface where the socket is created. Only usable for libwebsocket
+    bool enable_tls_keylog = false; ///< If set to true enables logging of TLS secrets to the keylog_file
+    std::optional<std::filesystem::path> keylog_file; ///< Optional path to a keylog file
 };
 
 ///

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -36,7 +36,7 @@ struct WebsocketConnectionOptions {
     bool use_tpm_tls;
     bool verify_csms_allow_wildcards;
     std::optional<std::string> iface; // Optional interface where the socket is created. Only usable for libwebsocket
-    bool enable_tls_keylog = false; ///< If set to true enables logging of TLS secrets to the keylog_file
+    bool enable_tls_keylog = false;   ///< If set to true enables logging of TLS secrets to the keylog_file
     std::optional<std::filesystem::path> keylog_file; ///< Optional path to a keylog file
 };
 

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -103,6 +103,9 @@ public:
     int getMaxMessageSize();
     KeyValue getMaxMessageSizeKeyValue();
 
+    bool getEnableTLSKeylog();
+    std::string getTLSKeylogFile();
+
     int32_t getRetryBackoffRandomRange();
     void setRetryBackoffRandomRange(int32_t retry_backoff_random_range);
     KeyValue getRetryBackoffRandomRangeKeyValue();

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -71,6 +71,8 @@ extern const ComponentVariable& VerifyCsmsCommonName;
 extern const ComponentVariable& UseTPM;
 extern const ComponentVariable& VerifyCsmsAllowWildcards;
 extern const ComponentVariable& IFace;
+extern const ComponentVariable& EnableTLSKeylog;
+extern const ComponentVariable& TLSKeylogFile;
 extern const ComponentVariable& OcspRequestInterval;
 extern const ComponentVariable& WebsocketPingPayload;
 extern const ComponentVariable& WebsocketPongTimeout;

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -636,6 +636,14 @@ KeyValue ChargePointConfiguration::getMaxMessageSizeKeyValue() {
     return kv;
 }
 
+bool ChargePointConfiguration::getEnableTLSKeylog() {
+    return this->config["Internal"]["EnableTLSKeylog"];
+}
+
+std::string ChargePointConfiguration::getTLSKeylogFile() {
+    return this->config["Internal"]["TLSKeylogFile"];
+}
+
 KeyValue ChargePointConfiguration::getWebsocketPingPayloadKeyValue() {
     KeyValue kv;
     kv.key = "WebsocketPingPayload";

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -362,7 +362,9 @@ WebsocketConnectionOptions ChargePointImpl::get_ws_connection_options() {
                                                   this->configuration->getVerifyCsmsCommonName(),
                                                   this->configuration->getUseTPM(),
                                                   this->configuration->getVerifyCsmsAllowWildcards(),
-                                                  this->configuration->getIFace()};
+                                                  this->configuration->getIFace(),
+                                                  this->configuration->getEnableTLSKeylog(),
+                                                  this->configuration->getTLSKeylogFile()};
     return connection_options;
 }
 

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -241,7 +241,9 @@ WebsocketConnectionOptions ConnectivityManager::get_ws_connection_options(const 
         this->device_model.get_optional_value<bool>(ControllerComponentVariables::UseTPM).value_or(false),
         this->device_model.get_optional_value<bool>(ControllerComponentVariables::VerifyCsmsAllowWildcards)
             .value_or(false),
-        this->device_model.get_optional_value<std::string>(ControllerComponentVariables::IFace)};
+        this->device_model.get_optional_value<std::string>(ControllerComponentVariables::IFace),
+        this->device_model.get_optional_value<bool>(ControllerComponentVariables::EnableTLSKeylog).value_or(false),
+        this->device_model.get_optional_value<std::string>(ControllerComponentVariables::TLSKeylogFile)};
 
     return connection_options;
 }

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -254,6 +254,20 @@ const ComponentVariable& IFace = {
         "IFace",
     }),
 };
+const ComponentVariable& EnableTLSKeylog = {
+    ControllerComponents::InternalCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "EnableTLSKeylog",
+    }),
+};
+const ComponentVariable& TLSKeylogFile = {
+    ControllerComponents::InternalCtrlr,
+    std::nullopt,
+    std::optional<Variable>({
+        "TLSKeylogFile",
+    }),
+};
 const ComponentVariable& OcspRequestInterval = {
     ControllerComponents::InternalCtrlr,
     std::nullopt,


### PR DESCRIPTION
## Describe your changes
   
If enabled this logs the TLS secrets used in security profile 2 and 3 to a configurable file in SSLKEYLOGFILE format which can be read by wireshark

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

