### PR TITLE
Enable pedantic compiler error and remove C++20 feature usage

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ target_compile_options(ocpp
     PRIVATE
          #-Werror # turn warnings into errors
         -Wimplicit-fallthrough  # avoid unintended fallthroughs
+        -pedantic-errors
 )
 
 target_compile_definitions(ocpp

--- a/lib/ocpp/v201/profile.cpp
+++ b/lib/ocpp/v201/profile.cpp
@@ -359,13 +359,12 @@ CompositeSchedule calculate_composite_schedule(std::vector<period_entry_t>& in_c
     const auto now = floor_seconds(in_now);
     const auto end = floor_seconds(in_end);
 
-    CompositeSchedule composite{
-        .chargingSchedulePeriod = {},
-        .evseId = EVSEID_NOT_SET,
-        .duration = elapsed_seconds(end, now),
-        .scheduleStart = now,
-        .chargingRateUnit = selected_unit,
-    };
+    CompositeSchedule composite;
+    composite.chargingSchedulePeriod = {};
+    composite.evseId = EVSEID_NOT_SET;
+    composite.duration = elapsed_seconds(end, now);
+    composite.scheduleStart = now;
+    composite.chargingRateUnit = selected_unit;
 
     // sort the combined_schedules in stack priority order
     struct {
@@ -476,14 +475,12 @@ CompositeSchedule calculate_composite_schedule(const CompositeSchedule& charging
                                                const CompositeScheduleDefaultLimits& default_limits,
                                                int32_t supply_voltage) {
 
-    CompositeSchedule combined{
-        .chargingSchedulePeriod = {},
-        .evseId = EVSEID_NOT_SET,
-        .duration = tx_default.duration,
-        .scheduleStart = tx_default.scheduleStart,
-        .chargingRateUnit = tx_default.chargingRateUnit,
-
-    };
+    CompositeSchedule combined;
+    combined.chargingSchedulePeriod = {};
+    combined.evseId = EVSEID_NOT_SET;
+    combined.duration = tx_default.duration;
+    combined.scheduleStart = tx_default.scheduleStart;
+    combined.chargingRateUnit = tx_default.chargingRateUnit;
 
     const float default_limit = (tx_default.chargingRateUnit == ChargingRateUnitEnum::A)
                                     ? static_cast<float>(default_limits.amps)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,13 @@ target_compile_definitions(libocpp_unit_tests
     TEST_PROFILES_LOCATION_V201="${TEST_PROFILES_LOCATION_V201}"
 )
 
+target_compile_options(libocpp_unit_tests
+    PRIVATE
+        -pedantic-errors
+)
+
+target_compile_features(libocpp_unit_tests PUBLIC cxx_std_17)
+
 add_custom_command(TARGET libocpp_unit_tests POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/unittest_device_model.db ${CMAKE_CURRENT_BINARY_DIR}/resources/unittest_device_model.db
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/resources/unittest_device_model_missing_required.db ${CMAKE_CURRENT_BINARY_DIR}/resources/unittest_device_model_missing_required.db

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -76,9 +76,8 @@ public:
     std::vector<ChargingSchedulePeriod> create_charging_schedule_periods(std::vector<int32_t> start_periods) {
         auto charging_schedule_periods = std::vector<ChargingSchedulePeriod>();
         for (auto start_period : start_periods) {
-            auto charging_schedule_period = ChargingSchedulePeriod{
-                .startPeriod = start_period,
-            };
+            ChargingSchedulePeriod charging_schedule_period;
+            charging_schedule_period.startPeriod = start_period;
             charging_schedule_periods.push_back(charging_schedule_period);
         }
 
@@ -114,16 +113,18 @@ public:
                             std::optional<ocpp::DateTime> validTo = {}) {
         auto recurrency_kind = RecurrencyKindEnum::Daily;
         std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
-        return ChargingProfile{.id = charging_profile_id,
-                               .stackLevel = stack_level,
-                               .chargingProfilePurpose = charging_profile_purpose,
-                               .chargingProfileKind = charging_profile_kind,
-                               .chargingSchedule = charging_schedules,
-                               .customData = {},
-                               .recurrencyKind = recurrency_kind,
-                               .validFrom = validFrom,
-                               .validTo = validTo,
-                               .transactionId = transaction_id};
+        ChargingProfile charging_profile;
+        charging_profile.id = charging_profile_id;
+        charging_profile.stackLevel = stack_level;
+        charging_profile.chargingProfilePurpose = charging_profile_purpose;
+        charging_profile.chargingProfileKind = charging_profile_kind;
+        charging_profile.chargingSchedule = charging_schedules;
+        charging_profile.customData = {};
+        charging_profile.recurrencyKind = recurrency_kind;
+        charging_profile.validFrom = validFrom;
+        charging_profile.validTo = validTo;
+        charging_profile.transactionId = transaction_id;
+        return charging_profile;
     }
 
     std::shared_ptr<DatabaseHandler> create_database_handler() {
@@ -626,11 +627,10 @@ public:
     template <class T, MessageType M> EnhancedMessage<MessageType> request_to_enhanced_message(const T& req) {
         auto message_id = uuid();
         ocpp::Call<T> call(req, message_id);
-        EnhancedMessage<MessageType> enhanced_message{
-            .uniqueId = message_id,
-            .messageType = M,
-            .messageTypeId = MessageTypeId::CALL,
-        };
+        EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.uniqueId = message_id;
+        enhanced_message.messageType = M;
+        enhanced_message.messageTypeId = MessageTypeId::CALL;
 
         call_to_json(enhanced_message.message, call);
 
@@ -783,7 +783,8 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
 
     RequestStartTransactionRequest req;
     req.evseId = DEFAULT_EVSE_ID;
-    req.idToken = IdToken{.idToken = "Local", .type = IdTokenEnum::Local};
+    req.idToken.idToken = "Local";
+    req.idToken.type = IdTokenEnum::Local;
     req.chargingProfile = profile;
 
     auto start_transaction_req =
@@ -909,7 +910,8 @@ TEST_F(ChargePointFunctionalityTestFixtureV201,
 
     RequestStartTransactionRequest req;
     req.evseId = DEFAULT_EVSE_ID;
-    req.idToken = IdToken{.idToken = "Local", .type = IdTokenEnum::Local};
+    req.idToken.idToken = "Local";
+    req.idToken.type = IdTokenEnum::Local;
     req.chargingProfile = profile;
 
     auto start_transaction_req =

--- a/tests/lib/ocpp/v201/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v201/test_composite_schedule.cpp
@@ -114,11 +114,10 @@ protected:
     std::vector<ChargingSchedulePeriod>
     create_charging_schedule_periods(int32_t start_period, std::optional<int32_t> number_phases = std::nullopt,
                                      std::optional<int32_t> phase_to_use = std::nullopt) {
-        auto charging_schedule_period = ChargingSchedulePeriod{
-            .startPeriod = start_period,
-            .numberPhases = number_phases,
-            .phaseToUse = phase_to_use,
-        };
+        ChargingSchedulePeriod charging_schedule_period;
+        charging_schedule_period.startPeriod = start_period;
+        charging_schedule_period.numberPhases = number_phases;
+        charging_schedule_period.phaseToUse = phase_to_use;
 
         return {charging_schedule_period};
     }
@@ -126,9 +125,8 @@ protected:
     std::vector<ChargingSchedulePeriod> create_charging_schedule_periods(std::vector<int32_t> start_periods) {
         auto charging_schedule_periods = std::vector<ChargingSchedulePeriod>();
         for (auto start_period : start_periods) {
-            auto charging_schedule_period = ChargingSchedulePeriod{
-                .startPeriod = start_period,
-            };
+            ChargingSchedulePeriod charging_schedule_period;
+            charging_schedule_period.startPeriod = start_period;
             charging_schedule_periods.push_back(charging_schedule_period);
         }
 
@@ -137,8 +135,10 @@ protected:
 
     std::vector<ChargingSchedulePeriod>
     create_charging_schedule_periods_with_phases(int32_t start_period, int32_t numberPhases, int32_t phaseToUse) {
-        auto charging_schedule_period =
-            ChargingSchedulePeriod{.startPeriod = start_period, .numberPhases = numberPhases, .phaseToUse = phaseToUse};
+        ChargingSchedulePeriod charging_schedule_period;
+        charging_schedule_period.startPeriod = start_period;
+        charging_schedule_period.numberPhases = numberPhases;
+        charging_schedule_period.phaseToUse = phaseToUse;
 
         return {charging_schedule_period};
     }
@@ -151,16 +151,18 @@ protected:
                             std::optional<ocpp::DateTime> validTo = {}) {
         auto recurrency_kind = RecurrencyKindEnum::Daily;
         std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
-        return ChargingProfile{.id = charging_profile_id,
-                               .stackLevel = stack_level,
-                               .chargingProfilePurpose = charging_profile_purpose,
-                               .chargingProfileKind = charging_profile_kind,
-                               .chargingSchedule = charging_schedules,
-                               .customData = {},
-                               .recurrencyKind = recurrency_kind,
-                               .validFrom = validFrom,
-                               .validTo = validTo,
-                               .transactionId = transaction_id};
+        ChargingProfile charging_profile;
+        charging_profile.id = charging_profile_id;
+        charging_profile.stackLevel = stack_level;
+        charging_profile.chargingProfilePurpose = charging_profile_purpose;
+        charging_profile.chargingProfileKind = charging_profile_kind;
+        charging_profile.chargingSchedule = charging_schedules;
+        charging_profile.customData = {};
+        charging_profile.recurrencyKind = recurrency_kind;
+        charging_profile.validFrom = validFrom;
+        charging_profile.validTo = validTo;
+        charging_profile.transactionId = transaction_id;
+        return charging_profile;
     }
 
     void create_device_model_db(const std::string& path) {
@@ -211,132 +213,110 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_Foundati
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/grid/");
     const DateTime start_time = ocpp::DateTime("2024-01-17T00:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-18T00:00:00");
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 1.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 3600,
-                                       .limit = 2.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 7200,
-                                       .limit = 3.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 10800,
-                                       .limit = 4.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 14400,
-                                       .limit = 5.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 18000,
-                                       .limit = 6.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 21600,
-                                       .limit = 7.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 25200,
-                                       .limit = 8.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 28800,
-                                       .limit = 9.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 32400,
-                                       .limit = 10.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 36000,
-                                       .limit = 11.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 39600,
-                                       .limit = 12.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 43200,
-                                       .limit = 13.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 46800,
-                                       .limit = 14.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 50400,
-                                       .limit = 15.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 54000,
-                                       .limit = 16.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 57600,
-                                       .limit = 17.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 61200,
-                                       .limit = 18.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 64800,
-                                       .limit = 19.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 68400,
-                                       .limit = 20.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 72000,
-                                       .limit = 21.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 75600,
-                                       .limit = 22.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 79200,
-                                       .limit = 23.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 82800,
-                                       .limit = 24.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 86400,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 1.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 3600;
+    period2.limit = 2.0;
+    period2.numberPhases = 1;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 7200;
+    period3.limit = 3.0;
+    period3.numberPhases = 1;
+    ChargingSchedulePeriod period4;
+    period4.startPeriod = 10800;
+    period4.limit = 4.0;
+    period4.numberPhases = 1;
+    ChargingSchedulePeriod period5;
+    period5.startPeriod = 14400;
+    period5.limit = 5.0;
+    period5.numberPhases = 1;
+    ChargingSchedulePeriod period6;
+    period6.startPeriod = 18000;
+    period6.limit = 6.0;
+    period6.numberPhases = 1;
+    ChargingSchedulePeriod period7;
+    period7.startPeriod = 21600;
+    period7.limit = 7.0;
+    period7.numberPhases = 1;
+    ChargingSchedulePeriod period8;
+    period8.startPeriod = 25200;
+    period8.limit = 8.0;
+    period8.numberPhases = 1;
+    ChargingSchedulePeriod period9;
+    period9.startPeriod = 28800;
+    period9.limit = 9.0;
+    period9.numberPhases = 1;
+    ChargingSchedulePeriod period10;
+    period10.startPeriod = 32400;
+    period10.limit = 10.0;
+    period10.numberPhases = 1;
+    ChargingSchedulePeriod period11;
+    period11.startPeriod = 36000;
+    period11.limit = 11.0;
+    period11.numberPhases = 1;
+    ChargingSchedulePeriod period12;
+    period12.startPeriod = 39600;
+    period12.limit = 12.0;
+    period12.numberPhases = 1;
+    ChargingSchedulePeriod period13;
+    period13.startPeriod = 43200;
+    period13.limit = 13.0;
+    period13.numberPhases = 1;
+    ChargingSchedulePeriod period14;
+    period14.startPeriod = 46800;
+    period14.limit = 14.0;
+    period14.numberPhases = 1;
+    ChargingSchedulePeriod period15;
+    period15.startPeriod = 50400;
+    period15.limit = 15.0;
+    period15.numberPhases = 1;
+    ChargingSchedulePeriod period16;
+    period16.startPeriod = 54000;
+    period16.limit = 16.0;
+    period16.numberPhases = 1;
+    ChargingSchedulePeriod period17;
+    period17.startPeriod = 57600;
+    period17.limit = 17.0;
+    period17.numberPhases = 1;
+    ChargingSchedulePeriod period18;
+    period18.startPeriod = 61200;
+    period18.limit = 18.0;
+    period18.numberPhases = 1;
+    ChargingSchedulePeriod period19;
+    period19.startPeriod = 64800;
+    period19.limit = 19.0;
+    period19.numberPhases = 1;
+    ChargingSchedulePeriod period20;
+    period20.startPeriod = 68400;
+    period20.limit = 20.0;
+    period20.numberPhases = 1;
+    ChargingSchedulePeriod period21;
+    period21.startPeriod = 72000;
+    period21.limit = 21.0;
+    period21.numberPhases = 1;
+    ChargingSchedulePeriod period22;
+    period22.startPeriod = 75600;
+    period22.limit = 22.0;
+    period22.numberPhases = 1;
+    ChargingSchedulePeriod period23;
+    period23.startPeriod = 79200;
+    period23.limit = 23.0;
+    period23.numberPhases = 1;
+    ChargingSchedulePeriod period24;
+    period24.startPeriod = 82800;
+    period24.limit = 24.0;
+    period24.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1,  period2,  period3,  period4,  period5,  period6,  period7,  period8,
+                                       period9,  period10, period11, period12, period13, period14, period15, period16,
+                                       period17, period18, period19, period20, period21, period22, period23, period24};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 86400;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -353,17 +333,16 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredT
         const DateTime start_time = ocpp::DateTime("2024-01-18T18:04:00");
         const DateTime end_time = ocpp::DateTime("2024-01-18T18:22:00");
 
-        CompositeSchedule expected = {
-            .chargingSchedulePeriod = {{
-                .startPeriod = 0,
-                .limit = 19.0,
-                .numberPhases = 1,
-            }},
-            .evseId = DEFAULT_EVSE_ID,
-            .duration = 1080,
-            .scheduleStart = start_time,
-            .chargingRateUnit = ChargingRateUnitEnum::W,
-        };
+        ChargingSchedulePeriod period;
+        period.startPeriod = 0;
+        period.limit = 19.0;
+        period.numberPhases = 1;
+        CompositeSchedule expected;
+        expected.chargingSchedulePeriod = {period};
+        expected.evseId = DEFAULT_EVSE_ID;
+        expected.duration = 1080;
+        expected.scheduleStart = start_time;
+        expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
         CompositeSchedule actual = handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID,
                                                                         ChargingRateUnitEnum::W);
@@ -376,22 +355,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredT
         const DateTime start_time = ocpp::DateTime("2024-01-17T18:04:00");
         const DateTime end_time = ocpp::DateTime("2024-01-17T18:33:00");
 
-        CompositeSchedule expected = {
-            .chargingSchedulePeriod = {{
-                                           .startPeriod = 0,
-                                           .limit = 2000.0,
-                                           .numberPhases = 1,
-                                       },
-                                       {
-                                           .startPeriod = 1080,
-                                           .limit = 19.0,
-                                           .numberPhases = 1,
-                                       }},
-            .evseId = DEFAULT_EVSE_ID,
-            .duration = 1740,
-            .scheduleStart = start_time,
-            .chargingRateUnit = ChargingRateUnitEnum::W,
-        };
+        ChargingSchedulePeriod period1;
+        period1.startPeriod = 0;
+        period1.limit = 2000.0;
+        period1.numberPhases = 1;
+        ChargingSchedulePeriod period2;
+        period2.startPeriod = 1080;
+        period2.limit = 19.0;
+        period2.numberPhases = 1;
+        CompositeSchedule expected;
+        expected.chargingSchedulePeriod = {period1, period2};
+        expected.evseId = DEFAULT_EVSE_ID;
+        expected.duration = 1740;
+        expected.scheduleStart = start_time;
+        expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
         CompositeSchedule actual = handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID,
                                                                         ChargingRateUnitEnum::W);
@@ -404,27 +381,25 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredT
         const DateTime start_time = ocpp::DateTime("2024-01-17T18:04:00");
         const DateTime end_time = ocpp::DateTime("2024-01-17T19:04:00");
 
-        CompositeSchedule expected = {
-            .chargingSchedulePeriod = {{
-                                           .startPeriod = 0,
-                                           .limit = 2000.0,
-                                           .numberPhases = 1,
-                                       },
-                                       {
-                                           .startPeriod = 1080,
-                                           .limit = 19.0,
-                                           .numberPhases = 1,
-                                       },
-                                       {
-                                           .startPeriod = 3360,
-                                           .limit = 20.0,
-                                           .numberPhases = 1,
-                                       }},
-            .evseId = DEFAULT_EVSE_ID,
-            .duration = 3600,
-            .scheduleStart = start_time,
-            .chargingRateUnit = ChargingRateUnitEnum::W,
-        };
+        ChargingSchedulePeriod period1;
+        period1.startPeriod = 0;
+        period1.limit = 2000.0;
+        period1.numberPhases = 1;
+        ChargingSchedulePeriod period2;
+        period2.startPeriod = 1080;
+        period2.limit = 19.0;
+        period2.numberPhases = 1;
+        ChargingSchedulePeriod period3;
+        period3.startPeriod = 3360;
+        period3.limit = 20.0;
+        period3.numberPhases = 1;
+
+        CompositeSchedule expected;
+        expected.chargingSchedulePeriod = {period1, period2, period3};
+        expected.evseId = DEFAULT_EVSE_ID;
+        expected.duration = 3600;
+        expected.scheduleStart = start_time;
+        expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
         CompositeSchedule actual = handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID,
                                                                         ChargingRateUnitEnum::W);
@@ -440,17 +415,16 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredR
     const DateTime start_time = ocpp::DateTime("2024-02-17T18:04:00");
     const DateTime end_time = ocpp::DateTime("2024-02-17T18:05:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-            .startPeriod = 0,
-            .limit = 2000.0,
-            .numberPhases = 1,
-        }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 60,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = 2000.0;
+    period.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 60;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -463,23 +437,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredT
         SmartChargingTestUtils::get_charging_profiles_from_file("singles/TXProfile_Absolute_Start18-04.json");
     const DateTime start_time = ocpp::DateTime("2024-01-17T18:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-17T18:05:00");
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = DEFAULT_LIMIT_WATTS,
-                                       .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES,
-                                   },
-                                   {
-                                       .startPeriod = 240,
-                                       .limit =
-                                           profiles.at(0).chargingSchedule.front().chargingSchedulePeriod.front().limit,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 300,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = DEFAULT_LIMIT_WATTS;
+    period1.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 240;
+    period2.limit = profiles.at(0).chargingSchedule.front().chargingSchedulePeriod.front().limit;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 300;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -492,33 +463,27 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_LayeredR
         SmartChargingTestUtils::get_charging_profiles_from_directory(BASE_JSON_PATH + "/layered_recurring/");
     const DateTime start_time = ocpp::DateTime("2024-02-19T18:00:00");
     const DateTime end_time = ocpp::DateTime("2024-02-19T19:04:00");
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod =
-            {{
-                 .startPeriod = 0,
-                 .limit = 19.0,
-                 .numberPhases = 1,
-             },
-             {
-                 .startPeriod = 240,
-                 .limit = profiles.back().chargingSchedule.front().chargingSchedulePeriod.front().limit,
-                 .numberPhases = 1,
-             },
-             {
-                 .startPeriod = 1320,
-                 .limit = 19.0,
-                 .numberPhases = 1,
-             },
-             {
-                 .startPeriod = 3600,
-                 .limit = 20.0,
-                 .numberPhases = 1,
-             }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 3840,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 19.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 240;
+    period2.limit = profiles.back().chargingSchedule.front().chargingSchedulePeriod.front().limit;
+    period2.numberPhases = 1;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 1320;
+    period3.limit = 19.0;
+    period3.numberPhases = 1;
+    ChargingSchedulePeriod period4;
+    period4.startPeriod = 3600;
+    period4.limit = 20.0;
+    period4.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3, period4}, expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 3840;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -533,27 +498,24 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_Validate
     const DateTime start_time = ocpp::DateTime("2024-01-17T18:01:00");
     const DateTime end_time = ocpp::DateTime("2024-01-18T06:00:00");
     std::vector<ChargingProfile> profiles = SmartChargingTestUtils::get_baseline_profile_vector();
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 2000.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 1020,
-                                       .limit = 11000.0,
-                                       .numberPhases = 3,
-                                   },
-                                   {
-                                       .startPeriod = 25140,
-                                       .limit = 6000.0,
-                                       .numberPhases = 3,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 43140,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 2000.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 1020;
+    period2.limit = 11000.0;
+    period2.numberPhases = 3;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 25140;
+    period3.limit = 6000.0;
+    period3.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 43140;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -572,17 +534,16 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_Relative
     // Doing this in order to avoid mocking system_clock::now()
     auto transaction = std::move(this->evse_manager->get_evse(DEFAULT_EVSE_ID).get_transaction());
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-            .startPeriod = 0,
-            .limit = 2000.0,
-            .numberPhases = 1,
-        }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 3600,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = 2000.0;
+    period.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 3600;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -601,22 +562,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_Relative
     const DateTime start_time = ocpp::DateTime("2024-05-17T05:00:00");
     const DateTime end_time = ocpp::DateTime("2024-05-17T06:01:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 2000.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 3601,
-                                       .limit = 7.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 3660,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 2000.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 3601;
+    period2.limit = 7.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 3660;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -633,27 +592,24 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_DemoCase
     const DateTime start_time = ocpp::DateTime("2024-01-17T18:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-18T06:00:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 2000.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 1080,
-                                       .limit = 11000.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 25200,
-                                       .limit = 6000.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 43200,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 2000.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 1080;
+    period2.limit = 11000.0;
+    period2.numberPhases = 1;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 25200;
+    period3.limit = 6000.0;
+    period3.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 43200;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -670,22 +626,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_DemoCase
     const DateTime start_time = ocpp::DateTime("2024-01-19T18:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-20T06:00:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 11000.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 25200,
-                                       .limit = 6000.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 43200,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 11000.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 25200;
+    period2.limit = 6000.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 43200;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -704,22 +658,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverr
     const DateTime start_time = ocpp::DateTime("2024-01-17T00:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-17T02:00:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 10.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 3600,
-                                       .limit = 20.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 7200,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 10.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 3600;
+    period2.limit = 20.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 7200;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -733,22 +685,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_MaxOverr
     const DateTime start_time = ocpp::DateTime("2024-01-17T22:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-18T00:00:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 230.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 3600,
-                                       .limit = 10.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 7200,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 230.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 3600;
+    period2.limit = 10.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 7200;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -762,22 +712,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_External
     const DateTime start_time = ocpp::DateTime("2024-01-17T00:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-17T02:00:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 10.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 3600,
-                                       .limit = 20.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 7200,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 10.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 3600;
+    period2.limit = 20.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 7200;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -791,22 +739,20 @@ TEST_F(CompositeScheduleTestFixtureV201, K08_CalculateCompositeSchedule_External
     const DateTime start_time = ocpp::DateTime("2024-01-17T22:00:00");
     const DateTime end_time = ocpp::DateTime("2024-01-18T00:00:00");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 230.0,
-                                       .numberPhases = 1,
-                                   },
-                                   {
-                                       .startPeriod = 3600,
-                                       .limit = 10.0,
-                                       .numberPhases = 1,
-                                   }},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 7200,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::W,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 230.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 3600;
+    period2.limit = 10.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 7200;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::W;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::W);
@@ -820,22 +766,36 @@ TEST_F(CompositeScheduleTestFixtureV201, OCTT_TC_K_41_CS) {
     const DateTime start_time = ocpp::DateTime("2024-08-21T12:24:40");
     const DateTime end_time = ocpp::DateTime("2024-08-21T12:31:20");
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {{
-                                       .startPeriod = 0,
-                                       .limit = 8.0,
-                                       .numberPhases = 3,
-                                   },
-                                   {.startPeriod = 46, .limit = 10.0, .numberPhases = 3},
-                                   {.startPeriod = 196, .limit = 6.0, .numberPhases = 3},
-                                   {.startPeriod = 236, .limit = 10.0, .numberPhases = 3},
-                                   {.startPeriod = 260, .limit = 8.0, .numberPhases = 3},
-                                   {.startPeriod = 300, .limit = 10.0, .numberPhases = 3}},
-        .evseId = DEFAULT_EVSE_ID,
-        .duration = 400,
-        .scheduleStart = start_time,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 8.0;
+    period1.numberPhases = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 46;
+    period2.limit = 10.0;
+    period2.numberPhases = 3;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 196;
+    period3.limit = 6.0;
+    period3.numberPhases = 3;
+    ChargingSchedulePeriod period4;
+    period4.startPeriod = 236;
+    period4.limit = 10.0;
+    period4.numberPhases = 3;
+    ChargingSchedulePeriod period5;
+    period5.startPeriod = 260;
+    period5.limit = 8.0;
+    period5.numberPhases = 3;
+    ChargingSchedulePeriod period6;
+    period6.startPeriod = 300;
+    period6.limit = 10.0;
+    period6.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3, period4, period5, period6};
+    expected.evseId = DEFAULT_EVSE_ID;
+    expected.duration = 400;
+    expected.scheduleStart = start_time;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual =
         handler.calculate_composite_schedule(profiles, start_time, end_time, DEFAULT_EVSE_ID, ChargingRateUnitEnum::A);

--- a/tests/lib/ocpp/v201/test_database_handler.cpp
+++ b/tests/lib/ocpp/v201/test_database_handler.cpp
@@ -168,9 +168,12 @@ TEST_F(DatabaseHandlerTest, TransactionDeleteNotFound) {
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithNoData_InsertProfile) {
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
+    ChargingProfile profile;
+    profile.id = 1;
+    profile.stackLevel = 1;
+    profile.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile);
 
     auto sut = this->database_handler.get_all_charging_profiles_group_by_evse();
 
@@ -181,12 +184,18 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithNoData_InsertProfile) {
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithProfileData_UpdateProfile) {
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 2, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 2, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
+    ChargingProfile profile1;
+    profile1.id = 2;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile1);
+    ChargingProfile profile2;
+    profile2.id = 2;
+    profile2.stackLevel = 2;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile2);
 
     std::string sql = "SELECT COUNT(*) FROM CHARGING_PROFILES";
     auto select_stmt = this->database->new_statement(sql);
@@ -198,12 +207,18 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithProfileData_UpdateProfile) {
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithProfileData_InsertNewProfile) {
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 2, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
+    ChargingProfile profile1;
+    profile1.id = 1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile1);
+    ChargingProfile profile2;
+    profile2.id = 2;
+    profile2.stackLevel = 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile2);
 
     std::string sql = "SELECT COUNT(*) FROM CHARGING_PROFILES";
     auto select_stmt = this->database->new_statement(sql);
@@ -215,12 +230,18 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithProfileData_InsertNewProfile) {
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithProfileData_DeleteRemovesSpecifiedProfiles) {
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 2, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
+    ChargingProfile profile1;
+    profile1.id = 1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile1);
+    ChargingProfile profile2;
+    profile2.id = 2;
+    profile2.stackLevel = 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile2);
 
     auto sql = "SELECT COUNT(*) FROM CHARGING_PROFILES";
 
@@ -243,12 +264,18 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithProfileData_DeleteRemovesSpecif
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithProfileData_DeleteAllRemovesAllProfiles) {
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
-    this->database_handler.insert_or_update_charging_profile(
-        1, ChargingProfile{
-               .id = 2, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile});
+    ChargingProfile profile1;
+    profile1.id = 1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile1);
+    ChargingProfile profile2;
+    profile2.id = 2;
+    profile2.stackLevel = 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(1, profile2);
 
     auto sql = "SELECT COUNT(*) FROM CHARGING_PROFILES";
 
@@ -289,8 +316,11 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithNoProfileData_DeleteAllDoesNotF
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithSingleProfileData_LoadsChargingProfile) {
-    auto profile = ChargingProfile{
-        .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile profile;
+    profile.id = 1;
+    profile.stackLevel = 1;
+    profile.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(1, profile);
 
     auto sut = this->database_handler.get_all_charging_profiles_group_by_evse();
@@ -307,17 +337,26 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithSingleProfileData_LoadsCharging
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithMultipleProfileSameEvse_LoadsChargingProfile) {
-    auto p1 = ChargingProfile{
-        .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p1;
+    p1.id = 1;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
 
     this->database_handler.insert_or_update_charging_profile(1, p1);
 
-    auto p2 = ChargingProfile{
-        .id = 2, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p2;
+    p2.id = 2;
+    p2.stackLevel = 2;
+    p2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(1, p2);
 
-    auto p3 = ChargingProfile{
-        .id = 3, .stackLevel = 3, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p3;
+    p3.id = 3;
+    p3.stackLevel = 3;
+    p3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(1, p3);
 
     auto sut = this->database_handler.get_all_charging_profiles_group_by_evse();
@@ -336,27 +375,46 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithMultipleProfileSameEvse_LoadsCh
 }
 
 TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithMultipleProfileDiffEvse_LoadsChargingProfile) {
-    auto p1 = ChargingProfile{
-        .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p1;
+    p1.id = 1;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(1, p1);
 
-    auto p2 =
-        ChargingProfile{.id = 2, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
+    ChargingProfile p2;
+    p2.id = 2;
+    p2.stackLevel = 2;
+    p2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    p2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(1, p2);
 
-    auto p3 = ChargingProfile{
-        .id = 3, .stackLevel = 3, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p3;
+    p3.id = 3;
+    p3.stackLevel = 3;
+    p3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(2, p3);
-    auto p4 =
-        ChargingProfile{.id = 4, .stackLevel = 4, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
+
+    ChargingProfile p4;
+    p4.id = 4;
+    p4.stackLevel = 4;
+    p4.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    p4.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(2, p4);
 
-    auto p5 = ChargingProfile{
-        .id = 5, .stackLevel = 5, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p5;
+    p5.id = 5;
+    p5.stackLevel = 5;
+    p5.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p5.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(3, p5);
 
-    auto p6 =
-        ChargingProfile{.id = 6, .stackLevel = 6, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
+    ChargingProfile p6;
+    p6.id = 6;
+    p6.stackLevel = 6;
+    p6.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    p6.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(3, p6);
 
     auto sut = this->database_handler.get_all_charging_profiles_group_by_evse();
@@ -385,10 +443,17 @@ TEST_F(DatabaseHandlerTest, KO1_FR27_DatabaseWithMultipleProfileDiffEvse_LoadsCh
 }
 
 TEST_F(DatabaseHandlerTest, GetAllChargingProfiles_GetsAllProfiles) {
-    auto profile1 = ChargingProfile{
-        .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    auto profile2 =
-        ChargingProfile{.id = 2, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
+    ChargingProfile profile1;
+    profile1.id = 1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    ChargingProfile profile2;
+    profile2.id = 2;
+    profile2.stackLevel = 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
 
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID + 1, profile2);
@@ -401,10 +466,17 @@ TEST_F(DatabaseHandlerTest, GetAllChargingProfiles_GetsAllProfiles) {
 }
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesForEvse_GetsProfilesForEVSE) {
-    auto profile1 = ChargingProfile{
-        .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    auto profile2 =
-        ChargingProfile{.id = 2, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
+    ChargingProfile profile1;
+    profile1.id = 1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    ChargingProfile profile2;
+    profile2.id = 2;
+    profile2.stackLevel = 2;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
 
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
@@ -417,10 +489,17 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesForEvse_GetsProfilesForEVSE) {
 }
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesForEvse_DoesNotGetProfilesOnOtherEVSE) {
-    auto profile1 = ChargingProfile{
-        .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    auto profile2 =
-        ChargingProfile{.id = 2, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
+    ChargingProfile profile1;
+    profile1.id = 1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    ChargingProfile profile2;
+    profile2.id = 2;
+    profile2.stackLevel = 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
 
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID + 1, profile2);
@@ -435,12 +514,18 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesForEvse_DoesNotGetProfilesOnOther
 TEST_F(DatabaseHandlerTest, DeleteChargingProfileByTransactionId_DeletesByTransactionId) {
     const auto profile_id = 1;
     const auto transaction_id = uuid();
-    auto profile1 = ChargingProfile{
-        .id = profile_id, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    auto profile2 = ChargingProfile{.id = profile_id + 1,
-                                    .stackLevel = 1,
-                                    .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile,
-                                    .transactionId = transaction_id};
+    ChargingProfile profile1;
+    profile1.id = profile_id;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    ChargingProfile profile2;
+    profile2.id = profile_id + 1;
+    profile2.stackLevel = 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    profile2.transactionId = transaction_id;
 
     this->database_handler.insert_or_update_charging_profile(1, profile1);
     this->database_handler.insert_or_update_charging_profile(1, profile2);
@@ -462,8 +547,11 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenGivenProfi
     const ClearChargingProfile clear_criteria;
 
     const auto profile_id = 1;
-    auto p1 = ChargingProfile{
-        .id = profile_id, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p1;
+    p1.id = profile_id;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, p1);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -480,8 +568,11 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenNotGivenPr
     const ClearChargingProfile clear_criteria;
 
     const auto profile_id = 1;
-    auto p1 = ChargingProfile{
-        .id = profile_id, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p1;
+    p1.id = profile_id;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, p1);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -497,10 +588,16 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenNotGivenPr
 
 TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenNotGivenCriteria_DeletesAllProfiles) {
     const auto profile_id = 1;
-    auto p1 = ChargingProfile{
-        .id = profile_id, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    auto p2 = ChargingProfile{
-        .id = profile_id + 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
+    ChargingProfile p1;
+    p1.id = profile_id;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    ChargingProfile p2;
+    p2.id = profile_id + 1;
+    p2.stackLevel = 1;
+    p2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    p2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, p1);
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID + 1, p2);
 
@@ -518,13 +615,16 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_WhenAllCriteri
     const auto purpose = ChargingProfilePurposeEnum::TxDefaultProfile;
     const auto stack_level = 1;
 
-    const ClearChargingProfile clear_criteria = {
-        .evseId = DEFAULT_EVSE_ID,
-        .chargingProfilePurpose = purpose,
-        .stackLevel = stack_level,
-    };
+    ClearChargingProfile clear_criteria;
+    clear_criteria.evseId = DEFAULT_EVSE_ID;
+    clear_criteria.chargingProfilePurpose = purpose;
+    clear_criteria.stackLevel = stack_level;
 
-    auto p1 = ChargingProfile{.id = 1, .stackLevel = stack_level, .chargingProfilePurpose = purpose};
+    ChargingProfile p1;
+    p1.id = 1;
+    p1.stackLevel = stack_level;
+    p1.chargingProfilePurpose = purpose;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, p1);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -541,14 +641,16 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_UnknownPurpose
     const auto different_purpose = ChargingProfilePurposeEnum::TxProfile;
     const auto stack_level = 1;
 
-    const ClearChargingProfile clear_criteria = {
-        .evseId = DEFAULT_EVSE_ID,
-        .chargingProfilePurpose = different_purpose,
-        .stackLevel = stack_level,
-    };
+    ClearChargingProfile clear_criteria;
+    clear_criteria.evseId = DEFAULT_EVSE_ID;
+    clear_criteria.chargingProfilePurpose = different_purpose;
+    clear_criteria.stackLevel = stack_level;
 
-    auto p1 = ChargingProfile{
-        .id = 1, .stackLevel = stack_level, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile p1;
+    p1.id = 1;
+    p1.stackLevel = stack_level;
+    p1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, p1);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -567,13 +669,16 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_UnknownStackLe
     const auto purpose = ChargingProfilePurposeEnum::TxDefaultProfile;
     const auto different_stack_level = 2;
 
-    const ClearChargingProfile clear_criteria = {
-        .evseId = DEFAULT_EVSE_ID,
-        .chargingProfilePurpose = purpose,
-        .stackLevel = different_stack_level,
-    };
+    ClearChargingProfile clear_criteria;
+    clear_criteria.evseId = DEFAULT_EVSE_ID;
+    clear_criteria.chargingProfilePurpose = purpose;
+    clear_criteria.stackLevel = different_stack_level;
 
-    auto p1 = ChargingProfile{.id = 1, .stackLevel = 1, .chargingProfilePurpose = purpose};
+    ChargingProfile p1;
+    p1.id = 1;
+    p1.stackLevel = 1;
+    p1.chargingProfilePurpose = purpose;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, p1);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -593,13 +698,16 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_UnknownEvseId_
     const auto stack_level = 1;
     const auto different_evse_id = DEFAULT_EVSE_ID + 1;
 
-    const ClearChargingProfile clear_criteria = {
-        .evseId = different_evse_id,
-        .chargingProfilePurpose = purpose,
-        .stackLevel = stack_level,
-    };
+    ClearChargingProfile clear_criteria;
+    clear_criteria.evseId = different_evse_id;
+    clear_criteria.chargingProfilePurpose = purpose;
+    clear_criteria.stackLevel = stack_level;
 
-    auto p1 = ChargingProfile{.id = 1, .stackLevel = stack_level, .chargingProfilePurpose = purpose};
+    ChargingProfile p1;
+    p1.id = 1;
+    p1.stackLevel = stack_level;
+    p1.chargingProfilePurpose = purpose;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, p1);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -618,13 +726,16 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_DoesNotDeleteE
     const auto purpose = ChargingProfilePurposeEnum::ChargingStationExternalConstraints;
     const auto stack_level = 1;
 
-    const ClearChargingProfile clear_criteria = {
-        .evseId = STATION_WIDE_ID,
-        .chargingProfilePurpose = purpose,
-        .stackLevel = stack_level,
-    };
+    ClearChargingProfile clear_criteria;
+    clear_criteria.evseId = STATION_WIDE_ID;
+    clear_criteria.chargingProfilePurpose = purpose;
+    clear_criteria.stackLevel = stack_level;
 
-    auto p1 = ChargingProfile{.id = 1, .stackLevel = stack_level, .chargingProfilePurpose = purpose};
+    ChargingProfile p1;
+    p1.id = 1;
+    p1.stackLevel = stack_level;
+    p1.chargingProfilePurpose = purpose;
+    p1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, p1);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -639,8 +750,11 @@ TEST_F(DatabaseHandlerTest, ClearChargingProfilesMatchingCriteria_DoesNotDeleteE
 }
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_NoCriteriaReturnsAll) {
-    auto profile = ChargingProfile{
-        .id = 1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile profile;
+    profile.id = 1;
+    profile.stackLevel = 1;
+    profile.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
@@ -653,14 +767,18 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_NoCriteriaReturn
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_NoMatchingIdsReturnsEmpty) {
     auto profile_id = 1;
-    auto profile = ChargingProfile{
-        .id = profile_id, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfile profile;
+    profile.id = profile_id;
+    profile.stackLevel = 1;
+    profile.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile.chargingProfileKind = ChargingProfileKindEnum::Absolute;
     this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 1);
 
-    ChargingProfileCriterion criteria = {.chargingProfileId = std::vector<int32_t>{2}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = std::vector<int32_t>{2};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -670,19 +788,28 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_NoMatchingIdsRet
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingIdReturnsSingleProfile) {
     auto profile_id_1 = 1;
-    auto profile_1 = ChargingProfile{
-        .id = profile_id_1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{
-        .id = profile_id_2, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = 2;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 2);
 
-    ChargingProfileCriterion criteria = {.chargingProfileId = std::vector<int32_t>{profile_id_1}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = std::vector<int32_t>{profile_id_1};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -692,19 +819,26 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingIdReturn
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingIdsReturnsMultipleProfiles) {
     auto profile_id_1 = 1;
-    auto profile_1 = ChargingProfile{
-        .id = profile_id_1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{
-        .id = profile_id_2, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = 2;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 2);
 
-    ChargingProfileCriterion criteria = {.chargingProfileId = std::vector<int32_t>{profile_id_1, profile_id_2}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = std::vector<int32_t>{profile_id_1, profile_id_2};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -714,24 +848,34 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingIdsRetur
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingChargingProfilePurposeReturnsProfiles) {
     auto profile_id_1 = 1;
-    auto profile_1 = ChargingProfile{
-        .id = profile_id_1, .stackLevel = 1, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = 1;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{
-        .id = profile_id_2, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = 2;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{
-        .id = profile_id_3, .stackLevel = 2, .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = 2;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -742,27 +886,34 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingCharging
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingStackLevelReturnsProfiles) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{.id = profile_id_3,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = stack_level + 1;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {.stackLevel = 2};
+    ChargingProfileCriterion criteria;
+    criteria.stackLevel = 2;
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -773,27 +924,34 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingStackLev
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingProfileSourceReturnsProfiles) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{.id = profile_id_3,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3, ChargingLimitSourceEnum::EMS);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = stack_level + 1;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3, ChargingLimitSourceEnum::EMS);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {.chargingLimitSource = {{ChargingLimitSourceEnum::CSO}}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingLimitSource = {{ChargingLimitSourceEnum::CSO}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -804,28 +962,34 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingProfileS
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingProfileSourcesReturnsProfiles) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{.id = profile_id_3,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3, ChargingLimitSourceEnum::EMS);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = stack_level + 1;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3, ChargingLimitSourceEnum::EMS);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {
-        .chargingLimitSource = {{ChargingLimitSourceEnum::CSO, ChargingLimitSourceEnum::EMS}}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingLimitSource = {{ChargingLimitSourceEnum::CSO, ChargingLimitSourceEnum::EMS}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -836,29 +1000,36 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingProfileS
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_AllCriteriaSetReturnsOne) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{.id = profile_id_3,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3, ChargingLimitSourceEnum::CSO);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = stack_level + 1;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3, ChargingLimitSourceEnum::CSO);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile,
-                                         .stackLevel = 2,
-                                         .chargingLimitSource = {{ChargingLimitSourceEnum::CSO}}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    criteria.stackLevel = 2;
+    criteria.chargingLimitSource = {{ChargingLimitSourceEnum::CSO}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -869,29 +1040,36 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_AllCriteriaSetRe
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_AllCriteriaSetReturnsNone) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{.id = profile_id_3,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3, ChargingLimitSourceEnum::CSO);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = stack_level + 1;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3, ChargingLimitSourceEnum::CSO);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile,
-                                         .stackLevel = 2,
-                                         .chargingLimitSource = {{ChargingLimitSourceEnum::EMS}}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    criteria.stackLevel = 2;
+    criteria.chargingLimitSource = {{ChargingLimitSourceEnum::EMS}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -902,29 +1080,36 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_AllCriteriaSetRe
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_AllCriteriaSetReturnsNothing) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{.id = profile_id_3,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3, ChargingLimitSourceEnum::CSO);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = stack_level + 1;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3, ChargingLimitSourceEnum::CSO);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile,
-                                         .stackLevel = 2,
-                                         .chargingLimitSource = {{ChargingLimitSourceEnum::EMS}}};
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    criteria.stackLevel = 2;
+    criteria.chargingLimitSource = {{ChargingLimitSourceEnum::EMS}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(std::nullopt, criteria);
@@ -935,31 +1120,36 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_AllCriteriaSetRe
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteriaAndEvseId0_AllCriteriaSetReturnsNone) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile2);
 
     auto profile_id_3 = 3;
-    auto profile_3 = ChargingProfile{.id = profile_id_3,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_3, ChargingLimitSourceEnum::CSO);
+    ChargingProfile profile3;
+    profile3.id = profile_id_3;
+    profile3.stackLevel = stack_level + 1;
+    profile3.chargingProfilePurpose = ChargingProfilePurposeEnum::TxProfile;
+    profile3.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile3, ChargingLimitSourceEnum::CSO);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 3);
 
-    ChargingProfileCriterion criteria = {
-        .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile,
-        .stackLevel = 2,
-        .chargingLimitSource = {{ChargingLimitSourceEnum::CSO}},
-    };
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    criteria.stackLevel = 2;
+    criteria.chargingLimitSource = {{ChargingLimitSourceEnum::CSO}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(0, criteria);
@@ -970,102 +1160,115 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteriaAndEvseId0_AllCri
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_IfProfileIdAndEvseIdGiven_ReturnsMatchingProfile) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile_2);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile2);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 2);
 
-    ChargingProfileCriterion criteria = {
-        .chargingProfileId = {{profile_id_1, profile_id_2}},
-    };
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = {{profile_id_1, profile_id_2}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria(STATION_WIDE_ID, criteria);
     EXPECT_EQ(sut.size(), 1);
 
-    EXPECT_THAT(sut[0].profile, testing::Eq(profile_2));
+    EXPECT_THAT(sut[0].profile, testing::Eq(profile2));
 }
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingProfileIds_ReturnsEVSEAndSource) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile_2, ChargingLimitSourceEnum::EMS);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile2, ChargingLimitSourceEnum::EMS);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 2);
 
-    ChargingProfileCriterion criteria = {
-        .chargingProfileId = {{profile_id_1, profile_id_2}},
-    };
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = {{profile_id_1, profile_id_2}};
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria({}, criteria);
     EXPECT_EQ(sut.size(), 2);
 
-    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile_1, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO)));
-    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile_2, STATION_WIDE_ID, ChargingLimitSourceEnum::EMS)));
+    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile1, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO)));
+    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile2, STATION_WIDE_ID, ChargingLimitSourceEnum::EMS)));
 }
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_MatchingCriteria_ReturnsEVSEAndSource) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile_2, ChargingLimitSourceEnum::EMS);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile2, ChargingLimitSourceEnum::EMS);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 2);
 
