### PR TITLE
K01 ChargePoint refactorings

### DIFF
--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -96,7 +96,7 @@ private:
 
     std::unique_ptr<Websocket> websocket;
     Everest::SteadyTimer websocket_timer;
-    std::unique_ptr<MessageQueue<v16::MessageType>> message_queue;
+    std::unique_ptr<MessageQueueInterface<v16::MessageType>> message_queue;
     std::map<int32_t, std::shared_ptr<Connector>> connectors;
     std::unique_ptr<SmartChargingHandler> smart_charging_handler;
     int32_t heartbeat_interval;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -327,7 +327,7 @@ private:
     std::unique_ptr<ConnectivityManager> connectivity_manager;
 
     // utility
-    std::shared_ptr<MessageQueue<v201::MessageType>> message_queue;
+    std::shared_ptr<MessageQueueInterface<v201::MessageType>> message_queue;
     std::shared_ptr<DatabaseHandler> database_handler;
 
     std::map<int32_t, AvailabilityChange> scheduled_change_availability_requests;
@@ -750,8 +750,9 @@ public:
     /// \param callbacks Callbacks that will be registered for ChargePoint
     ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure, std::shared_ptr<DeviceModel> device_model,
                 std::shared_ptr<DatabaseHandler> database_handler,
-                std::shared_ptr<MessageQueue<v201::MessageType>> message_queue, const std::string& message_log_path,
-                const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
+                std::shared_ptr<MessageQueueInterface<v201::MessageType>> message_queue,
+                const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                const Callbacks& callbacks);
 
     /// \brief Construct a new ChargePoint object
     /// \param evse_connector_structure Map that defines the structure of EVSE and connectors of the chargepoint. The

