### PR TITLE
Remote start and stop could fail in core, we should be able to report that

### DIFF
--- a/include/ocpp/v201/charge_point_callbacks.hpp
+++ b/include/ocpp/v201/charge_point_callbacks.hpp
@@ -33,7 +33,8 @@ struct Callbacks {
     std::function<bool(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
         is_reset_allowed_callback;
     std::function<void(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)> reset_callback;
-    std::function<void(const int32_t evse_id, const ReasonEnum& stop_reason)> stop_transaction_callback;
+    std::function<RequestStartStopStatusEnum(const int32_t evse_id, const ReasonEnum& stop_reason)>
+        stop_transaction_callback;
     std::function<void(const int32_t evse_id)> pause_charging_callback;
 
     /// \brief Used to notify the user of libocpp that the Operative/Inoperative state of the charging station changed
@@ -65,7 +66,8 @@ struct Callbacks {
     std::function<UnlockConnectorResponse(const int32_t evse_id, const int32_t connecor_id)> unlock_connector_callback;
     // callback to be called when the request can be accepted. authorize_remote_start indicates if Authorize.req needs
     // to follow or not
-    std::function<void(const RequestStartTransactionRequest& request, const bool authorize_remote_start)>
+    std::function<RequestStartStopStatusEnum(const RequestStartTransactionRequest& request,
+                                             const bool authorize_remote_start)>
         remote_start_transaction_callback;
     ///
     /// \brief Check if the current reservation for the given evse id is made for the id token / group id token.

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3164,14 +3164,13 @@ void ChargePoint::handle_remote_start_transaction_request(Call<RequestStartTrans
         EVLOG_warning << "No evse id given. Can not remote start transaction.";
     }
 
-    const ocpp::CallResult<RequestStartTransactionResponse> call_result(response, call.uniqueId);
-    this->send<RequestStartTransactionResponse>(call_result);
-
     if (response.status == RequestStartStopStatusEnum::Accepted) {
-        // F01.FR.01 and F01.FR.02
-        this->callbacks.remote_start_transaction_callback(
+        response.status = this->callbacks.remote_start_transaction_callback(
             msg, this->device_model->get_value<bool>(ControllerComponentVariables::AuthorizeRemoteStart));
     }
+
+    const ocpp::CallResult<RequestStartTransactionResponse> call_result(response, call.uniqueId);
+    this->send<RequestStartTransactionResponse>(call_result);
 }
 
 void ChargePoint::handle_remote_stop_transaction_request(Call<RequestStopTransactionRequest> call) {
@@ -3188,12 +3187,12 @@ void ChargePoint::handle_remote_stop_transaction_request(Call<RequestStopTransac
         response.status = RequestStartStopStatusEnum::Rejected;
     }
 
+    if (response.status == RequestStartStopStatusEnum::Accepted) {
+        response.status = this->callbacks.stop_transaction_callback(evseid.value(), ReasonEnum::Remote);
+    }
+
     const ocpp::CallResult<RequestStopTransactionResponse> call_result(response, call.uniqueId);
     this->send<RequestStopTransactionResponse>(call_result);
-
-    if (response.status == RequestStartStopStatusEnum::Accepted) {
-        this->callbacks.stop_transaction_callback(evseid.value(), ReasonEnum::Remote);
-    }
 }
 
 void ChargePoint::handle_change_availability_req(Call<ChangeAvailabilityRequest> call) {

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -257,7 +257,8 @@ public:
         is_reset_allowed_callback_mock;
     testing::MockFunction<void(const std::optional<const int32_t> evse_id, const ResetEnum& reset_type)>
         reset_callback_mock;
-    testing::MockFunction<void(const int32_t evse_id, const ReasonEnum& stop_reason)> stop_transaction_callback_mock;
+    testing::MockFunction<RequestStartStopStatusEnum(const int32_t evse_id, const ReasonEnum& stop_reason)>
+        stop_transaction_callback_mock;
     testing::MockFunction<void(const int32_t evse_id)> pause_charging_callback_mock;
     testing::MockFunction<void(const int32_t evse_id, const int32_t connector_id,
                                const OperationalStatusEnum new_status)>
@@ -265,7 +266,8 @@ public:
     testing::MockFunction<GetLogResponse(const GetLogRequest& request)> get_log_request_callback_mock;
     testing::MockFunction<UnlockConnectorResponse(const int32_t evse_id, const int32_t connecor_id)>
         unlock_connector_callback_mock;
-    testing::MockFunction<void(const RequestStartTransactionRequest& request, const bool authorize_remote_start)>
+    testing::MockFunction<RequestStartStopStatusEnum(const RequestStartTransactionRequest& request,
+                                                     const bool authorize_remote_start)>
         remote_start_transaction_callback_mock;
     testing::MockFunction<bool(const int32_t evse_id, const CiString<36> idToken,
                                const std::optional<CiString<36>> groupIdToken)>


### PR DESCRIPTION
## Describe your changes
Our implementation could result in a failure to start or stop and there was no option to report that to the CSMS. With this change we force the core to provide a result. It will still only get called if libocpp thinks it is accepted.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

