### PR TITLE
Connectivity manager refactoring

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -352,13 +352,13 @@ public:
     /// present. This returns the value from the cached network connection profiles. \param
     /// network_configuration_priority \return
     virtual std::optional<NetworkConnectionProfile>
-    get_network_connection_profile(const int32_t configuration_slot) = 0;
+    get_network_connection_profile(const int32_t configuration_slot) const = 0;
 
     /// \brief Get the priority of the given configuration slot.
     /// \param configuration_slot   The configuration slot to get the priority from.
     /// \return The priority if the configuration slot exists.
     ///
-    virtual std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) = 0;
+    virtual std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) const = 0;
 
     /// @brief Get the network connection slots sorted by priority.
     /// Each item in the vector contains the configured configuration slots, where the slot with index 0 has the highest
@@ -940,9 +940,9 @@ public:
     std::vector<CompositeSchedule> get_all_composite_schedules(const int32_t duration,
                                                                const ChargingRateUnitEnum& unit) override;
 
-    std::optional<NetworkConnectionProfile> get_network_connection_profile(const int32_t configuration_slot) override;
+    std::optional<NetworkConnectionProfile> get_network_connection_profile(const int32_t configuration_slot) const override;
 
-    std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) override;
+    std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) const override;
 
     const std::vector<int>& get_network_connection_slots() const override;
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -100,7 +100,8 @@ public:
 
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint
     /// \param bootreason  Optional bootreason (default: PowerUp).
-    /// \param autoconnect Set to false if you only want to initialize and not connect yet and use connect_websocket() to actually connect
+    /// \param autoconnect Set to false if you only want to initialize and not connect yet and use connect_websocket()
+    /// to actually connect
     virtual void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool autoconnect = true) = 0;
 
     /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -100,20 +100,19 @@ public:
 
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint
     /// \param bootreason  Optional bootreason (default: PowerUp).
-    /// \param configuration_slot Configuration slot used to connect websocket
-
-    virtual void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp,
-                       std::optional<int32_t> configuration_slot = std::nullopt) = 0;
+    /// \param start_connecting Optional, set to false to initialize but not start connecting. Otherwise will connect to
+    /// the first network profile. (default: true)
+    virtual void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool start_connecting = true) = 0;
 
     /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers
     virtual void stop() = 0;
 
-    /// \brief Initializes the websocket and connects to CSMS
-    /// a specific network connection profile given the configuration slot
-    /// if it is not yet connected.
+    /// \brief Initializes the websocket and connects to a CSMS. Provide a network_profile_slot to connect to that
+    /// specific slot.
     ///
-    /// \param configuration_slot Configuration slot used to connect websocket
-    virtual void connect_websocket(std::optional<int32_t> configuration_slot = std::nullopt) = 0;
+    /// \param network_profile_slot Optional slot to use when connecting. std::nullopt means the slot will be determined
+    /// automatically.
+    virtual void connect_websocket(std::optional<int32_t> network_profile_slot = std::nullopt) = 0;
 
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
     virtual void disconnect_websocket() = 0;
@@ -848,12 +847,11 @@ public:
 
     ~ChargePoint();
 
-    void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp,
-               std::optional<int32_t> configuration_slot = std::nullopt) override;
+    void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool start_connecting = true) override;
 
     void stop() override;
 
-    void connect_websocket(std::optional<int32_t> configuration_slot = std::nullopt) override;
+    void connect_websocket(std::optional<int32_t> network_profile_slot = std::nullopt) override;
     virtual void disconnect_websocket() override;
 
     void on_network_disconnected(OCPPInterfaceEnum ocpp_interface) override;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -100,9 +100,10 @@ public:
 
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint
     /// \param bootreason  Optional bootreason (default: PowerUp).
-    /// \param autoconnect Set to false if you only want to initialize and not connect yet and use connect_websocket()
-    /// to actually connect
-    virtual void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool autoconnect = true) = 0;
+    /// \param configuration_slot Configuration slot used to connect websocket
+
+    virtual void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp,
+                       std::optional<int32_t> configuration_slot = std::nullopt) = 0;
 
     /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers
     virtual void stop() = 0;
@@ -114,7 +115,7 @@ public:
     /// a specific network connection profile given the configuration slot
     /// if it is not yet connected.
     ///
-    /// \param configuration_slot Slot in which the configuration is stored
+    /// \param configuration_slot Configuration slot used to connect websocket
     virtual void connect_websocket(const int32_t configuration_slot) = 0;
 
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
@@ -854,7 +855,8 @@ public:
 
     ~ChargePoint();
 
-    void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool autoconnect = true) override;
+    void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp,
+               std::optional<int32_t> configuration_slot = std::nullopt) override;
 
     void stop() override;
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -99,8 +99,9 @@ public:
     virtual ~ChargePointInterface() = default;
 
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint
-    /// \param bootreason   Optional bootreason (default: PowerUp).
-    virtual void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp) = 0;
+    /// \param bootreason  Optional bootreason (default: PowerUp).
+    /// \param autoconnect Set to false if you only want to initialize and not connect yet and use connect_websocket() to actually connect
+    virtual void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool autoconnect = true) = 0;
 
     /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers
     virtual void stop() = 0;
