### PR TITLE
Bump libevse-security to 0.9.1 as used in everest-core already

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,7 +27,7 @@ date:
   options: ["BUILD_TZ_LIB ON", "HAS_REMOTE_API 0", "USE_AUTOLOAD 0", "USE_SYSTEM_TZ_DB ON"]
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.8.0
+  git_tag: v0.9.1
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
   git_tag: v4.3.3  


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

