### PR TITLE
Set libwebsockets install lib dir to follow the CMAKE_INSTALL_LIBDIR

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -51,6 +51,7 @@ libwebsockets:
     - LWS_WITHOUT_TEST_SERVER_EXTPOLL ON
     - LWS_WITHOUT_TEST_PING ON
     - LWS_WITHOUT_TEST_CLIENT ON
+    - LWS_INSTALL_LIB_DIR ${CMAKE_INSTALL_LIBDIR}
 gtest:
   # GoogleTest now follows the Abseil Live at Head philosophy. We recommend updating to the latest commit in the main branch as often as possible.
   git: https://github.com/google/googletest.git


### PR DESCRIPTION
This prevents inconsistencies when GNUInstallDirs sets it to eg. "lib64", but the libwebsockets default is "lib"

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

