### PR TITLE
Various code generator fixes

### DIFF
--- a/include/ocpp/v16/ocpp_types.hpp
+++ b/include/ocpp/v16/ocpp_types.hpp
@@ -180,9 +180,9 @@ std::ostream& operator<<(std::ostream& os, const LocalAuthorizationList& k);
 
 struct FirmwareType {
     CiString<512> location;
+    ocpp::DateTime retrieveDateTime;
     CiString<5500> signingCertificate;
     CiString<800> signature;
-    std::optional<ocpp::DateTime> retrieveDateTime;
     std::optional<ocpp::DateTime> installDateTime;
 };
 /// \brief Conversion from a given FirmwareType \p k to a given json object \p j

--- a/lib/ocpp/v16/ocpp_types.cpp
+++ b/lib/ocpp/v16/ocpp_types.cpp
@@ -406,13 +406,11 @@ void to_json(json& j, const FirmwareType& k) {
     // the required parts of the message
     j = json{
         {"location", k.location},
+        {"retrieveDateTime", k.retrieveDateTime.to_rfc3339()},
         {"signingCertificate", k.signingCertificate},
         {"signature", k.signature},
     };
     // the optional parts of the message
-    if (k.retrieveDateTime) {
-        j["retrieveDateTime"] = k.retrieveDateTime.value().to_rfc3339();
-    }
     if (k.installDateTime) {
         j["installDateTime"] = k.installDateTime.value().to_rfc3339();
     }
@@ -422,13 +420,11 @@ void to_json(json& j, const FirmwareType& k) {
 void from_json(const json& j, FirmwareType& k) {
     // the required parts of the message
     k.location = j.at("location");
+    k.retrieveDateTime = ocpp::DateTime(std::string(j.at("retrieveDateTime")));
     k.signingCertificate = j.at("signingCertificate");
     k.signature = j.at("signature");
 
     // the optional parts of the message
-    if (j.contains("retrieveDateTime")) {
-        k.retrieveDateTime.emplace(j.at("retrieveDateTime").get<std::string>());
-    }
     if (j.contains("installDateTime")) {
         k.installDateTime.emplace(j.at("installDateTime").get<std::string>());
     }

--- a/lib/ocpp/v16/ocpp_types.cpp
+++ b/lib/ocpp/v16/ocpp_types.cpp
@@ -301,7 +301,6 @@ void to_json(json& j, const MeterValue& k) {
 void from_json(const json& j, MeterValue& k) {
     // the required parts of the message
     k.timestamp = ocpp::DateTime(std::string(j.at("timestamp")));
-    ;
     for (auto val : j.at("sampledValue")) {
         k.sampledValue.push_back(val);
     }
@@ -456,7 +455,6 @@ void to_json(json& j, const TransactionData& k) {
 void from_json(const json& j, TransactionData& k) {
     // the required parts of the message
     k.timestamp = ocpp::DateTime(std::string(j.at("timestamp")));
-    ;
     for (auto val : j.at("sampledValue")) {
         k.sampledValue.push_back(val);
     }

--- a/lib/ocpp/v201/ocpp_types.cpp
+++ b/lib/ocpp/v201/ocpp_types.cpp
@@ -1866,7 +1866,6 @@ void from_json(const json& j, VariableAttribute& k) {
     if (j.contains("type")) {
         k.type.emplace(conversions::string_to_attribute_enum(j.at("type")));
     }
-
     if (j.contains("value")) {
         const json& value = j.at("value");
         if (value.is_string()) {
@@ -1886,7 +1885,6 @@ void from_json(const json& j, VariableAttribute& k) {
             k.value = value.dump();
         }
     }
-
     if (j.contains("mutability")) {
         k.mutability.emplace(conversions::string_to_mutability_enum(j.at("mutability")));
     }

--- a/lib/ocpp/v201/ocpp_types.cpp
+++ b/lib/ocpp/v201/ocpp_types.cpp
@@ -677,7 +677,6 @@ void from_json(const json& j, CompositeSchedule& k) {
     k.evseId = j.at("evseId");
     k.duration = j.at("duration");
     k.scheduleStart = ocpp::DateTime(std::string(j.at("scheduleStart")));
-    ;
     k.chargingRateUnit = conversions::string_to_charging_rate_unit_enum(j.at("chargingRateUnit"));
 
     // the optional parts of the message
@@ -1146,7 +1145,6 @@ void from_json(const json& j, MeterValue& k) {
         k.sampledValue.push_back(val);
     }
     k.timestamp = ocpp::DateTime(std::string(j.at("timestamp")));
-    ;
 
     // the optional parts of the message
     if (j.contains("customData")) {
@@ -1718,7 +1716,6 @@ void from_json(const json& j, EventData& k) {
     // the required parts of the message
     k.eventId = j.at("eventId");
     k.timestamp = ocpp::DateTime(std::string(j.at("timestamp")));
-    ;
     k.trigger = conversions::string_to_event_trigger_enum(j.at("trigger"));
     k.actualValue = j.at("actualValue");
     k.component = j.at("component");
@@ -2524,7 +2521,6 @@ void from_json(const json& j, Firmware& k) {
     // the required parts of the message
     k.location = j.at("location");
     k.retrieveDateTime = ocpp::DateTime(std::string(j.at("retrieveDateTime")));
-    ;
 
     // the optional parts of the message
     if (j.contains("customData")) {

--- a/src/code_generator/common/generate_cpp.py
+++ b/src/code_generator/common/generate_cpp.py
@@ -190,8 +190,6 @@ enum_types['ExtendedTriggerMessageRequest'] = dict()
 enum_types['ExtendedTriggerMessageRequest']['requestedMessage'] = 'MessageTriggerEnumType'
 enum_types['ExtendedTriggerMessageResponse'] = dict()
 enum_types['ExtendedTriggerMessageResponse']['status'] = 'TriggerMessageStatusEnumType'
-enum_types['SecurityEventNotificationRequest'] = dict()
-enum_types['SecurityEventNotificationRequest']['type'] = 'SecurityEvent'
 
 
 def object_exists(name: str) -> bool:

--- a/src/code_generator/common/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.cpp.jinja
@@ -131,7 +131,27 @@ j["{{property.name}}"] = k.{{property.name}}.value();
         {%- if property.type == 'ocpp::DateTime' %}
             k.{{property.name}}.emplace(j.at("{{property.name}}").get<std::string>());
         {%- else %}
+{% if type.name == "VariableAttribute" and property.name == "value"%}
+        const json& value = j.at("value");
+        if (value.is_string()) {
+            k.value = value;
+        } else if (value.is_boolean()) {
+            if (value.get<bool>()) {
+                // Convert to lower case if that is not the case currently.
+                k.value = "true";
+            } else {
+                // Convert to lower case if that is not the case currently.
+                k.value = "false";
+            }
+        } else if (value.is_array() || value.is_object()) {
+            // Maybe this is correct and is just a string (json value string), so just return the string.
+            k.value = value.dump();
+        } else {
+            k.value = value.dump();
+        }
+{% else %}
             k.{{property.name}}.emplace(j.at("{{property.name}}"));
+{% endif %}
         {%- endif %}
 {% endif %}
 {% endif %}

--- a/src/code_generator/common/templates/ocpp_types.cpp.jinja
+++ b/src/code_generator/common/templates/ocpp_types.cpp.jinja
@@ -100,7 +100,7 @@ j["{{property.name}}"] = k.{{property.name}}.value();
  conversions::string_to_{{- property.type | snake_case}}(j.at("{{property.name}}"))
     {%- else %}
         {%- if property.type == 'ocpp::DateTime' %}
- ocpp::DateTime(std::string(j.at("{{property.name}}")));
+ ocpp::DateTime(std::string(j.at("{{property.name}}")))
         {%- else %}
  j.at("{{property.name}}")
         {%- endif %}


### PR DESCRIPTION
## Describe your changes

1. Fix code generator to include manual fixes for 2.0.1 VariableAttribute
These fixes were manually applied, this PR includes them in den code generator so they are not lost in subsequent updates
2. Fix code generator to remove superfluous ; after DateTime conversions
3. Remove SecurityEvent enum from code generator since it is no enum anymore
4. 1.6: retrieveDateTime in SignedUpdateFirmware.firmware is not optional

## Issue ticket number and link
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