-    ChargingProfileCriterion criteria = {
-        .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile,
-    };
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
 
     std::vector<ReportedChargingProfile> sut =
         this->database_handler.get_charging_profiles_matching_criteria({}, criteria);
     EXPECT_EQ(sut.size(), 2);
 
-    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile_1, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO)));
-    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile_2, STATION_WIDE_ID, ChargingLimitSourceEnum::EMS)));
+    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile1, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO)));
+    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile2, STATION_WIDE_ID, ChargingLimitSourceEnum::EMS)));
 }
 
 TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_OnlyEVSEIDSet_ReturnsProfileOnEVSE) {
     auto profile_id_1 = 1;
     auto stack_level = 1;
-    auto profile_1 = ChargingProfile{.id = profile_id_1,
-                                     .stackLevel = stack_level,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile_1);
+    ChargingProfile profile1;
+    profile1.id = profile_id_1;
+    profile1.stackLevel = stack_level;
+    profile1.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile1.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(DEFAULT_EVSE_ID, profile1);
 
     auto profile_id_2 = 2;
-    auto profile_2 = ChargingProfile{.id = profile_id_2,
-                                     .stackLevel = stack_level + 1,
-                                     .chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile};
-    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile_2, ChargingLimitSourceEnum::EMS);
+    ChargingProfile profile2;
+    profile2.id = profile_id_2;
+    profile2.stackLevel = stack_level + 1;
+    profile2.chargingProfilePurpose = ChargingProfilePurposeEnum::TxDefaultProfile;
+    profile2.chargingProfileKind = ChargingProfileKindEnum::Absolute;
+    this->database_handler.insert_or_update_charging_profile(STATION_WIDE_ID, profile2, ChargingLimitSourceEnum::EMS);
 
     auto profiles = this->database_handler.get_all_charging_profiles();
     EXPECT_EQ(profiles.size(), 2);
