### PR TITLE
Libwebsockets (usage) improvements

### DIFF
--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -87,8 +87,6 @@ private:
 private:
     std::shared_ptr<EvseSecurity> evse_security;
 
-    std::function<void()> reconnect_callback;
-
     // Connection related data
     Everest::SteadyTimer reconnect_timer_tpm;
     std::unique_ptr<std::thread> websocket_thread;

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -700,6 +700,9 @@ bool WebsocketLibwebsockets::connect() {
         return false;
     }
 
+    // Clear shutting down so we allow to reconnect again as well
+    this->shutting_down = false;
+
     EVLOG_info << "Connecting to uri: " << this->connection_options.csms_uri.string() << " with security-profile "
                << this->connection_options.security_profile
                << (this->connection_options.use_tpm_tls ? " with TPM keys" : "");

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -728,7 +728,7 @@ bool WebsocketLibwebsockets::connect() {
             this->websocket_thread.reset();
         }
 
-        if (this->recv_message_thread && this->websocket_thread->joinable()) {
+        if (this->recv_message_thread && this->recv_message_thread->joinable()) {
             // Awake the receiving message thread to finish
             recv_message_cv.notify_one();
             this->recv_message_thread->join();

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -246,15 +246,17 @@ WebsocketLibwebsockets::~WebsocketLibwebsockets() {
         local_data->do_interrupt();
     }
 
-    if (websocket_thread != nullptr) {
-        websocket_thread->join();
+    std::lock_guard lock(this->connection_mutex);
+
+    if (this->websocket_thread != nullptr && this->websocket_thread->joinable()) {
+        this->websocket_thread->join();
     }
 
-    if (recv_message_thread != nullptr) {
-        recv_message_thread->join();
+    if (this->recv_message_thread != nullptr && this->recv_message_thread->joinable()) {
+        this->recv_message_thread->join();
     }
 
-    if (this->deferred_callback_thread != nullptr) {
+    if (this->deferred_callback_thread != nullptr && this->deferred_callback_thread->joinable()) {
         {
             std::scoped_lock tmp_lock(this->deferred_callback_mutex);
             this->stop_deferred_handler = true;
@@ -283,6 +285,8 @@ void WebsocketLibwebsockets::set_connection_options(const WebsocketConnectionOpt
         security::SecurityProfile::UNSECURED_TRANSPORT_WITH_BASIC_AUTHENTICATION) {
         this->connection_options.csms_uri.set_secure(true);
     }
+
+    this->connection_attempts = 1; // reset connection attempts
 }
 
 static int callback_minimal(struct lws* wsi, enum lws_callback_reasons reason, void* user, void* in, size_t len) {
@@ -713,17 +717,23 @@ bool WebsocketLibwebsockets::connect() {
     // use new connection context
     conn_data = local_data;
 
-    // Wait old thread for a clean state
-    if (this->websocket_thread) {
-        // Awake libwebsockets thread to quickly exit
-        request_write();
-        this->websocket_thread->join();
-    }
+    {
+        std::scoped_lock lock(connection_mutex);
 
-    if (this->recv_message_thread) {
-        // Awake the receiving message thread to finish
-        recv_message_cv.notify_one();
-        this->recv_message_thread->join();
+        // Wait old thread for a clean state
+        if (this->websocket_thread && this->websocket_thread->joinable()) {
+            // Awake libwebsockets thread to quickly exit
+            request_write();
+            this->websocket_thread->join();
+            this->websocket_thread.reset();
+        }
+
+        if (this->recv_message_thread && this->websocket_thread->joinable()) {
+            // Awake the receiving message thread to finish
+            recv_message_cv.notify_one();
+            this->recv_message_thread->join();
+            this->recv_message_thread.reset();
+        }
     }
 
     if (this->deferred_callback_thread == nullptr) {
@@ -750,16 +760,6 @@ bool WebsocketLibwebsockets::connect() {
         empty.swap(recv_message_queue);
     }
 
-    // Bind reconnect callback
-    this->reconnect_callback = [this]() {
-        // close connection before reconnecting
-        if (this->m_is_connected) {
-            this->close(WebsocketCloseReason::AbnormalClose, "before reconnecting");
-        }
-
-        this->connect();
-    };
-
     bool timeouted = false;
     bool connected = false;
 
@@ -767,7 +767,7 @@ bool WebsocketLibwebsockets::connect() {
         std::unique_lock<std::mutex> lock(connection_mutex);
 
         // Release other threads
-        this->websocket_thread.reset(new std::thread(&WebsocketLibwebsockets::client_loop, this));
+        this->websocket_thread = std::make_unique<std::thread>(&WebsocketLibwebsockets::client_loop, this);
 
         // TODO(ioan): remove this thread when the fix will be moved into 'MessageQueue'
         // The reason for having a received message processing thread is that because
@@ -775,7 +775,7 @@ bool WebsocketLibwebsockets::connect() {
         // will send back another message, and since we're waiting for that message to be
         // sent over the wire on the client_loop, not giving the opportunity to the loop to
         // advance we will have a dead-lock
-        this->recv_message_thread.reset(new std::thread(&WebsocketLibwebsockets::recv_loop, this));
+        this->recv_message_thread = std::make_unique<std::thread>(&WebsocketLibwebsockets::recv_loop, this);
 
         // Wait until connect or timeout
         timeouted = !conn_cv.wait_for(lock, std::chrono::seconds(60), [&]() {
@@ -827,11 +827,12 @@ void WebsocketLibwebsockets::reconnect(long delay) {
         std::lock_guard<std::mutex> lk(this->reconnect_mutex);
         this->reconnect_timer_tpm.timeout(
             [this]() {
-                if (this->reconnect_callback) {
-                    this->reconnect_callback();
-                } else {
-                    EVLOG_error << "Invalid reconnect callback!";
+                // close connection before reconnecting
+                if (this->m_is_connected) {
+                    this->close(WebsocketCloseReason::AbnormalClose, "before reconnecting");
                 }
+
+                this->connect();
             },
             std::chrono::milliseconds(delay));
     }

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -275,14 +275,20 @@ void ConnectivityManager::init_websocket() {
                                                VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
     }
 
-    this->websocket = std::make_unique<Websocket>(connection_options, this->evse_security, this->logging);
+    if (this->websocket == nullptr) {
+        this->websocket = std::make_unique<Websocket>(connection_options, this->evse_security, this->logging);
 
-    this->websocket->register_connected_callback(
-        std::bind(&ConnectivityManager::on_websocket_connected, this, std::placeholders::_1));
-    this->websocket->register_disconnected_callback(std::bind(&ConnectivityManager::on_websocket_disconnected, this));
-    this->websocket->register_closed_callback(
-        std::bind(&ConnectivityManager::on_websocket_closed, this, std::placeholders::_1));
+        this->websocket->register_connected_callback(
+            std::bind(&ConnectivityManager::on_websocket_connected, this, std::placeholders::_1));
+        this->websocket->register_disconnected_callback(
+            std::bind(&ConnectivityManager::on_websocket_disconnected, this));
+        this->websocket->register_closed_callback(
+            std::bind(&ConnectivityManager::on_websocket_closed, this, std::placeholders::_1));
+    } else {
+        this->websocket->set_connection_options(connection_options);
+    }
 
+    // Attach external callbacks everytime since they might have changed
     if (websocket_connection_failed_callback.has_value()) {
         this->websocket->register_connection_failed_callback(websocket_connection_failed_callback.value());
     }


### PR DESCRIPTION
## Describe your changes

We encountered deadlocks in the libwebsockters layer when we were often restarting the connectivity manager.
The issue is due to 2 threads calling `join()` at the same time.

I've added the proper `joinable()` checks and also removed the destruction and construction of libwebsockets every new config. This is no longer needed now we have one implementation that handles both secure and unsecure websockets.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

