### PR TITLE
Allow empty network connection priorities. Replace throw with a clear warning message.

### DIFF
--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -202,7 +202,8 @@ private:
     void next_network_configuration_priority();
 
     /// @brief Cache all the network connection profiles. Must be called once during initialization
-    void cache_network_connection_profiles();
+    /// \return True if the network connection profiles could be cached, else False.
+    bool cache_network_connection_profiles();
 };
 
 } // namespace v201

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -200,7 +200,7 @@ void ConnectivityManager::init_websocket() {
 
     // cache the network profiles on initialization
     if (!cache_network_connection_profiles()) {
-        EVLOG_warning << "Network connection profiles could not be cached, aborting websocket init";
+        EVLOG_warning << "No network connection profiles configured, aborting websocket connection.";
         return;
     }
 

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -199,9 +199,12 @@ void ConnectivityManager::init_websocket() {
     }
 
     // cache the network profiles on initialization
-    cache_network_connection_profiles();
+    if (!cache_network_connection_profiles()) {
+        EVLOG_warning << "Network connection profiles could not be cached, aborting websocket init";
+        return;
+    }
 
-    const int config_slot_int = this->network_connection_priorities.at(this->network_configuration_priority);
+    const int config_slot_int = this->get_active_network_configuration_slot();
 
     const auto network_connection_profile = this->get_network_connection_profile(config_slot_int);
     // Not const as the iface member can be set by the configure network connection profile callback
@@ -424,11 +427,11 @@ void ConnectivityManager::next_network_configuration_priority() {
         (this->network_configuration_priority + 1) % (this->network_connection_priorities.size());
 }
 
-void ConnectivityManager::cache_network_connection_profiles() {
+bool ConnectivityManager::cache_network_connection_profiles() {
 
     if (!this->network_connection_profiles.empty()) {
         EVLOG_debug << " Network connection profiles already cached";
-        return;
+        return true;
     }
 
     // get all the network connection profiles from the device model and cache them
@@ -442,9 +445,7 @@ void ConnectivityManager::cache_network_connection_profiles() {
         this->network_connection_priorities.push_back(num);
     }
 
-    if (this->network_connection_priorities.empty()) {
-        EVLOG_AND_THROW(std::runtime_error("NetworkConfigurationPriority must not be empty"));
-    }
+    return !this->network_connection_priorities.empty();
 }
 } // namespace v201
 } // namespace ocpp


### PR DESCRIPTION
## Describe your changes
Allow empty network connection priorities. Replace throw with a clear warning message. 
This makes it possible to run a charging station 'stand-alone' without any network connection.

## Issue ticket number and link

## Checklist before requesting a review
- [x ] I have performed a self-review of my code
- [n/a] I have made corresponding changes to the documentation
- [n/a] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