@@ -1074,5 +1277,5 @@ TEST_F(DatabaseHandlerTest, GetChargingProfilesMatchingCriteria_OnlyEVSEIDSet_Re
         this->database_handler.get_charging_profiles_matching_criteria(DEFAULT_EVSE_ID, {});
     EXPECT_EQ(sut.size(), 1);
 
-    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile_1, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO)));
+    EXPECT_THAT(sut, testing::Contains(testing::FieldsAre(profile1, DEFAULT_EVSE_ID, ChargingLimitSourceEnum::CSO)));
 }

--- a/tests/lib/ocpp/v201/test_device_model.cpp
+++ b/tests/lib/ocpp/v201/test_device_model.cpp
@@ -48,29 +48,31 @@ TEST_F(DeviceModelTest, test_allow_zero) {
 TEST_F(DeviceModelTest, test_component_as_key_in_map) {
     std::map<Component, int32_t> components_to_ints;
 
-    const Component base_comp = {.name = "Foo"};
+    Component base_comp;
+    base_comp.name = "Foo";
     components_to_ints[base_comp] = 1;
 
-    const Component different_instance_comp = {
-        .name = "Foo",
-        .instance = "bar",
-    };
-    const Component different_evse_comp = {
-        .name = "Foo",
-        .evse = EVSE{.id = 0},
-    };
-    const Component different_evse_and_instance_comp = {
-        .name = "Foo",
-        .evse = EVSE{.id = 0},
-        .instance = "bar",
-    };
-    const Component comp_with_custom_data = {
-        .name = "Foo",
-        .customData = json::object({{"vendorId", "Baz"}}),
-    };
-    const Component different_name_comp = {
-        .name = "Bar",
-    };
+    Component different_instance_comp;
+    different_instance_comp.name = "Foo";
+    different_instance_comp.instance = "bar";
+
+    Component different_evse_comp;
+    different_evse_comp.name = "Foo";
+    EVSE evse0;
+    evse0.id = 0;
+    different_evse_comp.evse = evse0;
+
+    Component different_evse_and_instance_comp;
+    different_evse_and_instance_comp.name = "Foo";
+    different_evse_and_instance_comp.evse = evse0;
+    different_evse_and_instance_comp.instance = "bar";
+
+    Component comp_with_custom_data;
+    comp_with_custom_data.name = "Foo";
+    comp_with_custom_data.customData = json::object({{"vendorId", "Baz"}});
+
+    Component different_name_comp;
+    different_name_comp.name = "Bar";
 
     EXPECT_EQ(components_to_ints.find(base_comp)->second, 1);
     EXPECT_EQ(components_to_ints.find(different_instance_comp), components_to_ints.end());
@@ -83,16 +85,21 @@ TEST_F(DeviceModelTest, test_component_as_key_in_map) {
 TEST_F(DeviceModelTest, test_set_monitors) {
     std::vector<SetMonitoringData> requests;
 
-    const EVSE evse = {.id = 2, .connectorId = 3};
+    EVSE evse;
+    evse.id = 2;
+    evse.connectorId = 3;
 
-    const Component component1 = {
-        .name = "UnitTestCtrlr",
-        .evse = evse,
-    };
-    const Component component2 = {.name = "AlignedDataCtrlr"};
+    Component component1;
+    component1.name = "UnitTestCtrlr";
+    component1.evse = evse;
 
-    const Variable variable_comp1 = {.name = "UnitTestPropertyAName"};
-    const Variable variable_comp2 = {.name = "Interval"};
+    Component component2;
+    component2.name = "AlignedDataCtrlr";
+
+    Variable variable_comp1;
+    variable_comp1.name = "UnitTestPropertyAName";
+    Variable variable_comp2;
+    variable_comp2.name = "Interval";
 
     std::vector<ComponentVariable> components = {
         {component1, std::nullopt, variable_comp1},
@@ -109,16 +116,18 @@ TEST_F(DeviceModelTest, test_set_monitors) {
         dm->clear_monitors(ids, true);
     }
 
-    const SetMonitoringData req_one{.value = 0.0,
-                                    .type = MonitorEnum::PeriodicClockAligned,
-                                    .severity = 7,
-                                    .component = component1,
-                                    .variable = variable_comp1};
-    const SetMonitoringData req_two{.value = 4.579,
-                                    .type = MonitorEnum::UpperThreshold,
-                                    .severity = 3,
-                                    .component = component2,
-                                    .variable = variable_comp2};
+    SetMonitoringData req_one;
+    req_one.value = 0.0;
+    req_one.type = MonitorEnum::PeriodicClockAligned;
+    req_one.severity = 7;
+    req_one.component = component1;
+    req_one.variable = variable_comp1;
+    SetMonitoringData req_two;
+    req_two.value = 4.579;
+    req_two.type = MonitorEnum::UpperThreshold;
+    req_two.severity = 3;
+    req_two.component = component2;
+    req_two.variable = variable_comp2;
 
     requests.push_back(req_one);
     requests.push_back(req_two);
@@ -138,16 +147,21 @@ TEST_F(DeviceModelTest, test_get_monitors) {
         MonitoringCriterionEnum::ThresholdMonitoring,
     };
 
-    const EVSE evse = {.id = 2, .connectorId = 3};
+    EVSE evse;
+    evse.id = 2;
+    evse.connectorId = 3;
 
-    const Component component1 = {
-        .name = "UnitTestCtrlr",
-        .evse = evse,
-    };
-    const Component component2 = {.name = "AlignedDataCtrlr"};
+    Component component1;
+    component1.name = "UnitTestCtrlr";
+    component1.evse = evse;
 
-    const Variable variable_comp1 = {.name = "UnitTestPropertyAName"};
-    const Variable variable_comp2 = {.name = "Interval"};
+    Component component2;
+    component2.name = "AlignedDataCtrlr";
+
+    Variable variable_comp1;
+    variable_comp1.name = "UnitTestPropertyAName";
+    Variable variable_comp2;
+    variable_comp2.name = "Interval";
 
     std::vector<ComponentVariable> components = {
         {component1, std::nullopt, variable_comp1},
@@ -161,11 +175,12 @@ TEST_F(DeviceModelTest, test_get_monitors) {
     auto monitor1 = results[0].variableMonitoring[0];
 
     // Valued used above
-    const SetMonitoringData req_one{.value = 0.0,
-                                    .type = MonitorEnum::PeriodicClockAligned,
-                                    .severity = 7,
-                                    .component = component1,
-                                    .variable = variable_comp1};
+    SetMonitoringData req_one;
+    req_one.value = 0.0;
+    req_one.type = MonitorEnum::PeriodicClockAligned;
+    req_one.severity = 7;
+    req_one.component = component1;
+    req_one.variable = variable_comp1;
 
     ASSERT_EQ(monitor1.severity, 7);
     ASSERT_EQ(monitor1.type, MonitorEnum::PeriodicClockAligned);
@@ -178,16 +193,20 @@ TEST_F(DeviceModelTest, test_clear_monitors) {
         MonitoringCriterionEnum::ThresholdMonitoring,
     };
 
-    const EVSE evse = {.id = 2, .connectorId = 3};
+    EVSE evse;
+    evse.id = 2;
+    evse.connectorId = 3;
 
-    const Component component1 = {
-        .name = "UnitTestCtrlr",
-        .evse = evse,
-    };
-    const Component component2 = {.name = "AlignedDataCtrlr"};
+    Component component1;
+    component1.name = "UnitTestCtrlr";
+    component1.evse = evse;
+    Component component2;
+    component2.name = "AlignedDataCtrlr";
 
-    const Variable variable_comp1 = {.name = "UnitTestPropertyAName"};
-    const Variable variable_comp2 = {.name = "Interval"};
+    Variable variable_comp1;
+    variable_comp1.name = "UnitTestPropertyAName";
+    Variable variable_comp2;
+    variable_comp2.name = "Interval";
 
     std::vector<ComponentVariable> components = {
         {component1, std::nullopt, variable_comp1},
@@ -195,16 +214,18 @@ TEST_F(DeviceModelTest, test_clear_monitors) {
     };
 
     // Insert some monitors that are hard-wired
-    const SetMonitoringData hardwired_one{.value = 0.0,
-                                          .type = MonitorEnum::PeriodicClockAligned,
-                                          .severity = 5,
-                                          .component = component1,
-                                          .variable = variable_comp1};
-    const SetMonitoringData hardwired_two{.value = 8.579,
-                                          .type = MonitorEnum::UpperThreshold,
-                                          .severity = 2,
-                                          .component = component2,
-                                          .variable = variable_comp2};
+    SetMonitoringData hardwired_one;
+    hardwired_one.value = 0.0;
+    hardwired_one.type = MonitorEnum::PeriodicClockAligned;
+    hardwired_one.severity = 5;
+    hardwired_one.component = component1;
+    hardwired_one.variable = variable_comp1;
+    SetMonitoringData hardwired_two;
+    hardwired_two.value = 8.579;
+    hardwired_two.type = MonitorEnum::UpperThreshold;
+    hardwired_two.severity = 2;
+    hardwired_two.component = component2;
+    hardwired_two.variable = variable_comp2;
 
     std::vector<SetMonitoringData> requests;
     requests.push_back(hardwired_one);

--- a/tests/lib/ocpp/v201/test_ocsp_updater.cpp
+++ b/tests/lib/ocpp/v201/test_ocsp_updater.cpp
@@ -35,64 +35,71 @@ protected:
         this->evse_security = std::make_shared<EvseSecurityMock>();
         this->status_update = [this](auto request) { return this->charge_point->get_certificate_status(request); };
 
-        this->example_ocsp_data.push_back(OCSPRequestData{.hashAlgorithm = HashAlgorithmEnumType::SHA256,
-                                                          .issuerNameHash = "issuerHash1",
-                                                          .issuerKeyHash = "issuerKey1",
-                                                          .serialNumber = "serial1",
-                                                          .responderUrl = "responder1"});
-        this->example_ocsp_data.push_back(OCSPRequestData{.hashAlgorithm = HashAlgorithmEnumType::SHA384,
-                                                          .issuerNameHash = "issuerHash2",
-                                                          .issuerKeyHash = "issuerKey2",
-                                                          .serialNumber = "serial2",
-                                                          .responderUrl = "responder2"});
-        this->example_ocsp_data.push_back(OCSPRequestData{.hashAlgorithm = HashAlgorithmEnumType::SHA512,
-                                                          .issuerNameHash = "issuerHash3",
-                                                          .issuerKeyHash = "issuerKey3",
-                                                          .serialNumber = "serial3",
-                                                          .responderUrl = "responder3"});
+        OCSPRequestData ocsp1;
+        ocsp1.hashAlgorithm = HashAlgorithmEnumType::SHA256;
+        ocsp1.issuerNameHash = "issuerHash1";
+        ocsp1.issuerKeyHash = "issuerKey1";
+        ocsp1.serialNumber = "serial1";
+        ocsp1.responderUrl = "responder1";
+        this->example_ocsp_data.push_back(ocsp1);
 
-        this->example_hash_data.push_back(CertificateHashDataType{
-            .hashAlgorithm = HashAlgorithmEnumType::SHA256,
-            .issuerNameHash = "issuerHash1",
-            .issuerKeyHash = "issuerKey1",
-            .serialNumber = "serial1",
-        });
-        this->example_hash_data.push_back(CertificateHashDataType{
-            .hashAlgorithm = HashAlgorithmEnumType::SHA384,
-            .issuerNameHash = "issuerHash2",
-            .issuerKeyHash = "issuerKey2",
-            .serialNumber = "serial2",
-        });
-        this->example_hash_data.push_back(CertificateHashDataType{
-            .hashAlgorithm = HashAlgorithmEnumType::SHA512,
-            .issuerNameHash = "issuerHash3",
-            .issuerKeyHash = "issuerKey3",
-            .serialNumber = "serial3",
-        });
+        OCSPRequestData ocsp2;
+        ocsp2.hashAlgorithm = HashAlgorithmEnumType::SHA384;
+        ocsp2.issuerNameHash = "issuerHash2";
+        ocsp2.issuerKeyHash = "issuerKey2";
+        ocsp2.serialNumber = "serial2";
+        ocsp2.responderUrl = "responder2";
+        this->example_ocsp_data.push_back(ocsp2);
+
+        OCSPRequestData ocsp3;
+        ocsp3.hashAlgorithm = HashAlgorithmEnumType::SHA512;
+        ocsp3.issuerNameHash = "issuerHash3";
+        ocsp3.issuerKeyHash = "issuerKey3";
+        ocsp3.serialNumber = "serial3";
+        ocsp3.responderUrl = "responder3";
+        this->example_ocsp_data.push_back(ocsp3);
+
+        CertificateHashDataType certificate_hash_data1;
+        certificate_hash_data1.hashAlgorithm = HashAlgorithmEnumType::SHA256;
+        certificate_hash_data1.issuerNameHash = "issuerHash1";
+        certificate_hash_data1.issuerKeyHash = "issuerKey1";
+        certificate_hash_data1.serialNumber = "serial1";
+        this->example_hash_data.push_back(certificate_hash_data1);
+
+        CertificateHashDataType certificate_hash_data2;
+        certificate_hash_data2.hashAlgorithm = HashAlgorithmEnumType::SHA384;
+        certificate_hash_data2.issuerNameHash = "issuerHash2";
+        certificate_hash_data2.issuerKeyHash = "issuerKey2";
+        certificate_hash_data2.serialNumber = "serial2";
+        this->example_hash_data.push_back(certificate_hash_data2);
+
+        CertificateHashDataType certificate_hash_data3;
+        certificate_hash_data3.hashAlgorithm = HashAlgorithmEnumType::SHA512;
+        certificate_hash_data3.issuerNameHash = "issuerHash3";
+        certificate_hash_data3.issuerKeyHash = "issuerKey3";
+        certificate_hash_data3.serialNumber = "serial3";
+        this->example_hash_data.push_back(certificate_hash_data3);
 
         v201::GetCertificateStatusRequest example_get_cert_status_request_1;
-        example_get_cert_status_request_1.ocspRequestData =
-            v201::OCSPRequestData{.hashAlgorithm = v201::HashAlgorithmEnum::SHA256,
-                                  .issuerNameHash = "issuerHash1",
-                                  .issuerKeyHash = "issuerKey1",
-                                  .serialNumber = "serial1",
-                                  .responderURL = "responder1"};
+        example_get_cert_status_request_1.ocspRequestData.hashAlgorithm = v201::HashAlgorithmEnum::SHA256;
+        example_get_cert_status_request_1.ocspRequestData.issuerNameHash = "issuerHash1";
+        example_get_cert_status_request_1.ocspRequestData.issuerKeyHash = "issuerKey1";
+        example_get_cert_status_request_1.ocspRequestData.serialNumber = "serial1";
+        example_get_cert_status_request_1.ocspRequestData.responderURL = "responder1";
         this->example_status_requests.push_back(example_get_cert_status_request_1);
         v201::GetCertificateStatusRequest example_get_cert_status_request_2;
-        example_get_cert_status_request_2.ocspRequestData =
-            v201::OCSPRequestData{.hashAlgorithm = v201::HashAlgorithmEnum::SHA384,
-                                  .issuerNameHash = "issuerHash2",
-                                  .issuerKeyHash = "issuerKey2",
-                                  .serialNumber = "serial2",
-                                  .responderURL = "responder2"};
+        example_get_cert_status_request_2.ocspRequestData.hashAlgorithm = v201::HashAlgorithmEnum::SHA384;
+        example_get_cert_status_request_2.ocspRequestData.issuerNameHash = "issuerHash2";
+        example_get_cert_status_request_2.ocspRequestData.issuerKeyHash = "issuerKey2";
+        example_get_cert_status_request_2.ocspRequestData.serialNumber = "serial2";
+        example_get_cert_status_request_2.ocspRequestData.responderURL = "responder2";
         this->example_status_requests.push_back(example_get_cert_status_request_2);
         v201::GetCertificateStatusRequest example_get_cert_status_request_3;
-        example_get_cert_status_request_3.ocspRequestData =
-            v201::OCSPRequestData{.hashAlgorithm = v201::HashAlgorithmEnum::SHA512,
-                                  .issuerNameHash = "issuerHash3",
-                                  .issuerKeyHash = "issuerKey3",
-                                  .serialNumber = "serial3",
-                                  .responderURL = "responder3"};
+        example_get_cert_status_request_3.ocspRequestData.hashAlgorithm = v201::HashAlgorithmEnum::SHA512;
+        example_get_cert_status_request_3.ocspRequestData.issuerNameHash = "issuerHash3";
+        example_get_cert_status_request_3.ocspRequestData.issuerKeyHash = "issuerKey3";
+        example_get_cert_status_request_3.ocspRequestData.serialNumber = "serial3";
+        example_get_cert_status_request_3.ocspRequestData.responderURL = "responder3";
         this->example_status_requests.push_back(example_get_cert_status_request_3);
     }
 

--- a/tests/lib/ocpp/v201/test_profile.cpp
+++ b/tests/lib/ocpp/v201/test_profile.cpp
@@ -27,11 +27,13 @@ using std::chrono::minutes;
 using std::chrono::seconds;
 
 period_entry_t gen_pe(ocpp::DateTime start, ocpp::DateTime end, ChargingProfile profile, int period_at) {
-    return {.start = start,
-            .end = end,
-            .limit = profile.chargingSchedule.front().chargingSchedulePeriod[period_at].limit,
-            .stack_level = profile.stackLevel,
-            .charging_rate_unit = profile.chargingSchedule.front().chargingRateUnit};
+    period_entry_t period_entry;
+    period_entry.start = start;
+    period_entry.end = end;
+    period_entry.limit = profile.chargingSchedule.front().chargingSchedulePeriod[period_at].limit;
+    period_entry.stack_level = profile.stackLevel;
+    period_entry.charging_rate_unit = profile.chargingSchedule.front().chargingRateUnit;
+    return period_entry;
 }
 
 const ChargingProfile absolute_profile =
@@ -51,13 +53,17 @@ const ChargingProfile weekly_profile =
 const ChargingProfile weekly_profile_no_duration =
     SmartChargingTestUtils::get_charging_profile_from_file("singles/Recurring_Weekly_NoDuration_301.json");
 
-CompositeSchedule DEFAULT_SCHEDULE = {
-    .chargingSchedulePeriod = {},
-    .evseId = EVSEID_NOT_SET,
-    .duration = 600,
-    .scheduleStart = dt("12:00"),
-    .chargingRateUnit = ChargingRateUnitEnum::A,
-};
+CompositeSchedule generate_default_schedule() {
+    CompositeSchedule schedule;
+    schedule.chargingSchedulePeriod = {};
+    schedule.evseId = EVSEID_NOT_SET;
+    schedule.duration = 600;
+    schedule.scheduleStart = dt("12:00");
+    schedule.chargingRateUnit = ChargingRateUnitEnum::A;
+    return schedule;
+}
+
+CompositeSchedule DEFAULT_SCHEDULE = generate_default_schedule();
 
 class ChargingProfileType_Param_Test
     : public ::testing::TestWithParam<std::tuple<ocpp::DateTime, ocpp::DateTime, std::optional<ocpp::DateTime>,
@@ -240,11 +246,12 @@ TEST_P(CalculateProfileEntryType_Param_Test, CalculateProfileEntry_Positive) {
     std::vector<period_entry_t> period_entries =
         calculate_profile_entry(now, end, session_start, profile, period_index);
 
-    period_entry_t expected_entry{.start = expected_start,
-                                  .end = expected_end,
-                                  .limit = profile.chargingSchedule.front().chargingSchedulePeriod[period_index].limit,
-                                  .stack_level = profile.stackLevel,
-                                  .charging_rate_unit = profile.chargingSchedule.front().chargingRateUnit};
+    period_entry_t expected_entry;
+    expected_entry.start = expected_start;
+    expected_entry.end = expected_end;
+    expected_entry.limit = profile.chargingSchedule.front().chargingSchedulePeriod[period_index].limit;
+    expected_entry.stack_level = profile.stackLevel;
+    expected_entry.charging_rate_unit = profile.chargingSchedule.front().chargingRateUnit;
 
     for (period_entry_t pet : period_entries) {
         EVLOG_debug << ">>> " << pet;
@@ -257,12 +264,12 @@ TEST_P(CalculateProfileEntryType_Param_Test, CalculateProfileEntry_Positive) {
     } else {
         period_entry_t second_entry = period_entries.at(1);
 
-        period_entry_t expected_second_entry{
-            .start = expected_2nd_entry_start.value(),
-            .end = expected_2nd_entry_end.value(),
-            .limit = profile.chargingSchedule.front().chargingSchedulePeriod[period_index].limit,
-            .stack_level = profile.stackLevel,
-            .charging_rate_unit = profile.chargingSchedule.front().chargingRateUnit};
+        period_entry_t expected_second_entry;
+        expected_second_entry.start = expected_2nd_entry_start.value();
+        expected_second_entry.end = expected_2nd_entry_end.value();
+        expected_second_entry.limit = profile.chargingSchedule.front().chargingSchedulePeriod[period_index].limit;
+        expected_second_entry.stack_level = profile.stackLevel;
+        expected_second_entry.charging_rate_unit = profile.chargingSchedule.front().chargingRateUnit;
 
         EVLOG_debug << "         second_entry> " << second_entry;
         EVLOG_debug << "expected_second_entry> " << expected_second_entry;
@@ -334,18 +341,20 @@ TEST_P(CalculateProfileEntryType_NegativeBoundary_Param_Test, CalculateProfileEn
 }
 
 TEST(OCPPTypesTest, PeriodEntry_Equality) {
-    period_entry_t actual_entry{.start = dt("2T08:45"),
-                                .end = dt("3T08:00"),
-                                .limit = absolute_profile.chargingSchedule.front().chargingSchedulePeriod[0].limit,
-                                .stack_level = absolute_profile.stackLevel,
-                                .charging_rate_unit = absolute_profile.chargingSchedule.front().chargingRateUnit};
+    period_entry_t actual_entry;
+    actual_entry.start = dt("2T08:45");
+    actual_entry.end = dt("3T08:00");
+    actual_entry.limit = absolute_profile.chargingSchedule.front().chargingSchedulePeriod[0].limit;
+    actual_entry.stack_level = absolute_profile.stackLevel;
+    actual_entry.charging_rate_unit = absolute_profile.chargingSchedule.front().chargingRateUnit;
     period_entry_t same_entry = actual_entry;
 
-    period_entry_t different_entry{.start = dt("3T08:00"),
-                                   .end = dt("3T08:00"),
-                                   .limit = absolute_profile.chargingSchedule.front().chargingSchedulePeriod[0].limit,
-                                   .stack_level = absolute_profile.stackLevel,
-                                   .charging_rate_unit = absolute_profile.chargingSchedule.front().chargingRateUnit};
+    period_entry_t different_entry;
+    different_entry.start = dt("3T08:00");
+    different_entry.end = dt("3T08:00");
+    different_entry.limit = absolute_profile.chargingSchedule.front().chargingSchedulePeriod[0].limit;
+    different_entry.stack_level = absolute_profile.stackLevel;
+    different_entry.charging_rate_unit = absolute_profile.chargingSchedule.front().chargingRateUnit;
 
     ASSERT_EQ(actual_entry, same_entry);
     ASSERT_NE(actual_entry, different_entry);
@@ -558,14 +567,14 @@ TEST(OCPPTypesTest, CalculateProfile_RelativeLimited) {
 }
 
 TEST(OCPPTypesTest, ChargingSchedulePeriod_Equality) {
-    ChargingSchedulePeriod period1 = ChargingSchedulePeriod{
-        .startPeriod = 0,
-        .limit = NO_LIMIT_SPECIFIED,
-    };
-    ChargingSchedulePeriod period2 = ChargingSchedulePeriod{
-        .startPeriod = 0,
-        .limit = NO_LIMIT_SPECIFIED,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = NO_LIMIT_SPECIFIED;
+
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 0;
+    period2.limit = NO_LIMIT_SPECIFIED;
+
     ASSERT_EQ(period1, period1);
     ASSERT_EQ(period1, period2);
 
@@ -580,10 +589,9 @@ TEST(OCPPTypesTest, ChargingSchedulePeriod_Equality) {
     period1.limit = 1;
     ASSERT_NE(period1, period2);
 
-    period2 = ChargingSchedulePeriod{
-        .startPeriod = 0,
-        .limit = 1,
-    };
+    period2.startPeriod = 0;
+    period2.limit = 1;
+
     ASSERT_EQ(period1, period2);
 
     // Optional phases
@@ -602,24 +610,26 @@ TEST(OCPPTypesTest, ChargingSchedulePeriod_Equality) {
 }
 
 TEST(OCPPTypesTest, ChargingSchedule_Equality) {
-    std::vector<ChargingSchedulePeriod> periods = {ChargingSchedulePeriod{
-                                                       .startPeriod = 0,
-                                                       .limit = 10,
-                                                   },
-                                                   ChargingSchedulePeriod{
-                                                       .startPeriod = 100,
-                                                       .limit = 20,
-                                                   }};
-    ChargingSchedule schedule1 = ChargingSchedule{
-        .id = 0,
-        .chargingSchedulePeriod = periods,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-    };
-    ChargingSchedule schedule2 = ChargingSchedule{
-        .id = 0,
-        .chargingSchedulePeriod = {periods.at(0)},
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 10;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 100;
+    period2.limit = 20;
+    std::vector<ChargingSchedulePeriod> periods = {period1, period2};
+
+    ChargingSchedule schedule1;
+    schedule1.id = 0;
+    schedule1.chargingSchedulePeriod = periods;
+    schedule1.chargingRateUnit = ChargingRateUnitEnum::W;
+    schedule1.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+
+    ChargingSchedule schedule2;
+    schedule2.id = 0;
+    schedule2.chargingSchedulePeriod = {periods.at(0)};
+    schedule2.chargingRateUnit = ChargingRateUnitEnum::W;
+    schedule2.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+
     ASSERT_NE(schedule1, schedule2);
 
     // Perios must match
@@ -669,12 +679,15 @@ TEST(OCPPTypesTest, ChargingSchedule_Equality) {
 
 TEST(OCPPTypesTest, CalculateChargingSchedule_Empty) {
     std::vector<period_entry_t> combined_schedules{};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = NO_LIMIT_SPECIFIED}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A};
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = NO_LIMIT_SPECIFIED;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = dt("12:00");
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, dt("12:00"), dt("12:10"), std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -687,17 +700,17 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_Exact) {
     DateTime end = dt("12:10");
     std::vector<period_entry_t> combined_schedules{
         {now, end, 24.0, 3, std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-            .startPeriod = 0,
-            .limit = 24.0,
-            .numberPhases = 3,
-        }},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = 24.0;
+    period.numberPhases = 3;
+
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, ChargingRateUnitEnum::A,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -711,18 +724,19 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_ShortExact) {
     std::vector<period_entry_t> combined_schedules{{now, DateTime(end.to_time_point() - seconds(1)), 24.0, 3,
                                                     std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
 
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-                                       .startPeriod = 0,
-                                       .limit = 24.0,
-                                       .numberPhases = 3,
-                                   },
-                                   ChargingSchedulePeriod{.startPeriod = 599, .limit = NO_LIMIT_SPECIFIED}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 24.0;
+    period1.numberPhases = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 599;
+    period2.limit = NO_LIMIT_SPECIFIED;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, ChargingRateUnitEnum::A,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -736,17 +750,17 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_LongExact) {
     std::vector<period_entry_t> combined_schedules{{DateTime(now.to_time_point() - seconds(1)), end, 24.0, 3,
                                                     std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
 
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-            .startPeriod = 0,
-            .limit = 24.0,
-            .numberPhases = 3,
-        }},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = 24.0;
+    period.numberPhases = 3;
+
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, ChargingRateUnitEnum::A,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -760,19 +774,23 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_AlmostExact) {
     std::vector<period_entry_t> combined_schedules{{DateTime(now.to_time_point() + seconds(1)),
                                                     DateTime(end.to_time_point() - seconds(1)), 24.0, 3, std::nullopt,
                                                     1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = NO_LIMIT_SPECIFIED},
-                                   ChargingSchedulePeriod{
-                                       .startPeriod = 1,
-                                       .limit = 24.0,
-                                       .numberPhases = 3,
-                                   },
-                                   ChargingSchedulePeriod{.startPeriod = 599, .limit = NO_LIMIT_SPECIFIED}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = NO_LIMIT_SPECIFIED;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 1;
+    period2.limit = 24.0;
+    period2.numberPhases = 3;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 599;
+    period3.limit = NO_LIMIT_SPECIFIED;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -785,17 +803,16 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_SingleLong) {
     DateTime end = dt("12:10");
     std::vector<period_entry_t> combined_schedules{
         {dt("11:00"), dt("12:30"), 24.0, 3, std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-            .startPeriod = 1,
-            .limit = 24.0,
-            .numberPhases = 3,
-        }},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period;
+    period.startPeriod = 1;
+    period.limit = 24.0;
+    period.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -808,18 +825,19 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_SingleShort) {
     DateTime end = dt("12:10");
     std::vector<period_entry_t> combined_schedules{
         {dt("11:00"), dt("12:05"), 24.0, 3, std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-                                       .startPeriod = 0,
-                                       .limit = 24.0,
-                                       .numberPhases = 3,
-                                   },
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = NO_LIMIT_SPECIFIED}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 24.0;
+    period1.numberPhases = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = NO_LIMIT_SPECIFIED;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -832,17 +850,17 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_SingleDelayedStartLong) {
     DateTime end = dt("12:10");
     std::vector<period_entry_t> combined_schedules{
         {dt("12:02"), dt("12:30"), 24.0, 3, std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-                                       .startPeriod = 0,
-                                       .limit = NO_LIMIT_SPECIFIED,
-                                   },
-                                   ChargingSchedulePeriod{.startPeriod = 120, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = NO_LIMIT_SPECIFIED;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 120, period2.limit = 24.0, period2.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -856,14 +874,20 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_OverlapStart) {
     std::vector<period_entry_t> combined_schedules{
         {dt("12:05"), dt("13:00"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("11:30"), dt("12:30"), 24.0, 3, std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 24.0, .numberPhases = 3},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 32.0, .numberPhases = 1}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 24.0;
+    period1.numberPhases = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 32.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -877,14 +901,20 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_OverlapEnd) {
     std::vector<period_entry_t> combined_schedules{
         {dt("11:30"), dt("12:05"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("11:30"), dt("12:30"), 24.0, 3, std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 32.0, .numberPhases = 1},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 32.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 24.0;
+    period2.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -898,15 +928,24 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_OverlapMiddle) {
     std::vector<period_entry_t> combined_schedules{
         {dt("12:02"), dt("12:05"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("11:30"), dt("12:30"), 24.0, 3, std::nullopt, 1, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 24.0, .numberPhases = 3},
-                                   ChargingSchedulePeriod{.startPeriod = 120, .limit = 32.0, .numberPhases = 1},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 24.0;
+    period1.numberPhases = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 120;
+    period2.limit = 32.0;
+    period2.numberPhases = 1;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 300;
+    period3.limit = 24.0;
+    period3.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -920,13 +959,16 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_OverlapIgnore) {
     std::vector<period_entry_t> combined_schedules{
         {dt("12:05"), dt("13:00"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("11:30"), dt("12:30"), 24.0, 3, std::nullopt, 31, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = 24.0;
+    period.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -940,14 +982,20 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_NoGapA) {
     std::vector<period_entry_t> combined_schedules{
         {dt("11:50"), dt("12:05"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("12:05"), dt("12:30"), 24.0, 3, std::nullopt, 31, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 32.0, .numberPhases = 1},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 32.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 24.0;
+    period2.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -961,14 +1009,20 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_NoGapB) {
     std::vector<period_entry_t> combined_schedules{
         {dt("12:05"), dt("12:30"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("11:50"), dt("12:05"), 24.0, 3, std::nullopt, 31, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 24.0, .numberPhases = 3},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 32.0, .numberPhases = 1}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 24.0;
+    period1.numberPhases = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 32.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -982,14 +1036,20 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_Overlap) {
     std::vector<period_entry_t> combined_schedules{
         {dt("11:50"), dt("12:05"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("12:05"), dt("12:30"), 24.0, 3, std::nullopt, 31, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 32.0, .numberPhases = 1},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 32.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 24.0;
+    period2.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -1004,14 +1064,20 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_OverlapInverted) {
     std::vector<period_entry_t> combined_schedules{
         {dt("12:05"), dt("12:30"), 32.0, 1, std::nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("11:50"), dt("12:05"), 24.0, 3, std::nullopt, 31, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 24.0, .numberPhases = 3},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 32.0, .numberPhases = 1}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 24.0;
+    period1.numberPhases = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 32.0;
+    period2.numberPhases = 1;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -1025,15 +1091,23 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_1SecondGap) {
     std::vector<period_entry_t> combined_schedules{
         {dt("11:50"), DateTime{"2024-01-01T12:04:59Z"}, 32.0, 1, nullopt, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("12:05"), dt("12:30"), 24.0, 3, nullopt, 31, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{.startPeriod = 0, .limit = 32.0, .numberPhases = 1},
-                                   ChargingSchedulePeriod{.startPeriod = 299, .limit = NO_LIMIT_SPECIFIED},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 32.0;
+    period1.numberPhases = 1;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 299;
+    period2.limit = NO_LIMIT_SPECIFIED;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 300;
+    period3.limit = 24.0;
+    period3.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -1047,16 +1121,24 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_WithPhaseToUse) {
     std::vector<period_entry_t> combined_schedules{
         {dt("11:50"), DateTime{"2024-01-01T12:04:59Z"}, 32.0, 1, 3, 21, ChargingRateUnitEnum::A, std::nullopt},
         {dt("12:05"), dt("12:30"), 24.0, 3, std::nullopt, 31, ChargingRateUnitEnum::A, std::nullopt}};
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-                                       .startPeriod = 0, .limit = 32.0, .numberPhases = 1, .phaseToUse = 3},
-                                   ChargingSchedulePeriod{.startPeriod = 299, .limit = NO_LIMIT_SPECIFIED},
-                                   ChargingSchedulePeriod{.startPeriod = 300, .limit = 24.0, .numberPhases = 3}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count(),
-        .scheduleStart = now,
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 32.0;
+    period1.numberPhases = 1;
+    period1.phaseToUse = 3;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 299;
+    period2.limit = NO_LIMIT_SPECIFIED;
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 300;
+    period3.limit = 24.0;
+    period3.numberPhases = 3;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period1, period2, period3};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = std::chrono::duration_cast<std::chrono::seconds>(minutes(10)).count();
+    expected.scheduleStart = now;
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     CompositeSchedule actual = calculate_composite_schedule(combined_schedules, now, end, std::nullopt,
                                                             DEFAULT_AND_MAX_NUMBER_PHASES, LOW_VOLTAGE);
@@ -1065,15 +1147,16 @@ TEST(OCPPTypesTest, CalculateChargingSchedule_WithPhaseToUse) {
 }
 
 TEST(OCPPTypesTest, CalculateChargingScheduleCombined_Default) {
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-            .startPeriod = 0, .limit = DEFAULT_LIMIT_AMPS, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = DEFAULT_SCHEDULE.duration,
-        .scheduleStart = DEFAULT_SCHEDULE.scheduleStart,
-        .chargingRateUnit = DEFAULT_SCHEDULE.chargingRateUnit,
-
-    };
+    ChargingSchedulePeriod period;
+    period.startPeriod = 0;
+    period.limit = DEFAULT_LIMIT_AMPS;
+    period.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = DEFAULT_SCHEDULE.duration;
+    expected.scheduleStart = DEFAULT_SCHEDULE.scheduleStart;
+    expected.chargingRateUnit = DEFAULT_SCHEDULE.chargingRateUnit;
 
     const CompositeSchedule actual = calculate_composite_schedule(DEFAULT_SCHEDULE, DEFAULT_SCHEDULE, DEFAULT_SCHEDULE,
                                                                   DEFAULT_SCHEDULE, DEFAULT_LIMITS, LOW_VOLTAGE);
@@ -1083,21 +1166,26 @@ TEST(OCPPTypesTest, CalculateChargingScheduleCombined_Default) {
 
 TEST(OCPPTypesTest, CalculateChargingScheduleCombined_CombinedTxDefault) {
     CompositeSchedule profile = DEFAULT_SCHEDULE;
-    CompositeSchedule tx_default_schedule = {
-        .chargingSchedulePeriod = {{0, 10.0, nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
-    CompositeSchedule expected = CompositeSchedule{
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-            .startPeriod = 0, .limit = 10, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 10.0;
+    CompositeSchedule tx_default_schedule;
+    tx_default_schedule.chargingSchedulePeriod = {period1};
+    tx_default_schedule.evseId = EVSEID_NOT_SET;
+    tx_default_schedule.duration = 600;
+    tx_default_schedule.scheduleStart = dt("12:00");
+    tx_default_schedule.chargingRateUnit = ChargingRateUnitEnum::A;
+
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 0;
+    period2.limit = 10;
+    period2.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period2};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = 600;
+    expected.scheduleStart = dt("12:00");
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     const CompositeSchedule actual =
         calculate_composite_schedule(profile, profile, tx_default_schedule, profile, DEFAULT_LIMITS, LOW_VOLTAGE);
@@ -1107,29 +1195,35 @@ TEST(OCPPTypesTest, CalculateChargingScheduleCombined_CombinedTxDefault) {
 
 TEST(OCPPTypesTest, CalculateChargingScheduleCombined_CombinedTxDefaultTx) {
     CompositeSchedule charging_station_max = DEFAULT_SCHEDULE;
-    CompositeSchedule tx_default_schedule = {
-        .chargingSchedulePeriod = {{0, 10.0, nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
-    CompositeSchedule tx_schedule = {
-        .chargingSchedulePeriod = {{0, 32.0, nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 10.0;
+    CompositeSchedule tx_default_schedule;
+    tx_default_schedule.chargingSchedulePeriod = {period1};
+    tx_default_schedule.evseId = EVSEID_NOT_SET;
+    tx_default_schedule.duration = 600;
+    tx_default_schedule.scheduleStart = dt("12:00");
+    tx_default_schedule.chargingRateUnit = ChargingRateUnitEnum::A;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 0;
+    period2.limit = 32.0;
+    CompositeSchedule tx_schedule;
+    tx_schedule.chargingSchedulePeriod = {period2};
+    tx_schedule.evseId = EVSEID_NOT_SET;
+    tx_schedule.duration = 600;
+    tx_schedule.scheduleStart = dt("12:00");
+    tx_schedule.chargingRateUnit = ChargingRateUnitEnum::A;
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod = {ChargingSchedulePeriod{
-            .startPeriod = 0, .limit = 32.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 0;
+    period3.limit = 32.0;
+    period3.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period3};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = 600;
+    expected.scheduleStart = dt("12:00");
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     const CompositeSchedule actual = calculate_composite_schedule(
         DEFAULT_SCHEDULE, charging_station_max, tx_default_schedule, tx_schedule, DEFAULT_LIMITS, LOW_VOLTAGE);
@@ -1138,42 +1232,64 @@ TEST(OCPPTypesTest, CalculateChargingScheduleCombined_CombinedTxDefaultTx) {
 }
 
 TEST(OCPPTypesTest, CalculateChargingScheduleCombined_CombinedOverlapTxAndTxDefault) {
-    CompositeSchedule tx_default_schedule = {
-        .chargingSchedulePeriod = {{0, 10.0, std::nullopt}, {300, 24.0, nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 10.0;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 24.0;
+    CompositeSchedule tx_default_schedule;
+    tx_default_schedule.chargingSchedulePeriod = {period1, period2};
+    tx_default_schedule.evseId = EVSEID_NOT_SET;
+    tx_default_schedule.duration = 600;
+    tx_default_schedule.scheduleStart = dt("12:00");
+    tx_default_schedule.chargingRateUnit = ChargingRateUnitEnum::A;
 
-    CompositeSchedule tx_schedule = {
-        .chargingSchedulePeriod = {{0, NO_LIMIT_SPECIFIED, nullopt},
-                                   {150, 32.0, std::nullopt},
-                                   {450, NO_LIMIT_SPECIFIED, nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 0;
+    period3.limit = NO_LIMIT_SPECIFIED;
+    ChargingSchedulePeriod period4;
+    period4.startPeriod = 150;
+    period4.limit = 32.0;
+    ChargingSchedulePeriod period5;
+    period5.startPeriod = 450;
+    period5.limit = NO_LIMIT_SPECIFIED;
+    CompositeSchedule tx_schedule;
+    tx_schedule.chargingSchedulePeriod = {period3, period4, period5};
+    tx_schedule.evseId = EVSEID_NOT_SET;
+    tx_schedule.duration = 600;
+    tx_schedule.scheduleStart = dt("12:00");
+    tx_schedule.chargingRateUnit = ChargingRateUnitEnum::A;
 
-    CompositeSchedule charging_station_max = {
-        .chargingSchedulePeriod = {{0, NO_LIMIT_SPECIFIED, nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period6;
+    period6.startPeriod = 0;
+    period6.limit = NO_LIMIT_SPECIFIED;
+    CompositeSchedule charging_station_max;
+    charging_station_max.chargingSchedulePeriod = {period6};
+    charging_station_max.evseId = EVSEID_NOT_SET;
+    charging_station_max.duration = 600;
+    charging_station_max.scheduleStart = dt("12:00");
+    charging_station_max.chargingRateUnit = ChargingRateUnitEnum::A;
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod =
-            {ChargingSchedulePeriod{.startPeriod = 0, .limit = 10.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES},
-             ChargingSchedulePeriod{.startPeriod = 150, .limit = 32.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES},
-             ChargingSchedulePeriod{.startPeriod = 450, .limit = 24.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period7;
+    period7.startPeriod = 0;
+    period7.limit = 10.0;
+    period7.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    ChargingSchedulePeriod period8;
+    period8.startPeriod = 150;
+    period8.limit = 32.0;
+    period8.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    ChargingSchedulePeriod period9;
+    period9.startPeriod = 450;
+    period9.limit = 24.0;
+    period9.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period7, period8, period9};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = 600;
+    expected.scheduleStart = dt("12:00");
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     const CompositeSchedule actual = calculate_composite_schedule(
         DEFAULT_SCHEDULE, charging_station_max, tx_default_schedule, tx_schedule, DEFAULT_LIMITS, LOW_VOLTAGE);
@@ -1182,46 +1298,80 @@ TEST(OCPPTypesTest, CalculateChargingScheduleCombined_CombinedOverlapTxAndTxDefa
 }
 
 TEST(OCPPTypesTest, CalculateChargingScheduleCombined_CombinedOverlapTxTxDefaultAndChargingStationMax) {
-    CompositeSchedule tx_default_schedule = {
-        .chargingSchedulePeriod = {{0, 10.0, std::nullopt}, {300, 24.0, std::nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period1;
+    period1.startPeriod = 0;
+    period1.limit = 10.0;
+    ChargingSchedulePeriod period2;
+    period2.startPeriod = 300;
+    period2.limit = 24.0;
+    CompositeSchedule tx_default_schedule;
+    tx_default_schedule.chargingSchedulePeriod = {period1, period2};
+    tx_default_schedule.evseId = EVSEID_NOT_SET;
+    tx_default_schedule.duration = 600;
+    tx_default_schedule.scheduleStart = dt("12:00");
+    tx_default_schedule.chargingRateUnit = ChargingRateUnitEnum::A;
 
-    CompositeSchedule tx_schedule = {
-        .chargingSchedulePeriod = {{0, NO_LIMIT_SPECIFIED, std::nullopt},
-                                   {150, 32.0, std::nullopt},
-                                   {450, NO_LIMIT_SPECIFIED, std::nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period3;
+    period3.startPeriod = 0;
+    period3.limit = NO_LIMIT_SPECIFIED;
+    ChargingSchedulePeriod period4;
+    period4.startPeriod = 150;
+    period4.limit = 32.0;
+    ChargingSchedulePeriod period5;
+    period5.startPeriod = 450;
+    period5.limit = NO_LIMIT_SPECIFIED;
 
-    CompositeSchedule charging_station_max = {
-        .chargingSchedulePeriod = {{0, NO_LIMIT_SPECIFIED, std::nullopt},
-                                   {500, 15.0, std::nullopt},
-                                   {550, NO_LIMIT_SPECIFIED, std::nullopt}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    CompositeSchedule tx_schedule;
+    tx_schedule.chargingSchedulePeriod = {period3, period4, period5};
+    tx_schedule.evseId = EVSEID_NOT_SET;
+    tx_schedule.duration = 600;
+    tx_schedule.scheduleStart = dt("12:00");
+    tx_schedule.chargingRateUnit = ChargingRateUnitEnum::A;
 
-    CompositeSchedule expected = {
-        .chargingSchedulePeriod =
-            {ChargingSchedulePeriod{.startPeriod = 0, .limit = 10.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES},
-             ChargingSchedulePeriod{.startPeriod = 150, .limit = 32.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES},
-             ChargingSchedulePeriod{.startPeriod = 450, .limit = 24.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES},
-             ChargingSchedulePeriod{.startPeriod = 500, .limit = 15.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES},
-             ChargingSchedulePeriod{.startPeriod = 550, .limit = 24.0, .numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES}},
-        .evseId = EVSEID_NOT_SET,
-        .duration = 600,
-        .scheduleStart = dt("12:00"),
-        .chargingRateUnit = ChargingRateUnitEnum::A,
-    };
+    ChargingSchedulePeriod period6;
+    period6.startPeriod = 0;
+    period6.limit = NO_LIMIT_SPECIFIED;
+    ChargingSchedulePeriod period7;
+    period7.startPeriod = 500;
+    period7.limit = 15.0;
+    ChargingSchedulePeriod period8;
+    period8.startPeriod = 550;
+    period8.limit = NO_LIMIT_SPECIFIED;
+    CompositeSchedule charging_station_max;
+    charging_station_max.chargingSchedulePeriod = {period6, period7, period8};
+    charging_station_max.evseId = EVSEID_NOT_SET;
+    charging_station_max.duration = 600;
+    charging_station_max.scheduleStart = dt("12:00");
+    charging_station_max.chargingRateUnit = ChargingRateUnitEnum::A;
+
+    ChargingSchedulePeriod period_expected1;
+    period_expected1.startPeriod = 0;
+    period_expected1.limit = 10.0;
+    period_expected1.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    ChargingSchedulePeriod period_expected2;
+    period_expected2.startPeriod = 150;
+    period_expected2.limit = 32.0;
+    period_expected2.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    ChargingSchedulePeriod period_expected3;
+    period_expected3.startPeriod = 450;
+    period_expected3.limit = 24.0;
+    period_expected3.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    ChargingSchedulePeriod period_expected4;
+    period_expected4.startPeriod = 500;
+    period_expected4.limit = 15.0;
+    period_expected4.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+    ChargingSchedulePeriod period_expected5;
+    period_expected5.startPeriod = 550;
+    period_expected5.limit = 24.0;
+    period_expected5.numberPhases = DEFAULT_AND_MAX_NUMBER_PHASES;
+
+    CompositeSchedule expected;
+    expected.chargingSchedulePeriod = {period_expected1, period_expected2, period_expected3, period_expected4,
+                                       period_expected5};
+    expected.evseId = EVSEID_NOT_SET;
+    expected.duration = 600;
+    expected.scheduleStart = dt("12:00");
+    expected.chargingRateUnit = ChargingRateUnitEnum::A;
 
     const CompositeSchedule actual = calculate_composite_schedule(
         DEFAULT_SCHEDULE, charging_station_max, tx_default_schedule, tx_schedule, DEFAULT_LIMITS, LOW_VOLTAGE);

--- a/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v201/test_smart_charging_handler.cpp
@@ -114,11 +114,10 @@ protected:
     std::vector<ChargingSchedulePeriod>
     create_charging_schedule_periods(int32_t start_period, std::optional<int32_t> number_phases = std::nullopt,
                                      std::optional<int32_t> phase_to_use = std::nullopt) {
-        auto charging_schedule_period = ChargingSchedulePeriod{
-            .startPeriod = start_period,
-            .numberPhases = number_phases,
-            .phaseToUse = phase_to_use,
-        };
+        ChargingSchedulePeriod charging_schedule_period;
+        charging_schedule_period.startPeriod = start_period;
+        charging_schedule_period.numberPhases = number_phases;
+        charging_schedule_period.phaseToUse = phase_to_use;
 
         return {charging_schedule_period};
     }
@@ -126,9 +125,9 @@ protected:
     std::vector<ChargingSchedulePeriod> create_charging_schedule_periods(std::vector<int32_t> start_periods) {
         auto charging_schedule_periods = std::vector<ChargingSchedulePeriod>();
         for (auto start_period : start_periods) {
-            auto charging_schedule_period = ChargingSchedulePeriod{
-                .startPeriod = start_period,
-            };
+            ChargingSchedulePeriod charging_schedule_period;
+            charging_schedule_period.startPeriod = start_period;
+
             charging_schedule_periods.push_back(charging_schedule_period);
         }
 
@@ -137,8 +136,10 @@ protected:
 
     std::vector<ChargingSchedulePeriod>
     create_charging_schedule_periods_with_phases(int32_t start_period, int32_t numberPhases, int32_t phaseToUse) {
-        auto charging_schedule_period =
-            ChargingSchedulePeriod{.startPeriod = start_period, .numberPhases = numberPhases, .phaseToUse = phaseToUse};
+        ChargingSchedulePeriod charging_schedule_period;
+        charging_schedule_period.startPeriod = start_period;
+        charging_schedule_period.numberPhases = numberPhases;
+        charging_schedule_period.phaseToUse = phaseToUse;
 
         return {charging_schedule_period};
     }
@@ -151,16 +152,18 @@ protected:
                             std::optional<ocpp::DateTime> validTo = {}) {
         auto recurrency_kind = RecurrencyKindEnum::Daily;
         std::vector<ChargingSchedule> charging_schedules = {charging_schedule};
-        return ChargingProfile{.id = charging_profile_id,
-                               .stackLevel = stack_level,
-                               .chargingProfilePurpose = charging_profile_purpose,
-                               .chargingProfileKind = charging_profile_kind,
-                               .chargingSchedule = charging_schedules,
-                               .customData = {},
-                               .recurrencyKind = recurrency_kind,
-                               .validFrom = validFrom,
-                               .validTo = validTo,
-                               .transactionId = transaction_id};
+        ChargingProfile charging_profile;
+        charging_profile.id = charging_profile_id;
+        charging_profile.stackLevel = stack_level;
+        charging_profile.chargingProfilePurpose = charging_profile_purpose;
+        charging_profile.chargingProfileKind = charging_profile_kind;
+        charging_profile.chargingSchedule = charging_schedules;
+        charging_profile.customData = {};
+        charging_profile.recurrencyKind = recurrency_kind;
+        charging_profile.validFrom = validFrom;
+        charging_profile.validTo = validTo;
+        charging_profile.transactionId = transaction_id;
+        return charging_profile;
     }
 
     ChargingProfileCriterion create_charging_profile_criteria(
@@ -198,8 +201,12 @@ protected:
     ClearChargingProfile create_clear_charging_profile(std::optional<int32_t> evse_id = std::nullopt,
                                                        std::optional<ChargingProfilePurposeEnum> purpose = std::nullopt,
                                                        std::optional<int32_t> stack_level = std::nullopt) {
-        return ClearChargingProfile{
-            .customData = {}, .evseId = evse_id, .chargingProfilePurpose = purpose, .stackLevel = stack_level};
+        ClearChargingProfile clear_charging_profile;
+        clear_charging_profile.customData = {};
+        clear_charging_profile.evseId = evse_id;
+        clear_charging_profile.chargingProfilePurpose = purpose;
+        clear_charging_profile.stackLevel = stack_level;
+        return clear_charging_profile;
     }
 
     void create_device_model_db(const std::string& path) {
@@ -1274,9 +1281,9 @@ TEST_F(SmartChargingHandlerTestFixtureV201, AddProfile_StoresChargingLimitSource
     auto response = handler.add_profile(profile, DEFAULT_EVSE_ID, charging_limit_source);
     EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
-    ChargingProfileCriterion criteria = {
-        .chargingProfileId = {{profile.id}},
-    };
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = {{profile.id}};
+
     auto profiles = this->database_handler->get_charging_profiles_matching_criteria(DEFAULT_EVSE_ID, criteria);
     const auto [e, p, sut] = profiles[0];
     EXPECT_THAT(sut, ChargingLimitSourceEnum::SO);
@@ -1296,9 +1303,9 @@ TEST_F(SmartChargingHandlerTestFixtureV201, ValidateAndAddProfile_StoresCharging
     auto response = handler.conform_validate_and_add_profile(profile, DEFAULT_EVSE_ID, charging_limit_source);
     EXPECT_THAT(response.status, testing::Eq(ChargingProfileStatusEnum::Accepted));
 
-    ChargingProfileCriterion criteria = {
-        .chargingProfileId = {{profile.id}},
-    };
+    ChargingProfileCriterion criteria;
+    criteria.chargingProfileId = {{profile.id}};
+
     auto profiles = this->database_handler->get_charging_profiles_matching_criteria(DEFAULT_EVSE_ID, criteria);
     const auto [e, p, sut] = profiles[0];
     EXPECT_THAT(sut, ChargingLimitSourceEnum::SO);


### PR DESCRIPTION
Removed designated initializer usage in library code and tests

Adaption to unit tests to not use designated initializers anymore

Fixed some test errors with missing chargingProfileKind being left uninitialized

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