@@ -863,7 +864,7 @@ public:
 
     ~ChargePoint();
 
-    void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp) override;
+    void start(BootReasonEnum bootreason = BootReasonEnum::PowerUp, bool autoconnect = true) override;
 
     void stop() override;
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -108,15 +108,12 @@ public:
     /// \brief Stops the ChargePoint. Disconnects the websocket connection and stops MessageQueue and all timers
     virtual void stop() = 0;
 
-    /// \brief Initializes the websocket and connects to CSMS if it is not yet connected
-    virtual void connect_websocket() = 0;
-
     /// \brief Initializes the websocket and connects to CSMS
     /// a specific network connection profile given the configuration slot
     /// if it is not yet connected.
     ///
     /// \param configuration_slot Configuration slot used to connect websocket
-    virtual void connect_websocket(const int32_t configuration_slot) = 0;
+    virtual void connect_websocket(std::optional<int32_t> configuration_slot = std::nullopt) = 0;
 
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
     virtual void disconnect_websocket() = 0;
@@ -482,10 +479,6 @@ private:
     GetCompositeScheduleResponse
     get_composite_schedule_internal(const GetCompositeScheduleRequest& request,
                                     const std::set<ChargingProfilePurposeEnum>& profiles_to_ignore = {});
-
-    /// \brief Removes all network connection profiles below the actual security profile and stores the new list in the
-    /// device model
-    void remove_network_connection_profiles_below_actual_security_profile();
 
     void message_callback(const std::string& message);
     void update_aligned_data_interval();
@@ -860,8 +853,7 @@ public:
 
     void stop() override;
 
-    virtual void connect_websocket() override;
-    void connect_websocket(const int32_t configuration_slot) override;
+    void connect_websocket(std::optional<int32_t> configuration_slot = std::nullopt) override;
     virtual void disconnect_websocket() override;
 
     void on_network_disconnected(OCPPInterfaceEnum ocpp_interface) override;

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -940,7 +940,8 @@ public:
     std::vector<CompositeSchedule> get_all_composite_schedules(const int32_t duration,
                                                                const ChargingRateUnitEnum& unit) override;
 
-    std::optional<NetworkConnectionProfile> get_network_connection_profile(const int32_t configuration_slot) const override;
+    std::optional<NetworkConnectionProfile>
+    get_network_connection_profile(const int32_t configuration_slot) const override;
 
     std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) const override;
 

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -110,6 +110,13 @@ public:
     /// \brief Initializes the websocket and connects to CSMS if it is not yet connected
     virtual void connect_websocket() = 0;
 
+    /// \brief Initializes the websocket and connects to CSMS
+    /// a specific network connection profile given the configuration slot
+    /// if it is not yet connected.
+    ///
+    /// \param configuration_slot Slot in which the configuration is stored
+    virtual void connect_websocket(const int32_t configuration_slot) = 0;
+
     /// \brief Disconnects the the websocket connection to the CSMS if it is connected
     virtual void disconnect_websocket() = 0;
 
@@ -127,27 +134,9 @@ public:
     /// This is introduced because the websocket can take several minutes to timeout when a network interface becomes
     /// unavailable, whereas the system can detect this sooner.
     ///
-    /// \param configuration_slot   The slot of the network connection profile that is disconnected.
-    ///
-    virtual void on_network_disconnected(int32_t configuration_slot) = 0;
-
-    ///
-    /// \brief Can be called when a network is disconnected, for example when an ethernet cable is removed.
-    ///
-    /// This is introduced because the websocket can take several minutes to timeout when a network interface becomes
-    /// unavailable, whereas the system can detect this sooner.
-    ///
     /// \param ocpp_interface       The interface that is disconnected.
     ///
     virtual void on_network_disconnected(OCPPInterfaceEnum ocpp_interface) = 0;
-
-    /// \brief Switch to a specific network connection profile given the configuration slot.
-    ///
-    /// Switch will only be done when the configuration slot has a higher priority.
-    ///
-    /// \param configuration_slot Slot in which the configuration is stored
-    /// \return true if the switch is possible.
-    virtual bool on_try_switch_network_connection_profile(const int32_t configuration_slot) = 0;
 
     /// \brief Chargepoint notifies about new firmware update status firmware_update_status. This function should be
     ///        called during a Firmware Update to indicate the current firmware_update_status.
@@ -372,14 +361,14 @@ public:
     /// \param configuration_slot   The configuration slot to get the priority from.
     /// \return The priority if the configuration slot exists.
     ///
-    virtual std::optional<int> get_configuration_slot_priority(const int configuration_slot) = 0;
+    virtual std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) = 0;
 
