### PR TITLE
Handle enum value in message queue and use if instead of switch to prevent compiler warnings

### DIFF
--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -561,6 +561,9 @@ public:
                     case QueueType::Transaction:
                         this->transaction_message_queue.erase(selected_transaction_message_it);
                         break;
+                    case QueueType::None:
+                        // do nothing
+                        break;
 
                     default:
                         break;

--- a/lib/ocpp/v201/monitoring_updater.cpp
+++ b/lib/ocpp/v201/monitoring_updater.cpp
@@ -209,9 +209,8 @@ void MonitoringUpdater::evaluate_monitor(const VariableMonitoringMeta& monitor_m
                                          const VariableAttribute& attribute, const std::string& value_previous,
                                          const std::string& value_current) {
     // Don't care about periodic
-    switch (monitor_meta.monitor.type) {
-    case MonitorEnum::Periodic:
-    case MonitorEnum::PeriodicClockAligned:
+    if (monitor_meta.monitor.type == MonitorEnum::Periodic or
+        monitor_meta.monitor.type == MonitorEnum::PeriodicClockAligned) {
         return;
     }
 


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

