### PR TITLE
Removed call to validate_profile within get_valid_profiles_for_evse

### DIFF
--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -463,9 +463,7 @@ std::vector<ChargingProfile> SmartChargingHandler::get_valid_profiles_for_evse(i
 
     auto evse_profiles = this->database_handler->get_charging_profiles_for_evse(evse_id);
     for (auto profile : evse_profiles) {
-        if (this->validate_profile(profile, evse_id) == ProfileValidationResultEnum::Valid) {
-            valid_profiles.push_back(profile);
-        }
+        valid_profiles.push_back(profile);
     }
 
     return valid_profiles;

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -1608,26 +1608,6 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
     EXPECT_THAT(profiles.size(), testing::Eq(1));
 }
 
-TEST_F(SmartChargingHandlerTestFixtureV201, K08_GetValidProfiles_IfInvalidProfileExists_ThenThatProfileIsNotReturned) {
-    auto extraneous_start_schedule = ocpp::DateTime("2024-01-17T17:00:00");
-    auto periods = create_charging_schedule_periods(0);
-    auto invalid_profile =
-        create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
-                                create_charge_schedule(ChargingRateUnitEnum::A, periods, extraneous_start_schedule),
-                                DEFAULT_TX_ID, ChargingProfileKindEnum::Relative, 1);
-    handler.add_profile(invalid_profile, DEFAULT_EVSE_ID);
-
-    auto invalid_station_wide_profile =
-        create_charging_profile(DEFAULT_PROFILE_ID + 1, ChargingProfilePurposeEnum::TxProfile,
-                                create_charge_schedule(ChargingRateUnitEnum::A, periods, extraneous_start_schedule),
-                                DEFAULT_TX_ID, ChargingProfileKindEnum::Relative, 1);
-    handler.add_profile(invalid_station_wide_profile, STATION_WIDE_ID);
-
-    auto profiles = handler.get_valid_profiles(DEFAULT_EVSE_ID);
-    EXPECT_THAT(profiles, testing::Not(testing::Contains(invalid_profile)));
-    EXPECT_THAT(profiles, testing::Not(testing::Contains(invalid_station_wide_profile)));
-}
-
 TEST_F(SmartChargingHandlerTestFixtureV201, K02FR05_SmartChargingTransactionEnds_DeletesTxProfilesByTransactionId) {
     auto transaction_id = uuid();
     EVLOG_debug << "TRANSACTION ID: " << transaction_id;


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/819

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

