### PR TITLE
Harden message_callback against runtime error

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1263,9 +1263,14 @@ void ChargePointImpl::message_callback(const std::string& message) {
         EVLOG_error << "Exception during handling of message: " << e.what();
         this->message_dispatcher->dispatch_call_error(
             CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({})));
+        return;
     } catch (const json::exception& e) {
         EVLOG_error << "JSON exception during reception of message: " << e.what();
         this->message_dispatcher->dispatch_call_error(CallError(MessageId("-1"), "GenericError", e.what(), json({})));
+        return;
+    } catch (const std::runtime_error& e) {
+        EVLOG_error << "runtime_error during reception of message: " << e.what();
+        this->send(CallError(MessageId("-1"), "GenericError", e.what(), json({})));
         return;
     }
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1270,7 +1270,7 @@ void ChargePointImpl::message_callback(const std::string& message) {
         return;
     } catch (const std::runtime_error& e) {
         EVLOG_error << "runtime_error during reception of message: " << e.what();
-        this->send(CallError(MessageId("-1"), "GenericError", e.what(), json({})));
+        this->message_dispatcher->dispatch_call_error(CallError(MessageId("-1"), "GenericError", e.what(), json({})));
         return;
     }
 


### PR DESCRIPTION
## Describe your changes
In terms runtime errors during message handling avoid undefined behavior.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

