### PR TITLE
Fix reporting of log rotation status

### DIFF
--- a/lib/ocpp/common/ocpp_logging.cpp
+++ b/lib/ocpp/common/ocpp_logging.cpp
@@ -193,7 +193,7 @@ LogRotationStatus MessageLogging::rotate_log(const std::string& file_basename) {
             std::filesystem::rename(file, new_file_name);
             EVLOG_info << "Renaming: " << file.string() << " -> " << new_file_name.string();
             if (status == LogRotationStatus::NotRotated) {
-                status == LogRotationStatus::Rotated;
+                status = LogRotationStatus::Rotated;
             }
         } else {
             // try parsing the .x extension and log an error if this was not possible
@@ -210,7 +210,7 @@ LogRotationStatus MessageLogging::rotate_log(const std::string& file_basename) {
                     EVLOG_info << "Renaming: " << file.string() << " -> " << new_file_name.string();
                     std::filesystem::rename(file, new_file_name);
                     if (status == LogRotationStatus::NotRotated) {
-                        status == LogRotationStatus::Rotated;
+                        status = LogRotationStatus::Rotated;
                     }
                 }
 


### PR DESCRIPTION
Accidental use of comparison operator when an assignment was needed

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