-    /// @brief Get the network connection priorities.
+    /// @brief Get the network connection slots sorted by priority.
     /// Each item in the vector contains the configured configuration slots, where the slot with index 0 has the highest
     /// priority.
-    /// @return The network connection priorities
+    /// @return The network connection slots
     ///
-    virtual const std::vector<int>& get_network_connection_priorities() const = 0;
+    virtual const std::vector<int>& get_network_connection_slots() const = 0;
 };
 
 /// \brief Class implements OCPP2.0.1 Charging Station
@@ -870,13 +859,10 @@ public:
     void stop() override;
 
     virtual void connect_websocket() override;
+    void connect_websocket(const int32_t configuration_slot) override;
     virtual void disconnect_websocket() override;
 
-    void on_network_disconnected(int32_t configuration_slot) override;
-
     void on_network_disconnected(OCPPInterfaceEnum ocpp_interface) override;
-
-    bool on_try_switch_network_connection_profile(const int32_t configuration_slot) override;
 
     void on_firmware_update_status_notification(int32_t request_id,
                                                 const FirmwareStatusEnum& firmware_update_status) override;
@@ -964,9 +950,9 @@ public:
 
     std::optional<NetworkConnectionProfile> get_network_connection_profile(const int32_t configuration_slot) override;
 
-    std::optional<int> get_configuration_slot_priority(const int configuration_slot) override;
+    std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) override;
 
-    const std::vector<int>& get_network_connection_priorities() const override;
+    const std::vector<int>& get_network_connection_slots() const override;
 
     /// \brief Requests a value of a VariableAttribute specified by combination of \p component_id and \p variable_id
     /// from the device model

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -88,13 +88,13 @@ public:
     /// \brief Gets the cached NetworkConnectionProfile based on the given \p configuration_slot.
     /// This returns the value from the cached network connection profiles.
     /// \return Returns a profile if the slot is found
-    std::optional<NetworkConnectionProfile> get_network_connection_profile(const int32_t configuration_slot);
+    std::optional<NetworkConnectionProfile> get_network_connection_profile(const int32_t configuration_slot) const;
 
     /// \brief Get the priority of the given configuration slot.
     /// \param configuration_slot   The configuration slot to get the priority from.
     /// \return The priority if the configuration slot exists.
     ///
-    std::optional<int32_t> get_priority_from_configuration_slot(const int configuration_slot);
+    std::optional<int32_t> get_priority_from_configuration_slot(const int configuration_slot) const;
 
     /// @brief Get the network connection slots sorted by priority.
     /// Each item in the vector contains the configured configuration slots, where the slot with index 0 has the highest
@@ -174,7 +174,7 @@ private:
     /// \brief Get the active network configuration slot in use.
     /// \return The active slot the network is connected to or the pending slot.
     ///
-    int get_active_network_configuration_slot();
+    int get_active_network_configuration_slot() const;
 
     ///
     /// \brief Get the network configuration slot of the given priority.

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -135,7 +135,7 @@ public:
 
     /// \brief Called when the charging station certificate is changed
     ///
-    void on_reconfiguration_of_security_parameters();
+    void on_charging_station_certificate_changed();
 
     /// \brief Confirms the connection is successful so the security profile requirements can be handled
     void confirm_successful_connection();
@@ -154,9 +154,10 @@ private:
     /// \param slot The configuration slot to get the interface for
     /// \param profile The network connection profile to get the interface for
     ///
-    /// \return A string containing the network interface to use, nullptr if the request failed or the callback is not
-    /// configured
-    std::optional<std::string> get_network_configuration_interface(int slot, const NetworkConnectionProfile& profile);
+    /// \return The network configuration containing the network interface to use, nullptr if the request failed or the
+    /// callback is not configured
+    std::optional<ConfigNetworkResult>
+    handle_configure_network_connection_profile_callback(int slot, const NetworkConnectionProfile& profile);
 
     /// \brief Function invoked when the web socket connected with the \p security_profile
     ///

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -158,6 +158,8 @@ public:
     /// \return true if the switch is possible.
     bool on_try_switch_network_connection_profile(const int32_t configuration_slot);
 
+    void confirm_successfull_connection();
+
 private:
     /// \brief Init the websocket
     ///

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -161,7 +161,7 @@ public:
 private:
     /// \brief Init the websocket
     ///
-    void init_websocket();
+    bool init_websocket();
 
     /// \brief Get the current websocket connection options
     /// \returns the current websocket connection options

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -166,7 +166,7 @@ private:
     /// \brief Get the current websocket connection options
     /// \returns the current websocket connection options
     ///
-    WebsocketConnectionOptions get_ws_connection_options(const int32_t configuration_slot);
+    std::optional<WebsocketConnectionOptions> get_ws_connection_options(const int32_t configuration_slot);
 
     /// \brief Function invoked when the web socket connected with the \p security_profile
     ///

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -85,10 +85,9 @@ public:
     ///
     void set_configure_network_connection_profile_callback(ConfigureNetworkConnectionProfileCallback callback);
 
