### PR TITLE
smart charging: updated validation to be explicit when conforming profile

### DIFF
--- a/include/ocpp/v201/smart_charging.hpp
+++ b/include/ocpp/v201/smart_charging.hpp
@@ -72,16 +72,16 @@ class SmartChargingHandlerInterface {
 public:
     virtual ~SmartChargingHandlerInterface() = default;
 
-    virtual SetChargingProfileResponse validate_and_add_profile(
+    virtual SetChargingProfileResponse conform_validate_and_add_profile(
         ChargingProfile& profile, int32_t evse_id,
         ChargingLimitSourceEnum charging_limit_source = ChargingLimitSourceEnum::CSO,
         AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
 
     virtual void delete_transaction_tx_profiles(const std::string& transaction_id) = 0;
 
-    virtual ProfileValidationResultEnum
-    validate_profile(ChargingProfile& profile, int32_t evse_id,
-                     AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
+    virtual ProfileValidationResultEnum conform_and_validate_profile(
+        ChargingProfile& profile, int32_t evse_id,
+        AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) = 0;
 
     virtual SetChargingProfileResponse
     add_profile(ChargingProfile& profile, int32_t evse_id,
@@ -121,7 +121,7 @@ public:
     /// \brief validates the given \p profile according to the specification,
     /// adding it to our stored list of profiles if valid.
     ///
-    SetChargingProfileResponse validate_and_add_profile(
+    SetChargingProfileResponse conform_validate_and_add_profile(
         ChargingProfile& profile, int32_t evse_id,
         ChargingLimitSourceEnum charging_limit_source = ChargingLimitSourceEnum::CSO,
         AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) override;
@@ -131,7 +131,7 @@ public:
     /// If a profile does not have validFrom or validTo set, we conform the values
     /// to a representation that fits the spec.
     ///
-    ProfileValidationResultEnum validate_profile(
+    ProfileValidationResultEnum conform_and_validate_profile(
         ChargingProfile& profile, int32_t evse_id,
         AddChargingProfileSource source_of_request = AddChargingProfileSource::SetChargingProfile) override;
 
@@ -181,7 +181,7 @@ protected:
     ///
     /// \brief validates the given \p profile and associated \p evse_id according to the specification
     ///
-    ProfileValidationResultEnum validate_tx_default_profile(ChargingProfile& profile, int32_t evse_id) const;
+    ProfileValidationResultEnum validate_tx_default_profile(const ChargingProfile& profile, int32_t evse_id) const;
 
     ///
     /// \brief validates the given \p profile according to the specification
@@ -216,6 +216,7 @@ private:
     std::vector<ChargingProfile> get_evse_specific_tx_default_profiles() const;
     std::vector<ChargingProfile> get_station_wide_tx_default_profiles() const;
     std::vector<ChargingProfile> get_valid_profiles_for_evse(int32_t evse_id);
+    void conform_schedule_number_phases(int32_t profile_id, ChargingSchedulePeriod& charging_schedule_period) const;
     void conform_validity_periods(ChargingProfile& profile) const;
     CurrentPhaseType get_current_phase_type(const std::optional<EvseInterface*> evse_opt) const;
 };

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3122,7 +3122,8 @@ void ChargePoint::handle_remote_start_transaction_request(Call<RequestStartTrans
                 if (charging_profile.chargingProfilePurpose == ChargingProfilePurposeEnum::TxProfile) {
 
                     const auto add_profile_response = this->smart_charging_handler->conform_validate_and_add_profile(
-                        msg.chargingProfile.value(), evse_id, ChargingLimitSourceEnum::CSO,, AddChargingProfileSource::RequestStartTransactionRequest);
+                        msg.chargingProfile.value(), evse_id, ChargingLimitSourceEnum::CSO, ,
+                        AddChargingProfileSource::RequestStartTransactionRequest);
                     if (add_profile_response.status == ChargingProfileStatusEnum::Accepted) {
                         EVLOG_debug << "Accepting SetChargingProfileRequest";
                     } else {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3122,7 +3122,7 @@ void ChargePoint::handle_remote_start_transaction_request(Call<RequestStartTrans
                 if (charging_profile.chargingProfilePurpose == ChargingProfilePurposeEnum::TxProfile) {
 
                     const auto add_profile_response = this->smart_charging_handler->conform_validate_and_add_profile(
-                        msg.chargingProfile.value(), evse_id, ChargingLimitSourceEnum::CSO, ,
+                        msg.chargingProfile.value(), evse_id, ChargingLimitSourceEnum::CSO,
                         AddChargingProfileSource::RequestStartTransactionRequest);
                     if (add_profile_response.status == ChargingProfileStatusEnum::Accepted) {
                         EVLOG_debug << "Accepting SetChargingProfileRequest";

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -3121,9 +3121,8 @@ void ChargePoint::handle_remote_start_transaction_request(Call<RequestStartTrans
 
                 if (charging_profile.chargingProfilePurpose == ChargingProfilePurposeEnum::TxProfile) {
 
-                    const auto add_profile_response = this->smart_charging_handler->validate_and_add_profile(
-                        msg.chargingProfile.value(), evse_id, ChargingLimitSourceEnum::CSO,
-                        AddChargingProfileSource::RequestStartTransactionRequest);
+                    const auto add_profile_response = this->smart_charging_handler->conform_validate_and_add_profile(
+                        msg.chargingProfile.value(), evse_id, ChargingLimitSourceEnum::CSO,, AddChargingProfileSource::RequestStartTransactionRequest);
                     if (add_profile_response.status == ChargingProfileStatusEnum::Accepted) {
                         EVLOG_debug << "Accepting SetChargingProfileRequest";
                     } else {
@@ -3367,7 +3366,7 @@ void ChargePoint::handle_set_charging_profile_req(Call<SetChargingProfileRequest
         return;
     }
 
-    response = this->smart_charging_handler->validate_and_add_profile(msg.chargingProfile, msg.evseId);
+    response = this->smart_charging_handler->conform_validate_and_add_profile(msg.chargingProfile, msg.evseId);
     if (response.status == ChargingProfileStatusEnum::Accepted) {
         EVLOG_debug << "Accepting SetChargingProfileRequest";
         this->callbacks.set_charging_profiles_callback();
@@ -4416,7 +4415,7 @@ void ChargePoint::clear_invalid_charging_profiles() {
         for (const auto& [evse_id, profiles] : evses) {
             for (auto profile : profiles) {
                 try {
-                    if (this->smart_charging_handler->validate_profile(profile, evse_id) !=
+                    if (this->smart_charging_handler->conform_and_validate_profile(profile, evse_id) !=
                         ProfileValidationResultEnum::Valid) {
                         this->database_handler->delete_charging_profile(profile.id);
                     }

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -155,13 +155,13 @@ void SmartChargingHandler::delete_transaction_tx_profiles(const std::string& tra
     this->database_handler->delete_charging_profile_by_transaction_id(transaction_id);
 }
 
-SetChargingProfileResponse SmartChargingHandler::validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
+SetChargingProfileResponse SmartChargingHandler::conform_validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
                                                                           ChargingLimitSourceEnum charging_limit_source,
                                                                           AddChargingProfileSource source_of_request) {
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatusEnum::Rejected;
 
-    auto result = this->validate_profile(profile, evse_id, source_of_request);
+    auto result = this->conform_and_validate_profile(profile, evse_id, source_of_request);
     if (result == ProfileValidationResultEnum::Valid) {
         response = this->add_profile(profile, evse_id, charging_limit_source);
     } else {
@@ -173,8 +173,9 @@ SetChargingProfileResponse SmartChargingHandler::validate_and_add_profile(Chargi
     return response;
 }
 
-ProfileValidationResultEnum SmartChargingHandler::validate_profile(ChargingProfile& profile, int32_t evse_id,
-                                                                   AddChargingProfileSource source_of_request) {
+ProfileValidationResultEnum
+SmartChargingHandler::conform_and_validate_profile(ChargingProfile& profile, int32_t evse_id,
+                                                   AddChargingProfileSource source_of_request) {
 
     auto result = ProfileValidationResultEnum::Valid;
 
@@ -256,7 +257,7 @@ ProfileValidationResultEnum SmartChargingHandler::validate_charging_station_max_
     return ProfileValidationResultEnum::Valid;
 }
 
-ProfileValidationResultEnum SmartChargingHandler::validate_tx_default_profile(ChargingProfile& profile,
+ProfileValidationResultEnum SmartChargingHandler::validate_tx_default_profile(const ChargingProfile& profile,
                                                                               int32_t evse_id) const {
     auto profiles = evse_id == 0 ? get_evse_specific_tx_default_profiles() : get_station_wide_tx_default_profiles();
 
@@ -396,10 +397,7 @@ SmartChargingHandler::validate_profile_schedules(ChargingProfile& profile,
                     return ProfileValidationResultEnum::ChargingSchedulePeriodUnsupportedNumberPhases;
                 }
 
-                // K01.FR.49
-                if (!charging_schedule_period.numberPhases.has_value()) {
-                    charging_schedule_period.numberPhases.emplace(DEFAULT_AND_MAX_NUMBER_PHASES);
-                }
+                conform_schedule_number_phases(profile.id, charging_schedule_period);
             }
         }
 
@@ -465,7 +463,7 @@ std::vector<ChargingProfile> SmartChargingHandler::get_valid_profiles_for_evse(i
 
     auto evse_profiles = this->database_handler->get_charging_profiles_for_evse(evse_id);
     for (auto profile : evse_profiles) {
-        if (this->validate_profile(profile, evse_id) == ProfileValidationResultEnum::Valid) {
+        if (this->conform_and_validate_profile(profile, evse_id) == ProfileValidationResultEnum::Valid) {
             valid_profiles.push_back(profile);
         }
     }
@@ -538,9 +536,35 @@ bool SmartChargingHandler::is_overlapping_validity_period(const ChargingProfile&
     return false;
 }
 
+/// \brief sets attributes of the given \p charging_schedule_period according to the specification.
+/// 2.11. ChargingSchedulePeriodType if absent numberPhases set to 3
+void SmartChargingHandler::conform_schedule_number_phases(int32_t profileId,
+                                                          ChargingSchedulePeriod& charging_schedule_period) const {
+    // K01.FR.49
+    if (!charging_schedule_period.numberPhases.has_value()) {
+        EVLOG_debug << "Conforming profile: " << profileId << " added number phase as "
+                    << DEFAULT_AND_MAX_NUMBER_PHASES;
+        charging_schedule_period.numberPhases.emplace(DEFAULT_AND_MAX_NUMBER_PHASES);
+    }
+}
+
+///
+/// \brief sets attributes of the given \p profile according to the specification.
+/// 2.10. ChargingProfileType validFrom if absent set to current date
+/// 2.10. ChargingProfileType validTo if absent set to max date
+///
 void SmartChargingHandler::conform_validity_periods(ChargingProfile& profile) const {
-    profile.validFrom = profile.validFrom.value_or(ocpp::DateTime());
-    profile.validTo = profile.validTo.value_or(ocpp::DateTime(date::utc_clock::time_point::max()));
+    if (!profile.validFrom.has_value()) {
+        auto validFrom = ocpp::DateTime();
+        EVLOG_debug << "Conforming profile: " << profile.id << " added validFrom as " << validFrom;
+        profile.validFrom = validFrom;
+    }
+
+    if (!profile.validTo.has_value()) {
+        auto validTo = ocpp::DateTime(date::utc_clock::time_point::max());
+        EVLOG_debug << "Conforming profile: " << profile.id << " added validTo as " << validTo;
+        profile.validTo = validTo;
+    }
 }
 
 ProfileValidationResultEnum

--- a/lib/ocpp/v201/smart_charging.cpp
+++ b/lib/ocpp/v201/smart_charging.cpp
@@ -155,9 +155,10 @@ void SmartChargingHandler::delete_transaction_tx_profiles(const std::string& tra
     this->database_handler->delete_charging_profile_by_transaction_id(transaction_id);
 }
 
-SetChargingProfileResponse SmartChargingHandler::conform_validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
-                                                                          ChargingLimitSourceEnum charging_limit_source,
-                                                                          AddChargingProfileSource source_of_request) {
+SetChargingProfileResponse
+SmartChargingHandler::conform_validate_and_add_profile(ChargingProfile& profile, int32_t evse_id,
+                                                       ChargingLimitSourceEnum charging_limit_source,
+                                                       AddChargingProfileSource source_of_request) {
     SetChargingProfileResponse response;
     response.status = ChargingProfileStatusEnum::Rejected;
 

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -12,10 +12,9 @@
 namespace ocpp::v201 {
 class SmartChargingHandlerMock : public SmartChargingHandlerInterface {
 public:
-    MOCK_METHOD(SetChargingProfileResponse, validate_and_add_profile,
-                (ChargingProfile & profile, int32_t evse_id, ChargingLimitSourceEnum charging_limit_source,
-                 AddChargingProfileSource source_of_request));
-    MOCK_METHOD(ProfileValidationResultEnum, validate_profile,
+    MOCK_METHOD(SetChargingProfileResponse, conform_validate_and_add_profile,
+                (ChargingProfile & profile, int32_t evse_id, ChargingLimitSourceEnum charging_limit_source, AddChargingProfileSource source_of_request));
+    MOCK_METHOD(ProfileValidationResultEnum, conform_and_validate_profile,
                 (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
     MOCK_METHOD(void, delete_transaction_tx_profiles, (const std::string& transaction_id));
     MOCK_METHOD(SetChargingProfileResponse, add_profile,

--- a/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_handler_mock.hpp
@@ -13,7 +13,8 @@ namespace ocpp::v201 {
 class SmartChargingHandlerMock : public SmartChargingHandlerInterface {
 public:
     MOCK_METHOD(SetChargingProfileResponse, conform_validate_and_add_profile,
-                (ChargingProfile & profile, int32_t evse_id, ChargingLimitSourceEnum charging_limit_source, AddChargingProfileSource source_of_request));
+                (ChargingProfile & profile, int32_t evse_id, ChargingLimitSourceEnum charging_limit_source,
+                 AddChargingProfileSource source_of_request));
     MOCK_METHOD(ProfileValidationResultEnum, conform_and_validate_profile,
                 (ChargingProfile & profile, int32_t evse_id, AddChargingProfileSource source_of_request));
     MOCK_METHOD(void, delete_transaction_tx_profiles, (const std::string& transaction_id));

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -666,8 +666,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201, K01_SetChargingProfileRequest_Va
         request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
 
     EXPECT_CALL(*smart_charging_handler,
-                validate_and_add_profile(profile, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO,
-                                         DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE));
+                conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO,, DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE));
 
     charge_point->handle_message(set_charging_profile_req);
 }
@@ -689,7 +688,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR07_SetChargingProfileReques
     SetChargingProfileResponse accept_response;
     accept_response.status = ChargingProfileStatusEnum::Accepted;
 
-    ON_CALL(*smart_charging_handler, validate_and_add_profile).WillByDefault(testing::Return(accept_response));
+    ON_CALL(*smart_charging_handler, conform_validate_and_add_profile).WillByDefault(testing::Return(accept_response));
     EXPECT_CALL(set_charging_profiles_callback_mock, Call);
 
     charge_point->handle_message(set_charging_profile_req);
@@ -717,7 +716,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR07_SetChargingProfileReques
     reject_response.statusInfo->additionalInfo = conversions::profile_validation_result_to_string(
         ProfileValidationResultEnum::TxProfileEvseHasNoActiveTransaction);
 
-    ON_CALL(*smart_charging_handler, validate_and_add_profile).WillByDefault(testing::Return(reject_response));
+    ON_CALL(*smart_charging_handler, conform_validate_and_add_profile).WillByDefault(testing::Return(reject_response));
     EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
 
     charge_point->handle_message(set_charging_profile_req);
@@ -738,7 +737,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
     auto set_charging_profile_req =
         request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
 
-    EXPECT_CALL(*smart_charging_handler, validate_and_add_profile).Times(0);
+    EXPECT_CALL(*smart_charging_handler, conform_validate_and_add_profile).Times(0);
     EXPECT_CALL(set_charging_profiles_callback_mock, Call).Times(0);
 
     charge_point->handle_message(set_charging_profile_req);
@@ -765,7 +764,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR29_SmartChargingCtrlrAvaila
     auto set_charging_profile_req =
         request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
 
-    EXPECT_CALL(*smart_charging_handler, validate_and_add_profile).Times(0);
+    EXPECT_CALL(*smart_charging_handler, conform_validate_and_add_profile).Times(0);
 
     charge_point->handle_message(set_charging_profile_req);
 }
@@ -789,7 +788,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
     auto start_transaction_req =
         request_to_enhanced_message<RequestStartTransactionRequest, MessageType::RequestStartTransaction>(req);
 
-    EXPECT_CALL(*smart_charging_handler, validate_and_add_profile).Times(1);
+    EXPECT_CALL(*smart_charging_handler, conform_validate_and_add_profile).Times(1);
 
     charge_point->handle_message(start_transaction_req);
 }
@@ -815,7 +814,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201, K01FR29_SmartChargingCtrlrAvaila
     auto set_charging_profile_req =
         request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
 
-    EXPECT_CALL(*smart_charging_handler, validate_and_add_profile).Times(1);
+    EXPECT_CALL(*smart_charging_handler, conform_validate_and_add_profile).Times(1);
 
     charge_point->handle_message(set_charging_profile_req);
 }
@@ -915,7 +914,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
     auto start_transaction_req =
         request_to_enhanced_message<RequestStartTransactionRequest, MessageType::RequestStartTransaction>(req);
 
-    EXPECT_CALL(*smart_charging_handler, validate_and_add_profile).Times(0);
+    EXPECT_CALL(*smart_charging_handler, conform_validate_and_add_profile).Times(0);
 
     charge_point->handle_message(start_transaction_req);
 }

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -666,7 +666,7 @@ TEST_F(ChargePointFunctionalityTestFixtureV201, K01_SetChargingProfileRequest_Va
         request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
 
     EXPECT_CALL(*smart_charging_handler,
-                conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO, ,
+                conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO,
                                                  DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE));
 
     charge_point->handle_message(set_charging_profile_req);

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -666,7 +666,8 @@ TEST_F(ChargePointFunctionalityTestFixtureV201, K01_SetChargingProfileRequest_Va
         request_to_enhanced_message<SetChargingProfileRequest, MessageType::SetChargingProfile>(req);
 
     EXPECT_CALL(*smart_charging_handler,
-                conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO,, DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE));
+                conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO, ,
+                                                 DEFAULT_REQUEST_TO_ADD_PROFILE_SOURCE));
 
     charge_point->handle_message(set_charging_profile_req);
 }

--- a/tests/lib/ocpp/v201/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v201/test_composite_schedule.cpp
@@ -690,8 +690,10 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_DemoCase
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
 
-    ASSERT_EQ(ProfileValidationResultEnum::Valid, handler.validate_profile(profiles.at(0), DEFAULT_EVSE_ID));
-    ASSERT_EQ(ProfileValidationResultEnum::Valid, handler.validate_profile(profiles.at(1), DEFAULT_EVSE_ID));
+    ASSERT_EQ(ProfileValidationResultEnum::Valid,
+              handler.conform_and_validate_profile(profiles.at(0), DEFAULT_EVSE_ID));
+    ASSERT_EQ(ProfileValidationResultEnum::Valid,
+              handler.conform_and_validate_profile(profiles.at(1), DEFAULT_EVSE_ID));
     ASSERT_EQ(actual, expected);
 }
 

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -921,7 +921,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-01T13:00:00"),
         ocpp::DateTime("2024-02-01T13:00:00"));
-    auto response = handler.validate_and_add_profile(existing_profile, DEFAULT_EVSE_ID);
+    auto response = handler.conform_validate_and_add_profile(existing_profile, DEFAULT_EVSE_ID);
     EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, DEFAULT_TX_ID);
@@ -932,11 +932,11 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-15T13:00:00"),
         ocpp::DateTime("2024-02-01T13:00:00"));
 
-    response = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    response = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
     EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     // verify TxDefaultProfile can still be validated when TxProfile was added
-    auto sut = handler.validate_profile(existing_profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(existing_profile, DEFAULT_EVSE_ID);
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
 
@@ -1293,7 +1293,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, ValidateAndAddProfile_StoresCharging
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
-    auto response = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID, charging_limit_source);
+    auto response = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, charging_limit_source);
     EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     ChargingProfileCriterion criteria = {
@@ -1513,7 +1513,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_ReportsProfi
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto response = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID, charging_limit_source);
+    auto response = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, charging_limit_source);
     EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     std::vector<int32_t> requested_profile_ids{1};
@@ -1709,7 +1709,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K05FR02_RequestStartTransactionReque
 TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateChargingStationMaxProfile_AllowsExistingMatchingProfile) {
     auto profile =
         SmartChargingTestUtils::get_charging_profile_from_file("max/ChargingStationMaxProfile_grid_hourly.json");
-    auto res = handler.validate_and_add_profile(profile, STATION_WIDE_ID);
+    auto res = handler.conform_validate_and_add_profile(profile, STATION_WIDE_ID);
     ASSERT_THAT(res.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     auto sut = handler.validate_charging_station_max_profile(profile, STATION_WIDE_ID);
@@ -1719,7 +1719,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateChargingStationMaxProfil
 
 TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateTxDefaultProfile_AllowsExistingMatchingProfile) {
     auto profile = SmartChargingTestUtils::get_charging_profile_from_file("singles/Absolute_301.json");
-    auto res = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    auto res = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
     ASSERT_THAT(res.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     auto sut = handler.validate_tx_default_profile(profile, DEFAULT_EVSE_ID);
@@ -1731,7 +1731,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateTxProfile_AllowsExisting
     auto profile = SmartChargingTestUtils::get_charging_profile_from_file("baseline/TxProfile_1.json");
     this->evse_manager->open_transaction(DEFAULT_EVSE_ID, profile.transactionId.value());
 
-    auto res = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    auto res = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
     ASSERT_THAT(res.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     auto sut = handler.validate_tx_profile(profile, DEFAULT_EVSE_ID);

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -254,7 +254,7 @@ protected:
         auto profile = create_charging_profile(
             profile_id, ChargingProfilePurposeEnum::TxDefaultProfile,
             create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-        auto response = handler.validate_and_add_profile(profile, evse_id);
+        auto response = handler.conform_validate_and_add_profile(profile, evse_id);
         if (response.status == ChargingProfileStatusEnum::Accepted) {
             return profile;
         } else {
@@ -844,7 +844,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01FR06_ExistingProfileLastsForever_
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-02T13:00:00"),
         ocpp::DateTime("2024-03-01T13:00:00"));
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -860,7 +860,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {}, ocpp::DateTime("2024-01-01T13:00:00"));
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -876,7 +876,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-31T13:00:00"), {});
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -892,7 +892,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01FR06_ExisitingProfileHasValidPeri
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), {},
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, {}, {});
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -908,7 +908,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01FR06_ExisitingProfileHasValidPeri
         ChargingProfileKindEnum::Absolute, DEFAULT_STACK_LEVEL, ocpp::DateTime("2024-01-15T13:00:00"),
         ocpp::DateTime("2024-02-01T13:00:00"));
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateProfileValidityPeriod));
 }
@@ -944,7 +944,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfEvseDoesNotExi
     auto profile = create_charging_profile(DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
                                            create_charge_schedule(ChargingRateUnitEnum::A), DEFAULT_TX_ID);
 
-    auto sut = handler.validate_profile(profile, NR_OF_EVSES + 1);
+    auto sut = handler.conform_and_validate_profile(profile, NR_OF_EVSES + 1);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::EvseDoesNotExist));
 }
@@ -957,7 +957,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfScheduleIsInva
                                 create_charge_schedule(ChargingRateUnitEnum::A, periods, extraneous_start_schedule),
                                 DEFAULT_TX_ID, ChargingProfileKindEnum::Relative, 1);
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingProfileExtraneousStartSchedule));
 }
@@ -969,7 +969,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ChargingStationMaxProfileEvseIdGreaterThanZero));
 }
@@ -984,7 +984,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
                                            create_charge_schedule(ChargingRateUnitEnum::A, periods), {},
                                            ChargingProfileKindEnum::Relative, DEFAULT_STACK_LEVEL);
 
-    auto sut = handler.validate_profile(profile, STATION_WIDE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateTxDefaultProfileFound));
 }
