### PR TITLE
Fixed bug setting NetworkConfigurationPriority

### DIFF
--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1855,10 +1855,11 @@ bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data
         const auto network_configuration_priorities = ocpp::split_string(set_variable_data.attributeValue.get(), ',');
         const auto active_security_profile =
             this->device_model->get_value<int>(ControllerComponentVariables::SecurityProfile);
-        const auto network_connection_profiles = json::parse(
-            this->device_model->get_value<std::string>(ControllerComponentVariables::NetworkConnectionProfiles));
-        for (const auto configuration_slot : network_configuration_priorities) {
-            try {
+
+        try {
+            const auto network_connection_profiles = json::parse(
+                this->device_model->get_value<std::string>(ControllerComponentVariables::NetworkConnectionProfiles));
+            for (const auto configuration_slot : network_configuration_priorities) {
                 auto network_profile_it =
                     std::find_if(network_connection_profiles.begin(), network_connection_profiles.end(),
                                  [configuration_slot](const SetNetworkProfileRequest& network_profile) {
@@ -1890,12 +1891,14 @@ bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data
                                   << " is >= 2 but no CSMS Root Certifciate is installed";
                     return false;
                 }
-            } catch (const std::invalid_argument& e) {
-                EVLOG_warning << "NetworkConfigurationPriority is not an integer: " << configuration_slot;
-                return false;
-            } catch (const json::exception& e) {
-                EVLOG_warning << "Could not parse data of SetNetworkProfileRequest: " << e.what();
             }
+        } catch (const std::invalid_argument& e) {
+            EVLOG_warning << "NetworkConfigurationPriority contains at least one value which is not an integer: "
+                          << set_variable_data.attributeValue.get();
+            return false;
+        } catch (const json::exception& e) {
+            EVLOG_warning << "Could not parse NetworkConnectionProfiles or SetNetworkProfileRequest: " << e.what();
+            return false;
         }
     }
     return true;

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1855,16 +1855,22 @@ bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data
         const auto network_configuration_priorities = ocpp::split_string(set_variable_data.attributeValue.get(), ',');
         const auto active_security_profile =
             this->device_model->get_value<int>(ControllerComponentVariables::SecurityProfile);
+        const auto network_connection_profiles = json::parse(
+            this->device_model->get_value<std::string>(ControllerComponentVariables::NetworkConnectionProfiles));
         for (const auto configuration_slot : network_configuration_priorities) {
             try {
-                auto network_profile_opt =
-                    this->connectivity_manager->get_network_connection_profile(std::stoi(configuration_slot));
-                if (!network_profile_opt.has_value()) {
+                auto network_profile_it =
+                    std::find_if(network_connection_profiles.begin(), network_connection_profiles.end(),
+                                 [configuration_slot](const SetNetworkProfileRequest& network_profile) {
+                                     return network_profile.configurationSlot == std::stoi(configuration_slot);
+                                 });
+
+                if (network_profile_it == network_connection_profiles.end()) {
                     EVLOG_warning << "Could not find network profile for configurationSlot: " << configuration_slot;
                     return false;
                 }
 
-                auto network_profile = network_profile_opt.value();
+                auto network_profile = SetNetworkProfileRequest(*network_profile_it).connectionData;
 
                 if (network_profile.securityProfile <= active_security_profile) {
                     continue;
@@ -1887,6 +1893,8 @@ bool ChargePoint::validate_set_variable(const SetVariableData& set_variable_data
             } catch (const std::invalid_argument& e) {
                 EVLOG_warning << "NetworkConfigurationPriority is not an integer: " << configuration_slot;
                 return false;
+            } catch (const json::exception& e) {
+                EVLOG_warning << "Could not parse data of SetNetworkProfileRequest: " << e.what();
             }
         }
     }


### PR DESCRIPTION
## Describe your changes

Fixed an issue when setting the `NetworkConfigurationPriority`. During the validation, every entry of the new priority list was checked using the `connectivity_manager`s cached slots. The slots of the `connectivity manager` are only initialized at startup. A new profile could have been send using a `SetNetworkProfile.req` by the CSMS at runtime, so when validating the `NetworkConfigurationPriority` we shall not use the cached `connectivity_manager` slots but the `NetworkConnectionProfiles` variable stored in the device model, since only this variable contains the new entry.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