-    /// \brief Gets the configured NetworkConnectionProfile based on the given \p configuration_slot . The
-    /// central system uri of the connection options will not contain ws:// or wss:// because this method removes it if
-    /// present. This returns the value from the cached network connection profiles. \param
-    /// active_network_configuration_priority \return
+    /// \brief Gets the cached NetworkConnectionProfile based on the given \p configuration_slot.
+    /// This returns the value from the cached network connection profiles.
+    /// \return Returns a profile if the slot is found
     std::optional<NetworkConnectionProfile> get_network_connection_profile(const int32_t configuration_slot);
 
     /// \brief Get the priority of the given configuration slot.
@@ -130,7 +129,7 @@ public:
     /// This is introduced because the websocket can take several minutes to timeout when a network interface becomes
     /// unavailable, whereas the system can detect this sooner.
     ///
-    /// \param ocpp_interface       The interface that is disconnected.
+    /// \param ocpp_interface The interface that is disconnected.
     ///
     void on_network_disconnected(OCPPInterfaceEnum ocpp_interface);
 
@@ -179,14 +178,14 @@ private:
 
     ///
     /// \brief Get the network configuration slot of the given priority.
-    /// \param priority   The priority to get the configuration slot.
+    /// \param priority The priority to get the configuration slot.
     /// \return The configuration slot.
     ///
     int get_configuration_slot_from_priority(const int priority);
 
     ///
     /// \brief Get the next prioritized network configuration slot of the given configuration slot.
-    /// \param configuration_slot   The current configuration slot.
+    /// \param configuration_slot The current configuration slot.
     /// \return The next prioritized configuration slot.
     ///
     int get_next_configuration_slot(int32_t configuration_slot);

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -109,8 +109,9 @@ public:
     bool is_websocket_connected();
 
     /// \brief Start the connectivity manager
+    /// \param autoconnect Set to false if you only want to initialize and not connect yet and use connect() to connect
     ///
-    void start();
+    void start(bool autoconnect = true);
 
     /// \brief Stop the connectivity manager
     ///

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -138,7 +138,7 @@ public:
     ///
     void on_reconfiguration_of_security_parameters();
 
-    void confirm_successfull_connection();
+    void confirm_successful_connection();
     void remove_network_connection_profiles_below_actual_security_profile();
 
 private:

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -46,10 +46,12 @@ private:
     bool disable_automatic_websocket_reconnects;
     int network_configuration_priority;
     /// @brief Local cached network connection profiles
-    std::vector<SetNetworkProfileRequest> network_connection_profiles;
+    std::vector<SetNetworkProfileRequest> cached_network_connection_profiles;
     /// @brief local cached network connection priorities
     std::vector<int> network_connection_priorities;
     WebsocketConnectionOptions current_connection_options{};
+
+    int last_security_level{0};
 
 public:
     ConnectivityManager(DeviceModel& device_model, std::shared_ptr<EvseSecurity> evse_security,
@@ -159,6 +161,7 @@ public:
     bool on_try_switch_network_connection_profile(const int32_t configuration_slot);
 
     void confirm_successfull_connection();
+    void remove_network_connection_profiles_below_actual_security_profile();
 
 private:
     /// \brief Init the websocket
@@ -207,6 +210,8 @@ private:
     /// @brief Cache all the network connection profiles. Must be called once during initialization
     /// \return True if the network connection profiles could be cached, else False.
     bool cache_network_connection_profiles();
+
+    void check_cache_for_invalid_security_profiles();
 };
 
 } // namespace v201

--- a/include/ocpp/v201/ocpp_types.hpp
+++ b/include/ocpp/v201/ocpp_types.hpp
@@ -891,7 +891,6 @@ std::ostream& operator<<(std::ostream& os, const SetMonitoringResult& k);
 
 /// @brief The result of a configuration of a network profile.
 struct ConfigNetworkResult {
-    uint8_t network_profile_slot;                 ///< @brief Network profile slot.
     std::optional<std::string> interface_address; ///< ip address or interface string
     bool success;                                 ///< true if the configuration was successful
 };

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -4453,11 +4453,11 @@ std::vector<CompositeSchedule> ChargePoint::get_all_composite_schedules(const in
     return composite_schedules;
 }
 
