### PR TITLE
Move functionality of OCPP message id generation

### DIFF
--- a/include/ocpp/common/call_types.hpp
+++ b/include/ocpp/common/call_types.hpp
@@ -52,6 +52,10 @@ enum class MessageTypeId {
     UNKNOWN,
 };
 
+/// \brief Creates a unique message ID
+/// \returns the unique message ID
+MessageId create_message_id();
+
 /// \brief Contains a OCPP Call message
 template <class T> struct Call {
     T msg;
@@ -61,7 +65,13 @@ template <class T> struct Call {
     Call() {
     }
 
-    /// \brief Creates a new Call message object with the given OCPP message \p msg and \p uniqueID
+    /// \brief Creates a new Call message object with the given OCPP message \p msg
+    explicit Call(T msg) {
+        this->msg = msg;
+        this->uniqueId = create_message_id();
+    }
+
+    /// \brief Creates a new Call message object with the given OCPP message \p msg and \p uniqueId
     Call(T msg, MessageId uniqueId) {
         this->msg = msg;
         this->uniqueId = uniqueId;

--- a/include/ocpp/common/charging_station_base.hpp
+++ b/include/ocpp/common/charging_station_base.hpp
@@ -23,12 +23,6 @@ protected:
     boost::asio::io_service io_service;
     std::thread io_service_thread;
 
-    boost::uuids::random_generator uuid_generator;
-
-    /// \brief Generates a uuid
-    /// \return uuid
-    std::string uuid();
-
 public:
     /// \brief Constructor for ChargingStationBase
     /// \param evse_security Pointer to evse_security that manages security related operations; if nullptr

--- a/include/ocpp/v16/transaction.hpp
+++ b/include/ocpp/v16/transaction.hpp
@@ -10,10 +10,6 @@
 #include <ocpp/v16/ocpp_types.hpp>
 #include <ocpp/v16/types.hpp>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 namespace ocpp {
 namespace v16 {
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -766,9 +766,8 @@ private:
     template <class RequestType, class ResponseType>
     std::function<ResponseType(RequestType)> send_callback(MessageType expected_response_message_type) {
         return [this, expected_response_message_type](auto request) {
-            MessageId message_id = MessageId(to_string(this->uuid_generator()));
             const auto enhanced_response =
-                this->message_dispatcher->dispatch_call_async(ocpp::Call<RequestType>(request, message_id)).get();
+                this->message_dispatcher->dispatch_call_async(ocpp::Call<RequestType>(request)).get();
             if (enhanced_response.messageType != expected_response_message_type) {
                 throw UnexpectedMessageTypeFromCSMS(
                     std::string("Got unexpected message type from CSMS, expected: ") +

--- a/lib/ocpp/common/call_types.cpp
+++ b/lib/ocpp/common/call_types.cpp
@@ -3,7 +3,19 @@
 
 #include <ocpp/common/call_types.hpp>
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 namespace ocpp {
+
+MessageId create_message_id() {
+    static boost::uuids::random_generator uuid_generator;
+    boost::uuids::uuid uuid = uuid_generator();
+    std::stringstream s;
+    s << uuid;
+    return MessageId(s.str());
+}
 
 bool operator<(const MessageId& lhs, const MessageId& rhs) {
     return lhs.get() < rhs.get();

--- a/lib/ocpp/common/charging_station_base.cpp
+++ b/lib/ocpp/common/charging_station_base.cpp
@@ -6,8 +6,7 @@
 
 namespace ocpp {
 ChargingStationBase::ChargingStationBase(const std::shared_ptr<EvseSecurity> evse_security,
-                                         const std::optional<SecurityConfiguration> security_configuration) :
-    uuid_generator(boost::uuids::random_generator()) {
+                                         const std::optional<SecurityConfiguration> security_configuration) {
 
     if (evse_security != nullptr) {
         this->evse_security = evse_security;
@@ -26,12 +25,6 @@ ChargingStationBase::~ChargingStationBase() {
     work->get_io_context().stop();
     io_service.stop();
     io_service_thread.join();
-}
-
-std::string ChargingStationBase::uuid() {
-    std::stringstream s;
-    s << this->uuid_generator();
-    return s.str();
 }
 
 } // namespace ocpp

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -418,7 +418,7 @@ void ChargePointImpl::heartbeat(bool initiated_by_trigger_message) {
     EVLOG_debug << "Sending heartbeat";
     HeartbeatRequest req;
 
-    ocpp::Call<HeartbeatRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<HeartbeatRequest> call(req);
     this->message_dispatcher->dispatch_call(call, initiated_by_trigger_message);
 }
 
@@ -435,7 +435,7 @@ void ChargePointImpl::boot_notification(bool initiated_by_trigger_message) {
     req.meterSerialNumber = this->configuration->getMeterSerialNumber();
     req.meterType = this->configuration->getMeterType();
 
-    ocpp::Call<BootNotificationRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<BootNotificationRequest> call(req);
     this->message_dispatcher->dispatch_call(call, initiated_by_trigger_message);
 }
 
@@ -953,7 +953,7 @@ void ChargePointImpl::send_meter_value(int32_t connector, MeterValue meter_value
     }
 
     MeterValuesRequest req;
-    const auto message_id = this->message_queue->createMessageId();
+    const auto message_id = ocpp::create_message_id();
     // connector = 0 designates the main measurement
     // connector > 0 designates a connector of the charge point
     req.connectorId = connector;
@@ -2618,7 +2618,7 @@ void ChargePointImpl::sign_certificate(const ocpp::CertificateSigningUseEnum& ce
 
     req.csr = response.csr.value();
 
-    ocpp::Call<SignCertificateRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<SignCertificateRequest> call(req);
     this->message_dispatcher->dispatch_call(call, initiated_by_trigger_message);
 }
 
@@ -2817,7 +2817,7 @@ void ChargePointImpl::securityEventNotification(const CiString<50>& event_type,
     }
 
     if (critical_security_event and !this->configuration->getDisableSecurityEventNotifications()) {
-        ocpp::Call<SecurityEventNotificationRequest> call(req, this->message_queue->createMessageId());
+        ocpp::Call<SecurityEventNotificationRequest> call(req);
         this->message_dispatcher->dispatch_call(call);
     }
 
@@ -2838,7 +2838,7 @@ void ChargePointImpl::log_status_notification(UploadLogStatusEnumType status, in
     this->log_status = status;
     this->log_status_request_id = requestId;
 
-    ocpp::Call<LogStatusNotificationRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<LogStatusNotificationRequest> call(req);
     this->message_dispatcher->dispatch_call(call, initiated_by_trigger_message);
 }
 
@@ -2865,7 +2865,7 @@ void ChargePointImpl::signed_firmware_update_status_notification(FirmwareStatusE
     this->signed_firmware_status = status;
     this->signed_firmware_status_request_id = requestId;
 
-    ocpp::Call<SignedFirmwareStatusNotificationRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<SignedFirmwareStatusNotificationRequest> call(req);
     this->message_dispatcher->dispatch_call(call, initiated_by_trigger_message);
 
     if (status == FirmwareStatusEnumType::InvalidSignature) {
@@ -3234,7 +3234,7 @@ void ChargePointImpl::status_notification(const int32_t connector, const ChargeP
     request.info = info;
     request.vendorId = vendor_id;
     request.vendorErrorCode = vendor_error_code;
-    ocpp::Call<StatusNotificationRequest> call(request, this->message_queue->createMessageId());
+    ocpp::Call<StatusNotificationRequest> call(request);
     this->message_dispatcher->dispatch_call(call, initiated_by_trigger_message);
 }
 
@@ -3280,7 +3280,7 @@ IdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const bool aut
     AuthorizeRequest req;
     req.idTag = idTag;
 
-    ocpp::Call<AuthorizeRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<AuthorizeRequest> call(req);
 
     auto authorize_future = this->message_dispatcher->dispatch_call_async(call);
 
@@ -3494,7 +3494,7 @@ ocpp::v201::AuthorizeResponse ChargePointImpl::data_transfer_pnc_authorize(
         req.data.emplace(json(authorize_req).dump());
 
         // Send the DataTransfer(Authorize) to the CSMS
-        Call<DataTransferRequest> call(req, this->message_queue->createMessageId());
+        Call<DataTransferRequest> call(req);
         auto authorize_future = this->message_dispatcher->dispatch_call_async(call);
 
         if (authorize_future.wait_for(DEFAULT_WAIT_FOR_FUTURE_TIMEOUT) == std::future_status::timeout) {
@@ -3576,7 +3576,7 @@ void ChargePointImpl::data_transfer_pnc_sign_certificate() {
     csr_req.certificateType = ocpp::v201::CertificateSigningUseEnum::V2GCertificate;
     req.data.emplace(json(csr_req).dump());
 
-    Call<DataTransferRequest> call(req, this->message_queue->createMessageId());
+    Call<DataTransferRequest> call(req);
     this->message_dispatcher->dispatch_call(call);
 }
 
@@ -3602,7 +3602,7 @@ void ChargePointImpl::data_transfer_pnc_get_15118_ev_certificate(
 
     req.data.emplace(json(cert_req).dump());
 
-    Call<DataTransferRequest> call(req, this->message_queue->createMessageId());
+    Call<DataTransferRequest> call(req);
     auto future = this->message_dispatcher->dispatch_call_async(call);
 
     if (future.wait_for(DEFAULT_WAIT_FOR_FUTURE_TIMEOUT) == std::future_status::timeout) {
@@ -3652,7 +3652,7 @@ void ChargePointImpl::data_transfer_pnc_get_certificate_status(const ocpp::v201:
 
     req.data.emplace(json(cert_status_req).dump());
 
-    Call<DataTransferRequest> call(req, this->message_queue->createMessageId());
+    Call<DataTransferRequest> call(req);
     auto future = this->message_dispatcher->dispatch_call_async(call);
 
     if (future.wait_for(DEFAULT_WAIT_FOR_FUTURE_TIMEOUT) == std::future_status::timeout) {
@@ -3907,7 +3907,7 @@ std::optional<DataTransferResponse> ChargePointImpl::data_transfer(const CiStrin
 
     DataTransferResponse response;
     response.status = DataTransferStatus::Rejected;
-    ocpp::Call<DataTransferRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<DataTransferRequest> call(req);
     auto data_transfer_future = this->message_dispatcher->dispatch_call_async(call);
 
     if (this->websocket == nullptr or !this->websocket->is_connected()) {
@@ -3987,7 +3987,7 @@ void ChargePointImpl::start_transaction(std::shared_ptr<Transaction> transaction
     req.idTag = transaction->get_id_tag();
     req.meterStart = std::round(transaction->get_start_energy_wh()->energy_Wh);
     req.timestamp = transaction->get_start_energy_wh()->timestamp;
-    const auto message_id = this->message_queue->createMessageId();
+    const auto message_id = ocpp::create_message_id();
 
     try {
         this->database_handler->insert_transaction(
@@ -4164,7 +4164,7 @@ void ChargePointImpl::stop_transaction(int32_t connector, Reason reason, std::op
         req.transactionData.emplace(transaction_data);
     }
 
-    auto message_id = this->message_queue->createMessageId();
+    auto message_id = ocpp::create_message_id();
     ocpp::Call<StopTransactionRequest> call(req, message_id);
 
     const auto max_message_size = this->configuration->getMaxMessageSize();
@@ -4322,7 +4322,7 @@ void ChargePointImpl::diagnostic_status_notification(DiagnosticsStatus status, b
     req.status = status;
     this->diagnostics_status = status;
 
-    ocpp::Call<DiagnosticsStatusNotificationRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<DiagnosticsStatusNotificationRequest> call(req);
     this->message_dispatcher->dispatch_call_async(call, true);
 }
 
@@ -4344,7 +4344,7 @@ void ChargePointImpl::firmware_status_notification(FirmwareStatus status, bool i
 
     this->firmware_status = status;
 
-    ocpp::Call<FirmwareStatusNotificationRequest> call(req, this->message_queue->createMessageId());
+    ocpp::Call<FirmwareStatusNotificationRequest> call(req);
     this->message_dispatcher->dispatch_call_async(call, initiated_by_trigger_message);
 
     if (this->firmware_update_is_pending) {

--- a/tests/lib/ocpp/v16/test_message_queue.cpp
+++ b/tests/lib/ocpp/v16/test_message_queue.cpp
@@ -26,36 +26,34 @@ protected:
 
 TEST_F(ControlMessageV16Test, test_is_transactional) {
 
-    EXPECT_TRUE(is_transaction_message(
-        (ControlMessage<v16::MessageType>{Call<v16::StartTransactionRequest>{v16::StartTransactionRequest{}, "0"}}
-             .messageType)));
-    EXPECT_TRUE(is_transaction_message(
-        (ControlMessage<v16::MessageType>{Call<v16::StopTransactionRequest>{v16::StopTransactionRequest{}, "0"}}
-             .messageType)));
+    EXPECT_TRUE(is_transaction_message((ControlMessage<v16::MessageType>{
+        Call<v16::StartTransactionRequest>{
+            v16::StartTransactionRequest{}}}.messageType)));
+    EXPECT_TRUE(is_transaction_message((ControlMessage<v16::MessageType>{
+        Call<v16::StopTransactionRequest>{
+            v16::StopTransactionRequest{}}}.messageType)));
     EXPECT_TRUE(is_transaction_message(ControlMessage<v16::MessageType>{
-        Call<v16::SecurityEventNotificationRequest>{v16::SecurityEventNotificationRequest{}, "0"}}
+        Call<v16::SecurityEventNotificationRequest>{v16::SecurityEventNotificationRequest{}}}
                                            .messageType));
     EXPECT_TRUE(is_transaction_message(
-        ControlMessage<v16::MessageType>{Call<v16::MeterValuesRequest>{v16::MeterValuesRequest{}, "0"}}.messageType));
+        ControlMessage<v16::MessageType>{Call<v16::MeterValuesRequest>{v16::MeterValuesRequest{}}}.messageType));
     EXPECT_TRUE(!is_transaction_message(
-        ControlMessage<v16::MessageType>{Call<v16::AuthorizeRequest>{v16::AuthorizeRequest{}, "0"}}.messageType));
+        ControlMessage<v16::MessageType>{Call<v16::AuthorizeRequest>{v16::AuthorizeRequest{}}}.messageType));
 }
 
 TEST_F(ControlMessageV16Test, test_is_transactional_update) {
 
-    EXPECT_TRUE(
-        !(ControlMessage<v16::MessageType>{Call<v16::StartTransactionRequest>{v16::StartTransactionRequest{}, "0"}})
-             .is_transaction_update_message());
-    EXPECT_TRUE(
-        !(ControlMessage<v16::MessageType>{Call<v16::StopTransactionRequest>{v16::StopTransactionRequest{}, "0"}})
-             .is_transaction_update_message());
-    EXPECT_TRUE(!(ControlMessage<v16::MessageType>{
-                      Call<v16::SecurityEventNotificationRequest>{v16::SecurityEventNotificationRequest{}, "0"}})
+    EXPECT_TRUE(!(ControlMessage<v16::MessageType>{Call<v16::StartTransactionRequest>{v16::StartTransactionRequest{}}})
                      .is_transaction_update_message());
-    EXPECT_TRUE((ControlMessage<v16::MessageType>{Call<v16::MeterValuesRequest>{v16::MeterValuesRequest{}, "0"}})
+    EXPECT_TRUE(!(ControlMessage<v16::MessageType>{Call<v16::StopTransactionRequest>{v16::StopTransactionRequest{}}})
+                     .is_transaction_update_message());
+    EXPECT_TRUE(!(ControlMessage<v16::MessageType>{
+                      Call<v16::SecurityEventNotificationRequest>{v16::SecurityEventNotificationRequest{}}})
+                     .is_transaction_update_message());
+    EXPECT_TRUE((ControlMessage<v16::MessageType>{Call<v16::MeterValuesRequest>{v16::MeterValuesRequest{}}})
                     .is_transaction_update_message());
 
-    EXPECT_TRUE(!(ControlMessage<v16::MessageType>{Call<v16::AuthorizeRequest>{v16::AuthorizeRequest{}, "0"}})
+    EXPECT_TRUE(!(ControlMessage<v16::MessageType>{Call<v16::AuthorizeRequest>{v16::AuthorizeRequest{}}})
                      .is_transaction_update_message());
 }
 

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -625,7 +625,7 @@ public:
 
     template <class T, MessageType M> EnhancedMessage<MessageType> request_to_enhanced_message(const T& req) {
         auto message_id = uuid();
-        ocpp::Call<T> call(req, message_id);
+        ocpp::Call<T> call(req);
         EnhancedMessage<MessageType> enhanced_message;
         enhanced_message.uniqueId = message_id;
         enhanced_message.messageType = M;

--- a/tests/lib/ocpp/v201/test_message_queue.cpp
+++ b/tests/lib/ocpp/v201/test_message_queue.cpp
@@ -18,11 +18,11 @@ protected:
 TEST_F(ControlMessageV201Test, test_is_transactional) {
 
     EXPECT_TRUE(is_transaction_message(
-        (ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{v201::TransactionEventRequest{}, "0"}}
+        (ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{v201::TransactionEventRequest{}}}
              .messageType)));
 
     EXPECT_TRUE(!is_transaction_message(
-        ControlMessage<v201::MessageType>{Call<v201::AuthorizeRequest>{v201::AuthorizeRequest{}, "0"}}.messageType));
+        ControlMessage<v201::MessageType>{Call<v201::AuthorizeRequest>{v201::AuthorizeRequest{}}}.messageType));
 }
 
 TEST_F(ControlMessageV201Test, test_is_transactional_update) {
@@ -30,18 +30,18 @@ TEST_F(ControlMessageV201Test, test_is_transactional_update) {
     v201::TransactionEventRequest transaction_event_request{};
     transaction_event_request.eventType = v201::TransactionEventEnum::Updated;
 
-    EXPECT_TRUE((ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{transaction_event_request, "0"}}
+    EXPECT_TRUE((ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{transaction_event_request}}
                      .is_transaction_update_message()));
 
     transaction_event_request.eventType = v201::TransactionEventEnum::Started;
-    EXPECT_TRUE(!(ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{transaction_event_request, "0"}}
+    EXPECT_TRUE(!(ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{transaction_event_request}}
                       .is_transaction_update_message()));
 
     transaction_event_request.eventType = v201::TransactionEventEnum::Ended;
-    EXPECT_TRUE(!(ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{transaction_event_request, "0"}}
+    EXPECT_TRUE(!(ControlMessage<v201::MessageType>{Call<v201::TransactionEventRequest>{transaction_event_request}}
                       .is_transaction_update_message()));
 
-    EXPECT_TRUE(!(ControlMessage<v201::MessageType>{Call<v201::AuthorizeRequest>{v201::AuthorizeRequest{}, "0"}}
+    EXPECT_TRUE(!(ControlMessage<v201::MessageType>{Call<v201::AuthorizeRequest>{v201::AuthorizeRequest{}}}
                       .is_transaction_update_message()));
 }
 


### PR DESCRIPTION
## Describe your changes
Moved functionality to create message id from message_queue to call_types and made it a free function. Removed unused imports and usage of boost/uuid headers

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