--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -104,13 +104,13 @@ public:
 class SmartChargingHandler : public SmartChargingHandlerInterface {
 private:
     EvseManagerInterface& evse_manager;
-    std::shared_ptr<DeviceModel>& device_model;
+    DeviceModel& device_model;
 
-    std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler;
+    ocpp::v201::DatabaseHandler& database_handler;
 
 public:
-    SmartChargingHandler(EvseManagerInterface& evse_manager, std::shared_ptr<DeviceModel>& device_model,
-                         std::shared_ptr<ocpp::v201::DatabaseHandler> database_handler);
+    SmartChargingHandler(EvseManagerInterface& evse_manager, DeviceModel& device_model,
+                         ocpp::v201::DatabaseHandler& database_handler);
 
     ///
     /// \brief for the given \p transaction_id removes the associated charging profile.

--- a/lib/ocpp/v16/message_queue.cpp
+++ b/lib/ocpp/v16/message_queue.cpp
@@ -42,4 +42,17 @@ template <> std::string MessageQueue<v16::MessageType>::messagetype_to_string(v1
     return v16::conversions::messagetype_to_string(m);
 }
 
+template <> bool MessageQueue<v16::MessageType>::contains_stop_transaction_message(const int32_t transaction_id) {
+    std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
+    for (const auto control_message : this->transaction_message_queue) {
+        if (control_message->messageType == v16::MessageType::StopTransaction) {
+            v16::StopTransactionRequest req = control_message->message.at(CALL_PAYLOAD);
+            if (req.transactionId == transaction_id) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 } // namespace ocpp

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1132,7 +1132,7 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
         transaction_meter_value_callback, this->callbacks.pause_charging_callback);
 
     this->smart_charging_handler =
-        std::make_shared<SmartChargingHandler>(*this->evse_manager, this->device_model, this->database_handler);
+        std::make_shared<SmartChargingHandler>(*this->evse_manager, *this->device_model, *this->database_handler);
 
     this->configure_message_logging_format(message_log_path);
     this->monitoring_updater.start_monitoring();

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -37,7 +37,7 @@ static DisplayMessage message_info_to_display_message(const MessageInfo& message
 
 ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
                          std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
-                         std::shared_ptr<MessageQueue<v201::MessageType>> message_queue,
+                         std::shared_ptr<MessageQueueInterface<v201::MessageType>> message_queue,
                          const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
                          const Callbacks& callbacks) :
     ocpp::ChargingStationBase(evse_security),

--- a/lib/ocpp/v201/message_queue.cpp
+++ b/lib/ocpp/v201/message_queue.cpp
@@ -45,4 +45,17 @@ template <> std::string MessageQueue<v201::MessageType>::messagetype_to_string(c
     return v201::conversions::messagetype_to_string(m);
 }
 
+template <> bool MessageQueue<v201::MessageType>::contains_transaction_messages(const CiString<36> transaction_id) {
+    std::lock_guard<std::recursive_mutex> lk(this->message_mutex);
+    for (const auto control_message : this->transaction_message_queue) {
+        if (control_message->messageType == v201::MessageType::TransactionEvent) {
+            v201::TransactionEventRequest req = control_message->message.at(CALL_PAYLOAD);
+            if (req.transactionInfo.transactionId == transaction_id) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 } // namespace ocpp

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -445,7 +445,7 @@ ClearChargingProfileResponse SmartChargingHandler::clear_profiles(const ClearCha
     response.status = ClearChargingProfileStatusEnum::Unknown;
 
     if (this->database_handler.clear_charging_profiles_matching_criteria(request.chargingProfileId,
-                                                                          request.chargingProfileCriteria)) {
+                                                                         request.chargingProfileCriteria)) {
         response.status = ClearChargingProfileStatusEnum::Accepted;
     }
 
@@ -485,7 +485,7 @@ std::vector<ChargingProfile> SmartChargingHandler::get_evse_specific_tx_default_
     std::vector<ChargingProfile> evse_specific_tx_default_profiles;
 
     auto stmt = this->database_handler.new_statement("SELECT PROFILE FROM CHARGING_PROFILES WHERE "
-                                                      "EVSE_ID != 0 AND CHARGING_PROFILE_PURPOSE = 'TxDefaultProfile'");
+                                                     "EVSE_ID != 0 AND CHARGING_PROFILE_PURPOSE = 'TxDefaultProfile'");
     while (stmt->step() != SQLITE_DONE) {
         ChargingProfile profile = json::parse(stmt->column_text(0));
         evse_specific_tx_default_profiles.push_back(profile);
@@ -546,7 +546,7 @@ SmartChargingHandler::verify_no_conflicting_external_constraints_id(const Chargi
     auto result = ProfileValidationResultEnum::Valid;
     auto conflicts_stmt =
         this->database_handler.new_statement("SELECT PROFILE FROM CHARGING_PROFILES WHERE ID = @profile_id AND "
-                                              "CHARGING_PROFILE_PURPOSE = 'ChargingStationExternalConstraints'");
+                                             "CHARGING_PROFILE_PURPOSE = 'ChargingStationExternalConstraints'");
 
     conflicts_stmt->bind_int("@profile_id", profile.id);
     if (conflicts_stmt->step() == SQLITE_ROW) {

--- a/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/message_queue_mock.hpp
@@ -1,0 +1,41 @@
+#include "ocpp/common/message_queue.hpp"
+
+#include "gmock/gmock.h"
+
+namespace ocpp {
+
+class MessageQueueMock : public MessageQueueInterface<v201::MessageType> {
+public:
+    MOCK_METHOD(void, start, ());
+    MOCK_METHOD(void, reset_next_message_to_send, ());
+    MOCK_METHOD(void, get_persisted_messages_from_db, (bool ignore_security_event_notifications));
+    MOCK_METHOD(void, push, (const json& message, const bool stall_until_accepted));
+    MOCK_METHOD(void, push_call_result, (const json& call_result_json, const MessageId& unique_id));
+    MOCK_METHOD(void, push, (CallError call_error));
+    MOCK_METHOD(std::future<EnhancedMessage<v201::MessageType>>, push_async_internal,
+                (std::shared_ptr<ControlMessage<v201::MessageType>> message));
+    MOCK_METHOD(EnhancedMessage<v201::MessageType>, receive, (std::string_view message));
+    MOCK_METHOD(void, reset_in_flight, ());
+    MOCK_METHOD(void, handle_call_result, (EnhancedMessage<v201::MessageType> & enhanced_message));
+    MOCK_METHOD(void, handle_timeout_or_callerror,
+                (const std::optional<EnhancedMessage<v201::MessageType>>& enhanced_message_opt));
+    MOCK_METHOD(void, stop, ());
+    MOCK_METHOD(void, pause, ());
+    MOCK_METHOD(void, resume, (std::chrono::seconds delay_on_reconnect));
+    MOCK_METHOD(void, set_registration_status_accepted, ());
+    MOCK_METHOD(bool, is_transaction_message_queue_empty, ());
+    MOCK_METHOD(bool, contains_transaction_messages, (const CiString<36> transaction_id));
+    MOCK_METHOD(bool, contains_stop_transaction_message, (const int32_t transaction_id));
+    MOCK_METHOD(void, update_transaction_message_attempts, (const int transaction_message_attempts));
+    MOCK_METHOD(void, update_transaction_message_retry_interval, (const int transaction_message_retry_interval));
+    MOCK_METHOD(void, update_message_timeout, (const int timeout));
+    MOCK_METHOD(MessageId, createMessageId, ());
+    MOCK_METHOD(void, add_stopped_transaction_id, (std::string stop_transaction_message_id, int32_t transaction_id));
+    MOCK_METHOD(void, add_meter_value_message_id,
+                (const std::string& start_transaction_message_id, const std::string& meter_value_message_id));
+    MOCK_METHOD(void, notify_start_transaction_handled,
+                (const std::string& start_transaction_message_id, const int32_t transaction_id));
+    MOCK_METHOD(v201::MessageType, string_to_messagetype, (const std::string& s));
+    MOCK_METHOD(std::string, messagetype_to_string, (v201::MessageType m));
+};
+} // namespace ocpp

--- a/tests/lib/ocpp/v201/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v201/test_composite_schedule.cpp
@@ -47,7 +47,8 @@ static const int DEFAULT_PROFILE_ID = 1;
 static const int DEFAULT_STACK_LEVEL = 1;
 static const std::string DEFAULT_TX_ID = "10c75ff7-74f5-44f5-9d01-f649f3ac7b78";
 const static std::string MIGRATION_FILES_PATH = "./resources/v201/device_model_migration_files";
-const static std::string CONFIG_PATH = "./resources/example_config/v201/component_config";
+const static std::string SCHEMAS_PATH = "./resources/example_config/v201/component_config";
+const static std::string CONFIG_PATH = "./resources/example_config/v201/config.json";
 const static std::string DEVICE_MODEL_DB_IN_MEMORY_PATH = "file::memory:?cache=shared";
 
 class TestSmartChargingHandler : public SmartChargingHandler {
@@ -165,7 +166,7 @@ protected:
 
     void create_device_model_db(const std::string& path) {
         InitDeviceModelDb db(path, MIGRATION_FILES_PATH);
-        db.initialize_database(CONFIG_PATH, true);
+        db.initialize_database(SCHEMAS_PATH, true);
     }
 
     std::shared_ptr<DeviceModel>
@@ -186,13 +187,14 @@ protected:
         return device_model;
     }
 
-    TestSmartChargingHandler create_smart_charging_handler() {
+    std::shared_ptr<DatabaseHandler> create_database_handler() {
         std::unique_ptr<common::DatabaseConnection> database_connection =
             std::make_unique<common::DatabaseConnection>(fs::path("/tmp/ocpp201") / "cp.db");
         std::shared_ptr<DatabaseHandler> database_handler =
             std::make_shared<DatabaseHandler>(std::move(database_connection), MIGRATION_FILES_LOCATION_V201);
         database_handler->open_connection();
-        return TestSmartChargingHandler(*this->evse_manager, device_model, database_handler);
+
+        return database_handler;
     }
 
     // Default values used within the tests
@@ -202,7 +204,8 @@ protected:
 
     bool ignore_no_transaction = true;
     std::shared_ptr<DeviceModel> device_model = create_device_model();
-    TestSmartChargingHandler handler = create_smart_charging_handler();
+    std::shared_ptr<DatabaseHandler> database_handler = create_database_handler();
+    TestSmartChargingHandler handler = TestSmartChargingHandler(*evse_manager, *device_model, *database_handler);
     boost::uuids::random_generator uuid_generator = boost::uuids::random_generator();
 };
 


### PR DESCRIPTION
This feature branch includes work that updates the ChargePoint constructor to take references instead of shared pointers as parameters, as well as provides a MessageQueueInterface to allow for the creation of a MessageQueueMock, which will make it possible to run tests faster as well as write and maintain tests more easily. 



## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

