### PR TITLE
Uri: fix schema reporting

### DIFF
--- a/lib/ocpp/common/websocket/websocket_uri.cpp
+++ b/lib/ocpp/common/websocket/websocket_uri.cpp
@@ -60,16 +60,16 @@ Uri Uri::parse_and_validate(std::string uri, std::string chargepoint_id, int sec
         case security::SecurityProfile::UNSECURED_TRANSPORT_WITH_BASIC_AUTHENTICATION:
             if (uri_temp.get_secure()) {
                 throw std::invalid_argument(
-                    "secure schema 'ws://' in URI does not fit with insecure security-profile = " +
-                    std::to_string(security_profile));
+                    "secure schema '" + uri_temp.get_scheme() +
+                    "://' in URI does not fit with insecure security-profile = " + std::to_string(security_profile));
             }
             break;
         case security::SecurityProfile::TLS_WITH_BASIC_AUTHENTICATION:
         case security::SecurityProfile::TLS_WITH_CLIENT_SIDE_CERTIFICATES:
             if (!uri_temp.get_secure()) {
                 throw std::invalid_argument(
-                    "insecure schema 'ws://' in URI does not fit with secure security-profile = " +
-                    std::to_string(security_profile));
+                    "insecure schema '" + uri_temp.get_scheme() +
+                    "://' in URI does not fit with secure security-profile = " + std::to_string(security_profile));
             }
             break;
         default:


### PR DESCRIPTION
"ws://" was being reported as secure.

Use `get_scheme()` to also correctly report the supported (legacy) "http(s)" URIs.

## Describe your changes

Replace the typo `ws://` with the actual schema from `get_scheme()`. Also make this change for the correct use of `ws://`, to allow for potential legacy `http://`.

## Issue ticket number and link

https://github.com/EVerest/libocpp/issues/697

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