@@ -999,7 +999,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
                                            create_charge_schedule(ChargingRateUnitEnum::A, periods), {},
                                            ChargingProfileKindEnum::Relative, DEFAULT_STACK_LEVEL);
 
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::DuplicateTxDefaultProfileFound));
 }
@@ -1009,7 +1009,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfTxProfileIsInv
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::TxProfileMissingTransactionId));
 }
@@ -1022,7 +1022,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfTxProfileIsVal
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -1033,7 +1033,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfTxDefaultProfi
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-    auto sut = handler.validate_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -1044,7 +1044,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateProfile_IfChargeStationM
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut = handler.validate_profile(profile, STATION_WIDE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::Valid));
 }
@@ -1061,7 +1061,7 @@ TEST_F(
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-    auto sut = handler.validate_profile(profile, STATION_WIDE_ID);
+    auto sut = handler.conform_and_validate_profile(profile, STATION_WIDE_ID);
 
     EXPECT_THAT(sut, testing::Eq(ProfileValidationResultEnum::ExistingChargingStationExternalConstraints));
 }
@@ -1310,7 +1310,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateAndAdd_RejectsInvalidPro
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
     auto status_info = sut.statusInfo;
     EXPECT_THAT(sut.status, testing::Eq(ChargingProfileStatusEnum::Rejected));
     EXPECT_THAT(status_info->reasonCode.get(), testing::Eq(conversions::profile_validation_result_to_reason_code(
@@ -1333,7 +1333,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K01_ValidateAndAdd_AddsValidProfiles
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")), DEFAULT_TX_ID);
 
-    auto sut = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    auto sut = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
     EXPECT_THAT(sut.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
     EXPECT_THAT(sut.statusInfo.has_value(), testing::IsFalse());
 
@@ -1351,8 +1351,8 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseId) {
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
-    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+    auto sut1 = handler.conform_validate_and_add_profile(profile1, STATION_WIDE_ID);
+    auto sut2 = handler.conform_validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
@@ -1382,8 +1382,8 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_NoEvseId) {
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
-    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+    auto sut1 = handler.conform_validate_and_add_profile(profile1, STATION_WIDE_ID);
+    auto sut2 = handler.conform_validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
@@ -1406,8 +1406,8 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_ProfileId) {
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
-    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+    auto sut1 = handler.conform_validate_and_add_profile(profile1, STATION_WIDE_ID);
+    auto sut2 = handler.conform_validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
@@ -1432,8 +1432,8 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSta
         create_charge_schedule(ChargingRateUnitEnum::A, periods,
                                ocpp::DateTime("2024-01-17T17:00:00"))); // contains default stackLevel(1)
 
-    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
-    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+    auto sut1 = handler.conform_validate_and_add_profile(profile1, STATION_WIDE_ID);
+    auto sut2 = handler.conform_validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
@@ -1453,7 +1453,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseIdAndSou
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    auto sut1 = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(1));
@@ -1482,8 +1482,8 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K09_GetChargingProfiles_EvseIdAndPur
         2, ChargingProfilePurposeEnum::TxDefaultProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut1 = handler.validate_and_add_profile(profile1, STATION_WIDE_ID);
-    auto sut2 = handler.validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
+    auto sut1 = handler.conform_validate_and_add_profile(profile1, STATION_WIDE_ID);
+    auto sut2 = handler.conform_validate_and_add_profile(profile2, DEFAULT_EVSE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::SizeIs(2));
@@ -1532,7 +1532,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K10_ClearChargingProfile_ClearsId) {
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-    handler.validate_and_add_profile(profile, STATION_WIDE_ID);
+    handler.conform_validate_and_add_profile(profile, STATION_WIDE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));
@@ -1580,7 +1580,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K10_ClearChargingProfile_UnknownId) 
     auto profile = create_charging_profile(
         DEFAULT_PROFILE_ID, ChargingProfilePurposeEnum::ChargingStationMaxProfile,
         create_charge_schedule(ChargingRateUnitEnum::A, periods, ocpp::DateTime("2024-01-17T17:00:00")));
