### PR TITLE
Add unit parameter in composite schedule request

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -159,17 +159,22 @@ public:
                                                       const std::optional<std::string>& data);
 
     /// \brief Calculates ChargingProfiles configured by the CSMS of all connectors from now until now + given \p
-    /// duration_s
+    /// duration_s and the given \p unit
     /// \param duration_s
+    /// \param unit defaults to A
     /// \return ChargingSchedules of all connectors
-    std::map<int32_t, ChargingSchedule> get_all_composite_charging_schedules(const int32_t duration_s);
+    std::map<int32_t, ChargingSchedule>
+    get_all_composite_charging_schedules(const int32_t duration_s, const ChargingRateUnit unit = ChargingRateUnit::A);
 
     /// \brief Calculates EnhancedChargingSchedule(s) configured by the CSMS of all connectors from now until now +
-    /// given \p duration_s . EnhancedChargingSchedules contain EnhancedChargingSchedulePeriod(s) that are enhanced by
-    /// the stackLevel that was provided for the ChargingProfile
+    /// given \p duration_s and the given \p unit . EnhancedChargingSchedules contain EnhancedChargingSchedulePeriod(s)
+    /// that are enhanced by the stackLevel that was provided for the ChargingProfile
     /// \param duration_s
+    /// \param unit defaults to A
     /// \return ChargingSchedules of all connectors
-    std::map<int32_t, EnhancedChargingSchedule> get_all_enhanced_composite_charging_schedules(const int32_t duration_s);
+    std::map<int32_t, EnhancedChargingSchedule>
+    get_all_enhanced_composite_charging_schedules(const int32_t duration_s,
+                                                  const ChargingRateUnit unit = ChargingRateUnit::A);
 
     /// \brief Stores the given \p powermeter values for the given \p connector . This function can be called when a new
     /// meter value is present.

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -495,17 +495,22 @@ public:
                                                       const std::optional<std::string>& data);
 
     /// \brief Calculates ChargingProfiles configured by the CSMS of all connectors from now until now + given \p
-    /// duration_s
+    /// duration_s and  the given \p unit
     /// \param duration_s
+    /// \param unit defaults to A
     /// \return ChargingSchedules of all connectors
-    std::map<int32_t, ChargingSchedule> get_all_composite_charging_schedules(const int32_t duration_s);
+    std::map<int32_t, ChargingSchedule>
+    get_all_composite_charging_schedules(const int32_t duration_s, const ChargingRateUnit unit = ChargingRateUnit::A);
 
     /// \brief Calculates EnhancedChargingSchedule(s) configured by the CSMS of all connectors from now until now +
-    /// given \p duration_s . EnhancedChargingSchedules contain EnhancedChargingSchedulePeriod(s) that are enhanced by
-    /// the stackLevel that was provided for the ChargingProfile
+    /// given \p duration_s and the given \p unit . EnhancedChargingSchedules contain EnhancedChargingSchedulePeriod(s)
+    /// that are enhanced by the stackLevel that was provided for the ChargingProfile
     /// \param duration_s
-    /// \return ChargingSchedules of all connectors
-    std::map<int32_t, EnhancedChargingSchedule> get_all_enhanced_composite_charging_schedules(const int32_t duration_s);
+    /// \param unit
+    /// defaults to A \return ChargingSchedules of all connectors
+    std::map<int32_t, EnhancedChargingSchedule>
+    get_all_enhanced_composite_charging_schedules(const int32_t duration_s,
+                                                  const ChargingRateUnit unit = ChargingRateUnit::A);
 
     /// \brief Stores the given \p powermeter values for the given \p connector . This function can be called when a new
     /// meter value is present.

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -71,13 +71,14 @@ std::optional<DataTransferResponse> ChargePoint::data_transfer(const CiString<25
     return this->charge_point->data_transfer(vendorId, messageId, data);
 }
 
-std::map<int32_t, ChargingSchedule> ChargePoint::get_all_composite_charging_schedules(const int32_t duration_s) {
-    return this->charge_point->get_all_composite_charging_schedules(duration_s);
+std::map<int32_t, ChargingSchedule> ChargePoint::get_all_composite_charging_schedules(const int32_t duration_s,
+                                                                                      const ChargingRateUnit unit) {
+    return this->charge_point->get_all_composite_charging_schedules(duration_s, unit);
 }
 
 std::map<int32_t, EnhancedChargingSchedule>
-ChargePoint::get_all_enhanced_composite_charging_schedules(const int32_t duration_s) {
-    return this->charge_point->get_all_enhanced_composite_charging_schedules(duration_s);
+ChargePoint::get_all_enhanced_composite_charging_schedules(const int32_t duration_s, const ChargingRateUnit unit) {
+    return this->charge_point->get_all_enhanced_composite_charging_schedules(duration_s, unit);
 }
 
 void ChargePoint::on_meter_values(int32_t connector, const Measurement& measurement) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3334,7 +3334,8 @@ IdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const bool aut
     return id_tag_info;
 }
 
-std::map<int32_t, ChargingSchedule> ChargePointImpl::get_all_composite_charging_schedules(const int32_t duration_s) {
+std::map<int32_t, ChargingSchedule> ChargePointImpl::get_all_composite_charging_schedules(const int32_t duration_s,
+                                                                                          const ChargingRateUnit unit) {
 
     std::map<int32_t, ChargingSchedule> charging_schedules;
 
@@ -3346,7 +3347,7 @@ std::map<int32_t, ChargingSchedule> ChargePointImpl::get_all_composite_charging_
         const auto valid_profiles =
             this->smart_charging_handler->get_valid_profiles(start_time, end_time, connector_id);
         const auto composite_schedule = this->smart_charging_handler->calculate_composite_schedule(
-            valid_profiles, start_time, end_time, connector_id, ChargingRateUnit::A);
+            valid_profiles, start_time, end_time, connector_id, unit);
         charging_schedules[connector_id] = composite_schedule;
     }
 
@@ -3354,7 +3355,7 @@ std::map<int32_t, ChargingSchedule> ChargePointImpl::get_all_composite_charging_
 }
 
 std::map<int32_t, EnhancedChargingSchedule>
-ChargePointImpl::get_all_enhanced_composite_charging_schedules(const int32_t duration_s) {
+ChargePointImpl::get_all_enhanced_composite_charging_schedules(const int32_t duration_s, const ChargingRateUnit unit) {
 
     std::map<int32_t, EnhancedChargingSchedule> charging_schedules;
 
@@ -3366,7 +3367,7 @@ ChargePointImpl::get_all_enhanced_composite_charging_schedules(const int32_t dur
         const auto valid_profiles =
             this->smart_charging_handler->get_valid_profiles(start_time, end_time, connector_id);
         const auto composite_schedule = this->smart_charging_handler->calculate_enhanced_composite_schedule(
-            valid_profiles, start_time, end_time, connector_id, ChargingRateUnit::A);
+            valid_profiles, start_time, end_time, connector_id, unit);
         charging_schedules[connector_id] = composite_schedule;
     }
 


### PR DESCRIPTION

## Describe your changes
Added parameter ChargingRateUnit to functions to get composite schedules. This allows the user application the specify which unit to use.

For backwards compatibility, a default value of `ChargingRateUnit::A` is used for the introduced argument.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

