### PR TITLE
Fix bug in ClearChargingProfile.req

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2359,8 +2359,6 @@ void ChargePointImpl::handleGetCompositeScheduleRequest(ocpp::Call<GetCompositeS
 void ChargePointImpl::handleClearChargingProfileRequest(ocpp::Call<ClearChargingProfileRequest> call) {
     EVLOG_debug << "Received ClearChargingProfileRequest: " << call.msg << "\nwith messageId: " << call.uniqueId;
 
-    // FIXME(kai): after a profile has been deleted we must notify interested parties (energy manager?)
-
     ClearChargingProfileResponse response;
     response.status = ClearChargingProfileStatus::Unknown;
 
@@ -2372,8 +2370,8 @@ void ChargePointImpl::handleClearChargingProfileRequest(ocpp::Call<ClearCharging
                this->smart_charging_handler->clear_all_profiles_with_filter(
                    call.msg.id, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, true)) {
         response.status = ClearChargingProfileStatus::Accepted;
-
-    } else if (this->smart_charging_handler->clear_all_profiles_with_filter(
+    } else if (!call.msg.id and
+               this->smart_charging_handler->clear_all_profiles_with_filter(
                    call.msg.id, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, false)) {
         response.status = ClearChargingProfileStatus::Accepted;
     }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2372,7 +2372,7 @@ void ChargePointImpl::handleClearChargingProfileRequest(ocpp::Call<ClearCharging
         response.status = ClearChargingProfileStatus::Accepted;
     } else if (!call.msg.id and
                this->smart_charging_handler->clear_all_profiles_with_filter(
-                   call.msg.id, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, false)) {
+                   std::nullopt, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, false)) {
         response.status = ClearChargingProfileStatus::Accepted;
     }
 


### PR DESCRIPTION
## Describe your changes
Fixed issue that other charging profiles were cleared even when a profile id was specified

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

