### PR TITLE
Restore increased size of Get15118EVCertificate.exiResponse

### DIFF
--- a/config/v201/component_config/standardized/OCPPCommCtrlr.json
+++ b/config/v201/component_config/standardized/OCPPCommCtrlr.json
@@ -339,6 +339,7 @@
           "mutability": "ReadOnly"
         }
       ],
+      "instance": "Get15118EVCertificateResponse.exiResponse",
       "description": "This variable is used to report the length of <field> in <message> when it is larger than the length that is defined in the standard OCPP message schema.",
       "type": "integer"
     }

--- a/include/ocpp/common/constants.hpp
+++ b/include/ocpp/common/constants.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
 
+#pragma once
+
 #include <cstdint>
 
 namespace ocpp {

--- a/include/ocpp/v201/constants.hpp
+++ b/include/ocpp/v201/constants.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <cstddef>
+
+namespace ocpp {
+namespace v201 {
+
+/// \brief OCPP 2.0.1 defines this as 5600 but it can be set to a higher value, which we do here, if it's reported via
+/// the device model, which we do as well
+constexpr std::size_t ISO15118_GET_EV_CERTIFICATE_EXI_RESPONSE_SIZE = 7500;
+
+} // namespace v201
+} // namespace ocpp

--- a/include/ocpp/v201/messages/Get15118EVCertificate.hpp
+++ b/include/ocpp/v201/messages/Get15118EVCertificate.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include <ocpp/common/types.hpp>
+#include <ocpp/v201/constants.hpp>
 #include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 
@@ -40,7 +41,7 @@ std::ostream& operator<<(std::ostream& os, const Get15118EVCertificateRequest& k
 /// \brief Contains a OCPP Get15118EVCertificateResponse message
 struct Get15118EVCertificateResponse : public ocpp::Message {
     Iso15118EVCertificateStatusEnum status;
-    CiString<5600> exiResponse;
+    CiString<ISO15118_GET_EV_CERTIFICATE_EXI_RESPONSE_SIZE> exiResponse;
     std::optional<CustomData> customData;
     std::optional<StatusInfo> statusInfo;
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1187,6 +1187,13 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
         this->connectivity_manager->set_configure_network_connection_profile_callback(
             this->callbacks.configure_network_connection_profile_callback.value());
     }
+
+    Component ocpp_comm_ctrlr = {"OCPPCommCtrlr"};
+    Variable field_length = {"FieldLength"};
+    field_length.instance = "Get15118EVCertificateResponse.exiResponse";
+    this->device_model->set_value(ocpp_comm_ctrlr, field_length, AttributeEnum::Actual,
+                                  std::to_string(ISO15118_GET_EV_CERTIFICATE_EXI_RESPONSE_SIZE),
+                                  VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL, true);
 }
 
 void ChargePoint::init_certificate_expiration_check_timers() {

--- a/src/code_generator/common/generate_cpp.py
+++ b/src/code_generator/common/generate_cpp.py
@@ -266,6 +266,8 @@ def parse_property(prop_name: str, prop: Dict, depends_on: List[str], ob_name=No
         else:
             if 'maxLength' in prop:
                 prop_type = 'CiString<{}>'.format(prop['maxLength'])
+                if ob_name == 'Get15118EVCertificateResponse' and prop_name == 'exiResponse':
+                    prop_type = 'CiString<ISO15118_GET_EV_CERTIFICATE_EXI_RESPONSE_SIZE>'
             else:
                 if 'format' in prop:
                     if prop['format'] in format_types:
@@ -406,6 +408,7 @@ def parse_schemas(version: str, schema_dir: Path = Path('schemas/json/'),
         message_uses_optional = False
         message_needs_enums = False
         message_needs_types = False
+        message_needs_constants = False
 
         for (type_name, type_key) in (('Request', 'req'), ('Response', 'res')):
             parsed_types.clear()
@@ -445,6 +448,8 @@ def parse_schemas(version: str, schema_dir: Path = Path('schemas/json/'),
                 message_needs_enums = needs_enums(sorted_types)
             if not message_needs_types:
                 message_needs_types = needs_types(sorted_types)
+            if action == 'Get15118EVCertificate':
+                message_needs_constants = True
 
         for (type_name, type_key) in (('Request', 'req'), ('Response', 'res')):
             parsed_types.clear()
@@ -484,6 +489,7 @@ def parse_schemas(version: str, schema_dir: Path = Path('schemas/json/'),
                     'uses_optional': message_uses_optional,
                     'needs_enums': message_needs_enums,
                     'needs_types': message_needs_types,
+                    'needs_constants': message_needs_constants,
                     'action': {
                         'name': action,
                         'class_name': action_class_name,

--- a/src/code_generator/common/templates/message.hpp.jinja
+++ b/src/code_generator/common/templates/message.hpp.jinja
@@ -11,6 +11,9 @@
 {% endif %}
 #include <nlohmann/json_fwd.hpp>
 
+{% if needs_constants %}
+#include <ocpp/{{namespace}}/constants.hpp>
+{% endif %}
 {% if needs_enums %}
 #include <ocpp/{{namespace}}/ocpp_enums.hpp>
 {% endif %}


### PR DESCRIPTION
Report this increased value via the device model as suggested in 1.16.2 of the OCPP 2.0.1 spec

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