-    handler.validate_and_add_profile(profile, STATION_WIDE_ID);
+    handler.conform_validate_and_add_profile(profile, STATION_WIDE_ID);
 
     auto profiles = database_handler->get_all_charging_profiles();
     EXPECT_THAT(profiles, testing::Contains(profile));
@@ -1666,7 +1666,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K02FR05_SmartChargingTransactionEnds
                                                                   ocpp::DateTime("2024-01-17T17:00:00")),
                                            transaction_id);
 
-    auto response = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    auto response = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
     ASSERT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     handler.delete_transaction_tx_profiles(transaction_id);
@@ -1687,7 +1687,7 @@ TEST_F(SmartChargingHandlerTestFixtureV201,
                                                                   ocpp::DateTime("2024-01-17T17:00:00")),
                                            other_transaction_id);
 
-    auto response = handler.validate_and_add_profile(profile, DEFAULT_EVSE_ID);
+    auto response = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID);
     ASSERT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
     handler.delete_transaction_tx_profiles(transaction_id);
@@ -1701,8 +1701,8 @@ TEST_F(SmartChargingHandlerTestFixtureV201, K05FR02_RequestStartTransactionReque
                                                                   create_charging_schedule_periods({0, 1, 2}),
                                                                   ocpp::DateTime("2024-01-17T17:00:00")));
 
-    auto sut =
-        handler.validate_profile(profile, DEFAULT_EVSE_ID, AddChargingProfileSource::RequestStartTransactionRequest);
+    auto sut = handler.conform_and_validate_profile(profile, DEFAULT_EVSE_ID,
+                                                    AddChargingProfileSource::RequestStartTransactionRequest);
     ASSERT_THAT(sut, testing::Eq(ProfileValidationResultEnum::RequestStartTransactionNonTxProfile));
 }
 


### PR DESCRIPTION
Original PR reopened: https://github.com/EVerest/libocpp/pull/815

## Describe your changes

As part of the validation there are times, per the standard, that a profile needs to be modified to conform to the spec. During the initial pass we had this logic in validate methods and did not explicitly state that the modification was occurring.

- renamed validate_profile to conform_and_validate_profile in order to convey the potential for change.
- renamed validate_and_add_profile to conform_validate_and_add_profile in order to convey the potential for change.
- added method conform_validity_periods to better show where the change is occurring.
- added comment as to why the conform is being performed.
- added logging to show the values that are being set.
- added a new conform_schedule_number_phases function moving existing modification of the number of phases.
- updated some methods to use const on profiles where attributes are not being modified.
   
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
