### PR TITLE
Harden handles against invalid connector id range

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2368,9 +2368,9 @@ void ChargePointImpl::handleClearChargingProfileRequest(ocpp::Call<ClearCharging
     ClearChargingProfileResponse response;
     response.status = ClearChargingProfileStatus::Unknown;
 
-    bool connectorIdValid=true;
+    bool connectorIdValid = true;
     if (call.msg.id.has_value() && ( call.msg.id < 0 || call.msg.id > this->configuration->getNumberOfConnectors())){
-        connectorIdValid=false;
+        connectorIdValid = false;
     }
 
     if (connectorIdValid) {
@@ -2892,13 +2892,20 @@ void ChargePointImpl::handleReserveNowRequest(ocpp::Call<ReserveNowRequest> call
     ReserveNowResponse response;
     response.status = ReservationStatus::Rejected;
 
-    if (this->status->get_state(call.msg.connectorId) == ChargePointStatus::Faulted) {
-        response.status = ReservationStatus::Faulted;
-    } else if (this->reserve_now_callback != nullptr &&
-               this->configuration->getSupportedFeatureProfiles().find("Reservation") != std::string::npos) {
-        if (call.msg.connectorId != 0 || this->configuration->getReserveConnectorZeroSupported().value_or(false)) {
-            response.status = this->reserve_now_callback(call.msg.reservationId, call.msg.connectorId,
-                                                         call.msg.expiryDate, call.msg.idTag, call.msg.parentIdTag);
+    bool connectorIdInRange = false;
+    if (call.msg.connectorId <0 || call.msg.connectorId > this->configuration->getNumberOfConnectors()) {
+        connectorIdInRange = false;
+    }
+
+    if (connectorIdInRange) {
+        if (this->status->get_state(call.msg.connectorId) == ChargePointStatus::Faulted) {
+            response.status = ReservationStatus::Faulted;
+        } else if (this->reserve_now_callback != nullptr &&
+                   this->configuration->getSupportedFeatureProfiles().find("Reservation") != std::string::npos) {
+            if (call.msg.connectorId != 0 || this->configuration->getReserveConnectorZeroSupported().value_or(false)) {
+                response.status = this->reserve_now_callback(call.msg.reservationId, call.msg.connectorId,
+                                                             call.msg.expiryDate, call.msg.idTag, call.msg.parentIdTag);
+            }
         }
     }
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2368,18 +2368,25 @@ void ChargePointImpl::handleClearChargingProfileRequest(ocpp::Call<ClearCharging
     ClearChargingProfileResponse response;
     response.status = ClearChargingProfileStatus::Unknown;
 
-    // clear all charging profiles
-    if (!call.msg.id && !call.msg.connectorId && !call.msg.chargingProfilePurpose && !call.msg.stackLevel) {
-        this->smart_charging_handler->clear_all_profiles();
-        response.status = ClearChargingProfileStatus::Accepted;
-    } else if (call.msg.id &&
-               this->smart_charging_handler->clear_all_profiles_with_filter(
-                   call.msg.id, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, true)) {
-        response.status = ClearChargingProfileStatus::Accepted;
-    } else if (!call.msg.id and
-               this->smart_charging_handler->clear_all_profiles_with_filter(
-                   std::nullopt, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, false)) {
-        response.status = ClearChargingProfileStatus::Accepted;
+    bool connectorIdValid=true;
+    if (call.msg.id.has_value() && ( call.msg.id < 0 || call.msg.id > this->configuration->getNumberOfConnectors())){
+        connectorIdValid=false;
+    }
+
+    if (connectorIdValid) {
+        // clear all charging profiles
+        if (!call.msg.id && !call.msg.connectorId && !call.msg.chargingProfilePurpose && !call.msg.stackLevel) {
+            this->smart_charging_handler->clear_all_profiles();
+            response.status = ClearChargingProfileStatus::Accepted;
+        } else if (call.msg.id &&
+                   this->smart_charging_handler->clear_all_profiles_with_filter(
+                       call.msg.id, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, true)) {
+            response.status = ClearChargingProfileStatus::Accepted;
+        } else if (!call.msg.id and
+                   this->smart_charging_handler->clear_all_profiles_with_filter(
+                       std::nullopt, call.msg.connectorId, call.msg.stackLevel, call.msg.chargingProfilePurpose, false)) {
+            response.status = ClearChargingProfileStatus::Accepted;
+        }
     }
 
     ocpp::CallResult<ClearChargingProfileResponse> call_result(response, call.uniqueId);

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2238,7 +2238,7 @@ void ChargePointImpl::handleUnlockConnectorRequest(ocpp::Call<UnlockConnectorReq
 
     UnlockConnectorResponse response;
     auto connector = call.msg.connectorId;
-    if (connector == 0 || connector > this->configuration->getNumberOfConnectors()) {
+    if (connector <= 0 || connector > this->configuration->getNumberOfConnectors()) {
         response.status = UnlockStatus::NotSupported;
     } else {
         // this message is not intended to remotely stop a transaction, but if a transaction is still ongoing it is

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2331,7 +2331,7 @@ void ChargePointImpl::handleGetCompositeScheduleRequest(ocpp::Call<GetCompositeS
     const auto connector_id = call.msg.connectorId;
     const auto allowed_charging_rate_units = this->configuration->getChargingScheduleAllowedChargingRateUnitVector();
 
-    if ((size_t)connector_id >= this->connectors.size() or connector_id < 0) {
+    if (connector_id > this->configuration->getNumberOfConnectors() or connector_id < 0) {
         response.status = GetCompositeScheduleStatus::Rejected;
     } else if (call.msg.chargingRateUnit and
                std::find(allowed_charging_rate_units.begin(), allowed_charging_rate_units.end(),

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2280,35 +2280,36 @@ void ChargePointImpl::handleSetChargingProfileRequest(ocpp::Call<SetChargingProf
     auto profile = call.msg.csChargingProfiles;
     const int connector_id = call.msg.connectorId;
 
-    const auto supported_purpose_types = this->configuration->getSupportedChargingProfilePurposeTypes();
-    if (std::find(supported_purpose_types.begin(), supported_purpose_types.end(),
-                  call.msg.csChargingProfiles.chargingProfilePurpose) == supported_purpose_types.end()) {
-        EVLOG_warning << "Rejecting SetChargingProfileRequest because purpose type is not supported: "
-                      << call.msg.csChargingProfiles.chargingProfilePurpose;
-        response.status = ChargingProfileStatus::Rejected;
-    } else if (this->smart_charging_handler->validate_profile(
-                   profile, connector_id, false, this->configuration->getChargeProfileMaxStackLevel(),
-                   this->configuration->getMaxChargingProfilesInstalled(),
-                   this->configuration->getChargingScheduleMaxPeriods(),
-                   this->configuration->getChargingScheduleAllowedChargingRateUnitVector())) {
-        response.status = ChargingProfileStatus::Accepted;
-        // If a charging profile with the same chargingProfileId, or the same combination of stackLevel /
-        // ChargingProfilePurpose, exists on the Charge Point, the new charging profile SHALL replace the
-        // existing charging profile, otherwise it SHALL be added.
-        this->smart_charging_handler->clear_all_profiles_with_filter(profile.chargingProfileId, std::nullopt,
-                                                                     std::nullopt, std::nullopt, true);
-        if (profile.chargingProfilePurpose == ChargingProfilePurposeType::ChargePointMaxProfile) {
-            this->smart_charging_handler->add_charge_point_max_profile(profile);
-        } else if (profile.chargingProfilePurpose == ChargingProfilePurposeType::TxDefaultProfile) {
-            this->smart_charging_handler->add_tx_default_profile(profile, connector_id);
-        } else if (profile.chargingProfilePurpose == ChargingProfilePurposeType::TxProfile) {
-            this->smart_charging_handler->add_tx_profile(profile, connector_id);
+    if(connector_id >0 and connector_id <= this->configuration->getNumberOfConnectors()) {
+        const auto supported_purpose_types = this->configuration->getSupportedChargingProfilePurposeTypes();
+        if (std::find(supported_purpose_types.begin(), supported_purpose_types.end(),
+                      call.msg.csChargingProfiles.chargingProfilePurpose) == supported_purpose_types.end()) {
+            EVLOG_warning << "Rejecting SetChargingProfileRequest because purpose type is not supported: "
+                          << call.msg.csChargingProfiles.chargingProfilePurpose;
+            response.status = ChargingProfileStatus::Rejected;
+        } else if (this->smart_charging_handler->validate_profile(
+                       profile, connector_id, false, this->configuration->getChargeProfileMaxStackLevel(),
+                       this->configuration->getMaxChargingProfilesInstalled(),
+                       this->configuration->getChargingScheduleMaxPeriods(),
+                       this->configuration->getChargingScheduleAllowedChargingRateUnitVector())) {
+            response.status = ChargingProfileStatus::Accepted;
+            // If a charging profile with the same chargingProfileId, or the same combination of stackLevel /
+            // ChargingProfilePurpose, exists on the Charge Point, the new charging profile SHALL replace the
+            // existing charging profile, otherwise it SHALL be added.
+            this->smart_charging_handler->clear_all_profiles_with_filter(profile.chargingProfileId, std::nullopt,
+                                                                         std::nullopt, std::nullopt, true);
+            if (profile.chargingProfilePurpose == ChargingProfilePurposeType::ChargePointMaxProfile) {
+                this->smart_charging_handler->add_charge_point_max_profile(profile);
+            } else if (profile.chargingProfilePurpose == ChargingProfilePurposeType::TxDefaultProfile) {
+                this->smart_charging_handler->add_tx_default_profile(profile, connector_id);
+            } else if (profile.chargingProfilePurpose == ChargingProfilePurposeType::TxProfile) {
+                this->smart_charging_handler->add_tx_profile(profile, connector_id);
+            }
+            response.status = ChargingProfileStatus::Accepted;
+        } else {
+            response.status = ChargingProfileStatus::Rejected;
         }
-        response.status = ChargingProfileStatus::Accepted;
-    } else {
-        response.status = ChargingProfileStatus::Rejected;
     }
-
     ocpp::CallResult<SetChargingProfileResponse> call_result(response, call.uniqueId);
     this->message_dispatcher->dispatch_call_result(call_result);
 


### PR DESCRIPTION
## Describe your changes
If from backend site, the connectorId is not in valid range, the relevant reject is answered to avoid undefined behavior.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

