### PR TITLE
Bugfix: revert renaming of nlohmann json validator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.17.1
+    VERSION 0.17.2
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -3,7 +3,7 @@ nlohmann_json:
   git: https://github.com/nlohmann/json
   git_tag: v3.11.2
   options: ["JSON_BuildTests OFF", "JSON_MultipleHeaders ON"]
-pboettch_json_schema_validator:
+nlohmann_json_schema_validator:
   git: https://github.com/pboettch/json-schema-validator
   git_tag: 2.3.0
   options:


### PR DESCRIPTION
## Describe your changes
While it's technically the json-schema-validator released by pboettch, it does live in the "nlohmann" namespace and is used under that alias throughout the project

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