-std::optional<NetworkConnectionProfile> ChargePoint::get_network_connection_profile(const int32_t configuration_slot) {
+std::optional<NetworkConnectionProfile> ChargePoint::get_network_connection_profile(const int32_t configuration_slot) const {
     return this->connectivity_manager->get_network_connection_profile(configuration_slot);
 }
 
-std::optional<int> ChargePoint::get_priority_from_configuration_slot(const int configuration_slot) {
+std::optional<int> ChargePoint::get_priority_from_configuration_slot(const int configuration_slot) const {
     return this->connectivity_manager->get_priority_from_configuration_slot(configuration_slot);
 }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -4453,7 +4453,8 @@ std::vector<CompositeSchedule> ChargePoint::get_all_composite_schedules(const in
     return composite_schedules;
 }
 
-std::optional<NetworkConnectionProfile> ChargePoint::get_network_connection_profile(const int32_t configuration_slot) const {
+std::optional<NetworkConnectionProfile>
+ChargePoint::get_network_connection_profile(const int32_t configuration_slot) const {
     return this->connectivity_manager->get_network_connection_profile(configuration_slot);
 }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -2323,7 +2323,7 @@ void ChargePoint::handle_certificate_signed_req(Call<CertificateSignedRequest> c
     if (response.status == CertificateSignedStatusEnum::Accepted and
         cert_signing_use == ocpp::CertificateSigningUseEnum::ChargingStationCertificate and
         this->device_model->get_value<int>(ControllerComponentVariables::SecurityProfile) == 3) {
-        this->connectivity_manager->on_reconfiguration_of_security_parameters();
+        this->connectivity_manager->on_charging_station_certificate_changed();
 
         const auto& security_event = ocpp::security_events::RECONFIGURATIONOFSECURITYPARAMETERS;
         std::string tech_info = "Changed charging station certificate";

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -111,7 +111,7 @@ ChargePoint::~ChargePoint() {
     this->auth_cache_cleanup_thread.join();
 }
 
-void ChargePoint::start(BootReasonEnum bootreason) {
+void ChargePoint::start(BootReasonEnum bootreason, bool autoconnect) {
     this->message_queue->start();
 
     this->bootreason = bootreason;
@@ -123,7 +123,7 @@ void ChargePoint::start(BootReasonEnum bootreason) {
     this->boot_notification_req(bootreason);
     // call clear_invalid_charging_profiles when system boots
     this->clear_invalid_charging_profiles();
-    this->connectivity_manager->start();
+    this->connectivity_manager->start(autoconnect);
 
     const std::string firmware_version =
         this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1207,53 +1207,6 @@ void ChargePoint::init_certificate_expiration_check_timers() {
             .value_or(60)));
 }
 
-void ChargePoint::remove_network_connection_profiles_below_actual_security_profile() {
-    // Remove all the profiles that are a lower security level than security_level
-    const auto security_level = this->device_model->get_value<int>(ControllerComponentVariables::SecurityProfile);
-
-    auto network_connection_profiles = json::parse(
-        this->device_model->get_value<std::string>(ControllerComponentVariables::NetworkConnectionProfiles));
-
-    auto is_lower_security_level = [security_level](const SetNetworkProfileRequest& item) {
-        return item.connectionData.securityProfile < security_level;
-    };
-
-    network_connection_profiles.erase(
-        std::remove_if(network_connection_profiles.begin(), network_connection_profiles.end(), is_lower_security_level),
-        network_connection_profiles.end());
-
-    this->device_model->set_value(ControllerComponentVariables::NetworkConnectionProfiles.component,
-                                  ControllerComponentVariables::NetworkConnectionProfiles.variable.value(),
-                                  AttributeEnum::Actual, network_connection_profiles.dump(),
-                                  VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
-
-    // Update the NetworkConfigurationPriority so only remaining profiles are in there
-    const auto network_priority = ocpp::split_string(
-        this->device_model->get_value<std::string>(ControllerComponentVariables::NetworkConfigurationPriority), ',');
-
-    auto in_network_profiles = [&network_connection_profiles](const std::string& item) {
-        auto is_same_slot = [&item](const SetNetworkProfileRequest& profile) {
-            return std::to_string(profile.configurationSlot) == item;
-        };
-        return std::any_of(network_connection_profiles.begin(), network_connection_profiles.end(), is_same_slot);
-    };
-
-    std::string new_network_priority;
-    for (const auto& item : network_priority) {
-        if (in_network_profiles(item)) {
-            if (!new_network_priority.empty()) {
-                new_network_priority += ',';
-            }
-            new_network_priority += item;
-        }
-    }
-
-    this->device_model->set_value(ControllerComponentVariables::NetworkConfigurationPriority.component,
-                                  ControllerComponentVariables::NetworkConfigurationPriority.variable.value(),
-                                  AttributeEnum::Actual, new_network_priority,
-                                  VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
-}
-
 void ChargePoint::handle_message(const EnhancedMessage<v201::MessageType>& message) {
     const auto& json_message = message.message;
     try {
@@ -2459,7 +2412,7 @@ void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationR
             this->callbacks.time_sync_callback.value()(msg.currentTime);
         }
 
-        this->remove_network_connection_profiles_below_actual_security_profile();
+        this->connectivity_manager->confirm_successfull_connection();
 
         // set timers
         if (msg.interval > 0) {
@@ -4173,33 +4126,29 @@ void ChargePoint::websocket_connected_callback(const int configuration_slot,
                                                const NetworkConnectionProfile& network_connection_profile) {
     this->message_queue->resume(this->message_queue_resume_delay);
 
-    const auto& security_profile_cv = ControllerComponentVariables::SecurityProfile;
-    if (security_profile_cv.variable.has_value()) {
-        this->device_model->set_read_only_value(
-            security_profile_cv.component, security_profile_cv.variable.value(), AttributeEnum::Actual,
-            std::to_string(network_connection_profile.securityProfile), VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
-    }
+    if (this->registration_status == RegistrationStatusEnum::Accepted) {
+        this->connectivity_manager->confirm_successfull_connection();
 
-    if (this->registration_status == RegistrationStatusEnum::Accepted and
-        this->time_disconnected.time_since_epoch() != 0s) {
-        // handle offline threshold
-        //  Get the current time point using steady_clock
-        auto offline_duration = std::chrono::steady_clock::now() - this->time_disconnected;
+        if (this->time_disconnected.time_since_epoch() != 0s) {
+            // handle offline threshold
+            //  Get the current time point using steady_clock
+            auto offline_duration = std::chrono::steady_clock::now() - this->time_disconnected;
 
-        // B04.FR.01
-        // If offline period exceeds offline threshold then send the status notification for all connectors
-        if (offline_duration >
-            std::chrono::seconds(this->device_model->get_value<int>(ControllerComponentVariables::OfflineThreshold))) {
-            EVLOG_debug << "offline for more than offline threshold ";
-            this->component_state_manager->send_status_notification_all_connectors();
-        } else {
-            // B04.FR.02
-            // If offline period doesn't exceed offline threshold then send the status notification for all
-            // connectors that changed state
-            EVLOG_debug << "offline for less than offline threshold ";
-            this->component_state_manager->send_status_notification_changed_connectors();
+            // B04.FR.01
+            // If offline period exceeds offline threshold then send the status notification for all connectors
+            if (offline_duration > std::chrono::seconds(this->device_model->get_value<int>(
+                                       ControllerComponentVariables::OfflineThreshold))) {
+                EVLOG_debug << "offline for more than offline threshold ";
+                this->component_state_manager->send_status_notification_all_connectors();
+            } else {
+                // B04.FR.02
+                // If offline period doesn't exceed offline threshold then send the status notification for all
+                // connectors that changed state
+                EVLOG_debug << "offline for less than offline threshold ";
+                this->component_state_manager->send_status_notification_changed_connectors();
+            }
+            this->init_certificate_expiration_check_timers(); // re-init as timers are stopped on disconnect
         }
-        this->init_certificate_expiration_check_timers(); // re-init as timers are stopped on disconnect
     }
     this->time_disconnected = std::chrono::time_point<std::chrono::steady_clock>();
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -164,10 +164,6 @@ void ChargePoint::stop() {
     this->message_queue->stop();
 }
 
-void ChargePoint::connect_websocket() {
-    this->connectivity_manager->connect();
-}
-
 void ChargePoint::disconnect_websocket() {
     this->connectivity_manager->disconnect();
 }
@@ -176,7 +172,7 @@ void ChargePoint::on_network_disconnected(OCPPInterfaceEnum ocpp_interface) {
     this->connectivity_manager->on_network_disconnected(ocpp_interface);
 }
 
-void ChargePoint::connect_websocket(const int32_t configuration_slot) {
+void ChargePoint::connect_websocket(std::optional<int32_t> configuration_slot) {
     this->connectivity_manager->connect(configuration_slot);
 }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -2403,7 +2403,7 @@ void ChargePoint::handle_boot_notification_response(CallResult<BootNotificationR
             this->callbacks.time_sync_callback.value()(msg.currentTime);
         }
 
-        this->connectivity_manager->confirm_successfull_connection();
+        this->connectivity_manager->confirm_successful_connection();
 
         // set timers
         if (msg.interval > 0) {
@@ -4118,7 +4118,7 @@ void ChargePoint::websocket_connected_callback(const int configuration_slot,
     this->message_queue->resume(this->message_queue_resume_delay);
 
     if (this->registration_status == RegistrationStatusEnum::Accepted) {
-        this->connectivity_manager->confirm_successfull_connection();
+        this->connectivity_manager->confirm_successful_connection();
 
         if (this->time_disconnected.time_since_epoch() != 0s) {
             // handle offline threshold

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -111,7 +111,7 @@ ChargePoint::~ChargePoint() {
     this->auth_cache_cleanup_thread.join();
 }
 
-void ChargePoint::start(BootReasonEnum bootreason, std::optional<int32_t> configuration_slot) {
+void ChargePoint::start(BootReasonEnum bootreason, bool start_connecting) {
     this->message_queue->start();
 
     this->bootreason = bootreason;
@@ -123,7 +123,9 @@ void ChargePoint::start(BootReasonEnum bootreason, std::optional<int32_t> config
     this->boot_notification_req(bootreason);
     // call clear_invalid_charging_profiles when system boots
     this->clear_invalid_charging_profiles();
-    this->connectivity_manager->connect(configuration_slot);
+    if (start_connecting) {
+        this->connectivity_manager->connect();
+    }
 
     const std::string firmware_version =
         this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion);
@@ -172,8 +174,8 @@ void ChargePoint::on_network_disconnected(OCPPInterfaceEnum ocpp_interface) {
     this->connectivity_manager->on_network_disconnected(ocpp_interface);
 }
 
-void ChargePoint::connect_websocket(std::optional<int32_t> configuration_slot) {
-    this->connectivity_manager->connect(configuration_slot);
+void ChargePoint::connect_websocket(std::optional<int32_t> network_profile_slot) {
+    this->connectivity_manager->connect(network_profile_slot);
 }
 
 void ChargePoint::on_firmware_update_status_notification(int32_t request_id,

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -111,7 +111,7 @@ ChargePoint::~ChargePoint() {
     this->auth_cache_cleanup_thread.join();
 }
 
-void ChargePoint::start(BootReasonEnum bootreason, bool autoconnect) {
+void ChargePoint::start(BootReasonEnum bootreason, std::optional<int32_t> configuration_slot) {
     this->message_queue->start();
 
     this->bootreason = bootreason;
@@ -123,9 +123,7 @@ void ChargePoint::start(BootReasonEnum bootreason, bool autoconnect) {
     this->boot_notification_req(bootreason);
     // call clear_invalid_charging_profiles when system boots
     this->clear_invalid_charging_profiles();
-    if (autoconnect) {
-        this->connectivity_manager->connect();
-    }
+    this->connectivity_manager->connect(configuration_slot);
 
     const std::string firmware_version =
         this->device_model->get_value<std::string>(ControllerComponentVariables::FirmwareVersion);

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -71,7 +71,7 @@ void ConnectivityManager::set_configure_network_connection_profile_callback(
 }
 
 std::optional<NetworkConnectionProfile>
-ConnectivityManager::get_network_connection_profile(const int32_t configuration_slot) {
+ConnectivityManager::get_network_connection_profile(const int32_t configuration_slot) const {
 
     for (const auto& network_profile : this->cached_network_connection_profiles) {
         if (network_profile.configurationSlot == configuration_slot) {
@@ -88,7 +88,7 @@ ConnectivityManager::get_network_connection_profile(const int32_t configuration_
     return std::nullopt;
 }
 
-std::optional<int32_t> ConnectivityManager::get_priority_from_configuration_slot(const int configuration_slot) {
+std::optional<int32_t> ConnectivityManager::get_priority_from_configuration_slot(const int configuration_slot) const {
     auto it =
         std::find(this->network_connection_slots.begin(), this->network_connection_slots.end(), configuration_slot);
     if (it != this->network_connection_slots.end()) {
@@ -98,7 +98,7 @@ std::optional<int32_t> ConnectivityManager::get_priority_from_configuration_slot
     return std::nullopt;
 }
 
-int ConnectivityManager::get_active_network_configuration_slot() {
+int ConnectivityManager::get_active_network_configuration_slot() const {
     return this->network_connection_slots.at(this->active_network_configuration_priority);
 }
 

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -103,7 +103,12 @@ bool ConnectivityManager::is_websocket_connected() {
     return this->websocket != nullptr && this->websocket->is_connected();
 }
 
-void ConnectivityManager::start() {
+void ConnectivityManager::start(bool autoconnect) {
+    if (!autoconnect) {
+        // Only cache the network profiles, starting the websocket is done by calling connect() later
+        this->cache_network_connection_profiles();
+        return;
+    }
     init_websocket();
     if (websocket != nullptr) {
         this->disable_automatic_websocket_reconnects = false;

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -115,7 +115,7 @@ bool ConnectivityManager::is_websocket_connected() {
 }
 
 void ConnectivityManager::connect(std::optional<int32_t> configuration_slot_opt) {
-    const int32_t configuration_slot = configuration_slot_opt.value_or(1);
+    const int32_t configuration_slot = configuration_slot_opt.value_or(this->get_active_network_configuration_slot());
     const std::optional<NetworkConnectionProfile> network_connection_profile_opt =
         this->get_network_connection_profile(configuration_slot);
     if (!network_connection_profile_opt.has_value()) {

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -222,6 +222,11 @@ bool ConnectivityManager::init_websocket() {
     if (!network_connection_profile.has_value()) {
         EVLOG_warning << "No network connection profile configured for " << config_slot_int;
         can_use_connection_profile = false;
+    } else if (const auto& security_profile_cv = ControllerComponentVariables::SecurityProfile;
+               network_connection_profile.value().securityProfile <
+               this->device_model.get_value<int>(security_profile_cv)) {
+        EVLOG_info << "Slot #" << config_slot_int << " has a lower security profile than current security profile";
+        can_use_connection_profile = false;
     } else if (this->configure_network_connection_profile_callback.has_value()) {
         EVLOG_debug << "Request to configure network connection profile " << config_slot_int;
 

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -109,27 +109,27 @@ void ConnectivityManager::start(bool autoconnect) {
         this->cache_network_connection_profiles();
         return;
     }
-    init_websocket();
-    if (websocket != nullptr) {
+    if (init_websocket() && websocket != nullptr) {
         this->disable_automatic_websocket_reconnects = false;
         websocket->connect();
     }
 }
 
 void ConnectivityManager::stop() {
-    this->websocket_timer.stop();
     disconnect_websocket(WebsocketCloseReason::Normal);
 }
 
 void ConnectivityManager::connect() {
     if (this->websocket != nullptr and !this->websocket->is_connected()) {
         this->disable_automatic_websocket_reconnects = false;
-        this->init_websocket();
-        this->websocket->connect();
+        if (this->init_websocket()) {
+            this->websocket->connect();
+        }
     }
 }
 
 void ConnectivityManager::disconnect_websocket(WebsocketCloseReason code) {
+    this->websocket_timer.stop();
     if (this->websocket != nullptr) {
         if (code != WebsocketCloseReason::ServiceRestart) {
             this->disable_automatic_websocket_reconnects = true;
@@ -156,6 +156,7 @@ void ConnectivityManager::on_network_disconnected(int32_t configuration_slot) {
     } else if (configuration_slot == actual_configuration_slot) {
         // Since there is no connection anymore: disconnect the websocket, the manager will try to connect with the next
         // available network connection profile as we enable reconnects.
+        EVLOG_info << "ConnectivityManager::on_network_disconnected";
         this->disconnect_websocket(ocpp::WebsocketCloseReason::GoingAway);
         this->disable_automatic_websocket_reconnects = false;
     }
@@ -172,15 +173,16 @@ void ConnectivityManager::on_network_disconnected(OCPPInterfaceEnum ocpp_interfa
     } else if (ocpp_interface == network_connection_profile.value().ocppInterface) {
         // Since there is no connection anymore: disconnect the websocket, the manager will try to connect with the next
         // available network connection profile as we enable reconnects.
+        EVLOG_info << "ConnectivityManager::on_network_disconnected";
         this->disconnect_websocket(ocpp::WebsocketCloseReason::GoingAway);
         this->disable_automatic_websocket_reconnects = false;
     }
 }
 
 bool ConnectivityManager::on_try_switch_network_connection_profile(const int32_t configuration_slot) {
-    if (!is_higher_priority_profile(configuration_slot)) {
-        return false;
-    }
+    // if (!is_higher_priority_profile(configuration_slot)) {
+    //     return false;
+    // }
 
     EVLOG_info << "Trying to connect with higher priority network connection profile (configuration slots: "
                << this->get_active_network_configuration_slot() << " --> " << configuration_slot << ").";
@@ -197,7 +199,8 @@ bool ConnectivityManager::on_try_switch_network_connection_profile(const int32_t
     return true;
 }
 
-void ConnectivityManager::init_websocket() {
+bool ConnectivityManager::init_websocket() {
+    EVLOG_info << "ConnectivityManager::init_websocket()";
     if (this->device_model.get_value<std::string>(ControllerComponentVariables::ChargePointId).find(':') !=
         std::string::npos) {
         EVLOG_AND_THROW(std::runtime_error("ChargePointId must not contain \':\'"));
@@ -206,7 +209,7 @@ void ConnectivityManager::init_websocket() {
     // cache the network profiles on initialization
     if (!cache_network_connection_profiles()) {
         EVLOG_warning << "No network connection profiles configured, aborting websocket connection.";
-        return;
+        return false;
     }
 
     const int config_slot_int = this->get_active_network_configuration_slot();
@@ -253,13 +256,20 @@ void ConnectivityManager::init_websocket() {
     }
 
     if (!can_use_connection_profile) {
+        EVLOG_info << "websocket_timer set_timeout";
+        if (this->disable_automatic_websocket_reconnects) {
+            return false;
+        }
+
         this->websocket_timer.timeout(
             [this]() {
+                EVLOG_info << "websocket_timer.timeout 1";
                 this->next_network_configuration_priority();
                 this->start();
             },
             WEBSOCKET_INIT_DELAY);
-        return;
+
+        return true;
     }
 
     EVLOG_info << "Open websocket with NetworkConfigurationPriority: " << this->network_configuration_priority + 1
@@ -299,6 +309,7 @@ void ConnectivityManager::init_websocket() {
     }
 
     this->websocket->register_message_callback([this](const std::string& message) { this->message_callback(message); });
+    return true;
 }
 
 WebsocketConnectionOptions ConnectivityManager::get_ws_connection_options(const int32_t configuration_slot) {


### PR DESCRIPTION
## Describe your changes

We refactored the connectivity manager a bit. We tried to make the interface simpler by just having `connect()` and `disconnect()` calls to control the manager instead of having 4.

This way we also are able to have slightly more control over how libocpp starts (with `start_connecting`) and be able to trigger a connection using a specific network profile.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

