### PR TITLE
Reintroduce constructor which constructs the message queue

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -769,6 +769,28 @@ public:
                 const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
                 const Callbacks& callbacks);
 
+    /// \brief Construct a new ChargePoint object
+    /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The
+    /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
+    /// the EVSEs have to increment starting with 1.
+    /// \param device_model_storage_address address to device model storage (e.g. location of SQLite database)
+    /// \param initialize_device_model  Set to true to initialize the device model database
+    /// \param device_model_migration_path  Path to the device model database migration files
+    /// \param device_model_config_path    Path to the device model config
+    /// \param ocpp_main_path Path where utility files for OCPP are read and written to
+    /// \param core_database_path Path to directory where core database is located
+    /// \param message_log_path Path to where logfiles are written to
+    /// \param evse_security Pointer to evse_security that manages security related operations; if nullptr
+    /// security_configuration must be set
+    /// \param callbacks Callbacks that will be registered for ChargePoint
+    ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                const std::string& device_model_storage_address, const bool initialize_device_model,
+                const std::string& device_model_migration_path, const std::string& device_model_config_path,
+                const std::string& ocpp_main_path, const std::string& core_database_path,
+                const std::string& sql_init_path, const std::string& message_log_path,
+                const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
+
+
     ~ChargePoint();
 
     void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp) override;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -742,7 +742,7 @@ public:
     /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The
     /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
     /// the EVSEs have to increment starting with 1.
-    /// \param device_model_storage device model storage instance
+    /// \param device_model device model instance
     /// \param database_handler database handler instance
     /// \param message_queue message queue instance
     /// \param message_log_path Path to where logfiles are written to
@@ -752,6 +752,22 @@ public:
                 std::shared_ptr<DatabaseHandler> database_handler,
                 std::shared_ptr<MessageQueue<v201::MessageType>> message_queue, const std::string& message_log_path,
                 const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
+
+    /// \brief Construct a new ChargePoint object
+    /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The
+    /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
+    /// the EVSEs have to increment starting with 1.
+    /// \param device_model_storage device model storage instance
+    /// \param ocpp_main_path Path where utility files for OCPP are read and written to
+    /// \param core_database_path Path to directory where core database is located
+    /// \param message_log_path Path to where logfiles are written to
+    /// \param evse_security Pointer to evse_security that manages security related operations
+    /// \param callbacks Callbacks that will be registered for ChargePoint
+    ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                std::unique_ptr<DeviceModelStorage> device_model_storage, const std::string& ocpp_main_path,
+                const std::string& core_database_path, const std::string& sql_init_path,
+                const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                const Callbacks& callbacks);
 
     ~ChargePoint();
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -790,7 +790,6 @@ public:
                 const std::string& sql_init_path, const std::string& message_log_path,
                 const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
 
-
     ~ChargePoint();
 
     void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp) override;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -119,6 +119,18 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
         this->database_handler);
 }
 
+ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                         const std::string& device_model_storage_address, const bool initialize_device_model,
+                         const std::string& device_model_migration_path, const std::string& device_model_config_path,
+                         const std::string& ocpp_main_path, const std::string& core_database_path,
+                         const std::string& sql_init_path, const std::string& message_log_path,
+                         const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks) :
+    ChargePoint(evse_connector_structure,
+                std::make_unique<DeviceModelStorageSqlite>(device_model_storage_address, device_model_migration_path,
+                                                           device_model_config_path, initialize_device_model),
+                ocpp_main_path, core_database_path, sql_init_path, message_log_path, evse_security, callbacks) {
+}
+
 ChargePoint::~ChargePoint() {
     {
         std::scoped_lock lk(this->auth_cache_cleanup_mutex);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -77,6 +77,50 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
     initialize(evse_connector_structure, message_log_path);
 }
 
+ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
+                         std::unique_ptr<DeviceModelStorage> device_model_storage, const std::string& ocpp_main_path,
+                         const std::string& core_database_path, const std::string& sql_init_path,
+                         const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                         const Callbacks& callbacks) :
+    ChargePoint(
+        evse_connector_structure, std::make_shared<DeviceModel>(std::move(device_model_storage)),
+        std::make_shared<DatabaseHandler>(
+            std::make_unique<common::DatabaseConnection>(fs::path(core_database_path) / "cp.db"), sql_init_path),
+        nullptr /* message_queue initialized in this constructor */, message_log_path, evse_security, callbacks)
+{
+
+    std::set<v201::MessageType> message_types_discard_for_queueing;
+    try {
+        const auto message_types_discard_for_queueing_csl = ocpp::split_string(
+            this->device_model
+                ->get_optional_value<std::string>(ControllerComponentVariables::MessageTypesDiscardForQueueing)
+                .value_or(""),
+            ',');
+        std::transform(message_types_discard_for_queueing_csl.begin(), message_types_discard_for_queueing_csl.end(),
+                       std::inserter(message_types_discard_for_queueing, message_types_discard_for_queueing.end()),
+                       [](const std::string element) { return conversions::string_to_messagetype(element); });
+    } catch (const StringToEnumException& e) {
+        EVLOG_warning << "Could not convert configured MessageType value of MessageTypesDiscardForQueueing. Please "
+                         "check you configuration: "
+                      << e.what();
+    } catch (...) {
+        EVLOG_warning << "Could not apply MessageTypesDiscardForQueueing configuration";
+    }
+
+    this->message_queue = std::make_unique<ocpp::MessageQueue<v201::MessageType>>(
+        [this](json message) -> bool { return this->connectivity_manager->send_to_websocket(message.dump()); },
+        MessageQueueConfig<v201::MessageType>{
+            this->device_model->get_value<int>(ControllerComponentVariables::MessageAttempts),
+            this->device_model->get_value<int>(ControllerComponentVariables::MessageAttemptInterval),
+            this->device_model->get_optional_value<int>(ControllerComponentVariables::MessageQueueSizeThreshold)
+                .value_or(DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD),
+            this->device_model->get_optional_value<bool>(ControllerComponentVariables::QueueAllMessages)
+                .value_or(false),
+            message_types_discard_for_queueing,
+            this->device_model->get_value<int>(ControllerComponentVariables::MessageTimeout)},
+        this->database_handler);
+}
+
 ChargePoint::~ChargePoint() {
     {
         std::scoped_lock lk(this->auth_cache_cleanup_mutex);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -86,9 +86,7 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
         evse_connector_structure, std::make_shared<DeviceModel>(std::move(device_model_storage)),
         std::make_shared<DatabaseHandler>(
             std::make_unique<common::DatabaseConnection>(fs::path(core_database_path) / "cp.db"), sql_init_path),
-        nullptr /* message_queue initialized in this constructor */, message_log_path, evse_security, callbacks)
-{
-
+        nullptr /* message_queue initialized in this constructor */, message_log_path, evse_security, callbacks) {
     std::set<v201::MessageType> message_types_discard_for_queueing;
     try {
         const auto message_types_discard_for_queueing_csl = ocpp::split_string(


### PR DESCRIPTION
## Describe your changes

https://github.com/EVerest/libocpp/pull/789 removed most constructors and I was to early with merging it. One of the removed constructors had a lot of libocpp internal logic in it that does not make sense to move to the called of the constructor.

This reintroduces that constructor making use of the other constructor to minimize duplication.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

