### PR TITLE
Add option to select multiple ocpp versions to libwebsockets and connectivity_manager

### DIFF
--- a/include/ocpp/common/types.hpp
+++ b/include/ocpp/common/types.hpp
@@ -610,7 +610,9 @@ std::ostream& operator<<(std::ostream& os, const CertificateHashDataChain& k);
 
 enum class OcppProtocolVersion {
     v16,
-    v201
+    v201,
+    v21,
+    Unknown,
 };
 
 namespace conversions {

--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -16,7 +16,7 @@ class Websocket {
 private:
     // unique_ptr holds address of base - requires WebSocketBase to have a virtual destructor
     std::unique_ptr<WebsocketBase> websocket;
-    std::function<void(const int security_profile)> connected_callback;
+    std::function<void(OcppProtocolVersion protocol)> connected_callback;
     std::function<void()> disconnected_callback;
     std::function<void(const WebsocketCloseReason reason)> closed_callback;
     std::function<void(const std::string& message)> message_callback;
@@ -43,7 +43,7 @@ public:
     bool is_connected();
 
     /// \brief register a \p callback that is called when the websocket is connected successfully
-    void register_connected_callback(const std::function<void(const int security_profile)>& callback);
+    void register_connected_callback(const std::function<void(OcppProtocolVersion protocol)>& callback);
 
     /// \brief register a \p callback that is called when the websocket connection is disconnected
     void register_disconnected_callback(const std::function<void()>& callback);

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -17,8 +17,8 @@ namespace ocpp {
 
 struct WebsocketConnectionOptions {
     std::vector<OcppProtocolVersion> ocpp_versions; // List of allowed protocols ordered by preference
-    Uri csms_uri;         // the URI of the CSMS
-    int security_profile; // FIXME: change type to `SecurityProfile`
+    Uri csms_uri;                                   // the URI of the CSMS
+    int security_profile;                           // FIXME: change type to `SecurityProfile`
     std::optional<std::string> authorization_key;
     int retry_backoff_random_range_s;
     int retry_backoff_repeat_times;

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -16,7 +16,7 @@
 namespace ocpp {
 
 struct WebsocketConnectionOptions {
-    OcppProtocolVersion ocpp_version;
+    std::vector<OcppProtocolVersion> ocpp_versions; // List of allowed protocols ordered by preference
     Uri csms_uri;         // the URI of the CSMS
     int security_profile; // FIXME: change type to `SecurityProfile`
     std::optional<std::string> authorization_key;
@@ -47,7 +47,7 @@ class WebsocketBase {
 protected:
     std::atomic_bool m_is_connected;
     WebsocketConnectionOptions connection_options;
-    std::function<void(const int security_profile)> connected_callback;
+    std::function<void(OcppProtocolVersion protocol)> connected_callback;
     std::function<void()> disconnected_callback;
     std::function<void(const WebsocketCloseReason reason)> closed_callback;
     std::function<void(const std::string& message)> message_callback;
@@ -111,7 +111,7 @@ public:
     virtual void close(const WebsocketCloseReason code, const std::string& reason) = 0;
 
     /// \brief register a \p callback that is called when the websocket is connected successfully
-    void register_connected_callback(const std::function<void(const int security_profile)>& callback);
+    void register_connected_callback(const std::function<void(OcppProtocolVersion protocol)>& callback);
 
     /// \brief register a \p callback that is called when the websocket connection is disconnected
     void register_disconnected_callback(const std::function<void()>& callback);

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -110,6 +110,8 @@ private:
     std::mutex deferred_callback_mutex;
     std::condition_variable deferred_callback_cv;
     std::atomic_bool stop_deferred_handler;
+
+    OcppProtocolVersion connected_ocpp_version;
 };
 
 } // namespace ocpp

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -16,7 +16,7 @@ namespace v201 {
 class DeviceModel;
 
 using WebsocketConnectionCallback =
-    std::function<void(const int configuration_slot, const NetworkConnectionProfile& network_connection_profile)>;
+    std::function<void(int configuration_slot, const NetworkConnectionProfile& network_connection_profile, OcppProtocolVersion version)>;
 using WebsocketConnectionFailedCallback = std::function<void(ConnectionFailedReason reason)>;
 using ConfigureNetworkConnectionProfileCallback = std::function<std::future<ConfigNetworkResult>(
     const int32_t configuration_slot, const NetworkConnectionProfile& network_connection_profile)>;
@@ -51,6 +51,7 @@ private:
     std::vector<SetNetworkProfileRequest> cached_network_connection_profiles;
     /// @brief local cached network connection priorities
     std::vector<int32_t> network_connection_slots;
+    OcppProtocolVersion connected_ocpp_version;
 
 public:
     ConnectivityManager(DeviceModel& device_model, std::shared_ptr<EvseSecurity> evse_security,

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -161,7 +161,7 @@ private:
 
     /// \brief Function invoked when the web socket connected with the \p security_profile
     ///
-    void on_websocket_connected(const int security_profile);
+    void on_websocket_connected(OcppProtocolVersion protocol);
 
     /// \brief Function invoked when the web socket disconnected
     ///

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -15,8 +15,8 @@ namespace v201 {
 
 class DeviceModel;
 
-using WebsocketConnectionCallback =
-    std::function<void(int configuration_slot, const NetworkConnectionProfile& network_connection_profile, OcppProtocolVersion version)>;
+using WebsocketConnectionCallback = std::function<void(
+    int configuration_slot, const NetworkConnectionProfile& network_connection_profile, OcppProtocolVersion version)>;
 using WebsocketConnectionFailedCallback = std::function<void(ConnectionFailedReason reason)>;
 using ConfigureNetworkConnectionProfileCallback = std::function<std::future<ConfigNetworkResult>(
     const int32_t configuration_slot, const NetworkConnectionProfile& network_connection_profile)>;

--- a/lib/ocpp/common/types.cpp
+++ b/lib/ocpp/common/types.cpp
@@ -1068,6 +1068,10 @@ std::string ocpp_protocol_version_to_string(OcppProtocolVersion e) {
         return "ocpp1.6";
     case OcppProtocolVersion::v201:
         return "ocpp2.0.1";
+    case OcppProtocolVersion::v21:
+        return "ocpp2.1";
+    case OcppProtocolVersion::Unknown:
+        return "unknown";
     }
 
     throw EnumToStringException{e, "OcppProtocolVersion"};
@@ -1079,6 +1083,12 @@ OcppProtocolVersion string_to_ocpp_protocol_version(const std::string& s) {
     }
     if (s == "ocpp2.0.1") {
         return OcppProtocolVersion::v201;
+    }
+    if (s == "ocpp2.1") {
+        return OcppProtocolVersion::v21;
+    }
+    if (s == "unknown") {
+        return OcppProtocolVersion::Unknown;
     }
     throw StringToEnumException{s, "OcppProtocolVersion"};
 }

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -45,12 +45,12 @@ bool Websocket::is_connected() {
     return this->websocket->is_connected();
 }
 
-void Websocket::register_connected_callback(const std::function<void(const int security_profile)>& callback) {
+void Websocket::register_connected_callback(const std::function<void(OcppProtocolVersion protocol)>& callback) {
     this->connected_callback = callback;
 
-    this->websocket->register_connected_callback([this](const int security_profile) {
+    this->websocket->register_connected_callback([this](OcppProtocolVersion protocol) {
         this->logging->sys("Connected");
-        this->connected_callback(security_profile);
+        this->connected_callback(protocol);
     });
 }
 

--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -36,7 +36,7 @@ void WebsocketBase::set_connection_options_base(const WebsocketConnectionOptions
     this->connection_options = connection_options;
 }
 
-void WebsocketBase::register_connected_callback(const std::function<void(const int security_profile)>& callback) {
+void WebsocketBase::register_connected_callback(const std::function<void(OcppProtocolVersion protocol)>& callback) {
     this->connected_callback = callback;
 }
 

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -233,7 +233,10 @@ static bool verify_csms_cn(const std::string& hostname, bool preverified, const 
 
 WebsocketLibwebsockets::WebsocketLibwebsockets(const WebsocketConnectionOptions& connection_options,
                                                std::shared_ptr<EvseSecurity> evse_security) :
-    WebsocketBase(), evse_security(evse_security), stop_deferred_handler(false) {
+    WebsocketBase(),
+    evse_security(evse_security),
+    stop_deferred_handler(false),
+    connected_ocpp_version{OcppProtocolVersion::Unknown} {
 
     set_connection_options(connection_options);
 
@@ -276,6 +279,15 @@ void WebsocketLibwebsockets::set_connection_options(const WebsocketConnectionOpt
     default:
         throw std::invalid_argument("unknown `security_profile`, value = " +
                                     std::to_string(connection_options.security_profile));
+    }
+
+    if (connection_options.ocpp_versions.empty()) {
+        throw std::invalid_argument("Connection options must contain at least 1 option");
+    }
+
+    if (std::any_of(connection_options.ocpp_versions.begin(), connection_options.ocpp_versions.end(),
+                    [](OcppProtocolVersion version) { return version == OcppProtocolVersion::Unknown; })) {
+        throw std::invalid_argument("Ocpp_versions may not contain 'Unknown'");
     }
 
     set_connection_options_base(connection_options);
@@ -638,6 +650,15 @@ void WebsocketLibwebsockets::client_loop() {
 
     auto& uri = this->connection_options.csms_uri;
 
+    std::string ocpp_versions;
+    for (bool first = true; auto version : this->connection_options.ocpp_versions) {
+        if (!first) {
+            ocpp_versions += ", ";
+        }
+        first = false;
+        ocpp_versions += conversions::ocpp_protocol_version_to_string(version);
+    }
+
     // TODO: No idea who releases the strdup?
     i.context = lws_ctx;
     i.port = uri.get_port();
@@ -646,7 +667,7 @@ void WebsocketLibwebsockets::client_loop() {
     i.host = i.address;
     i.origin = i.address;
     i.ssl_connection = ssl_connection;
-    i.protocol = strdup(conversions::ocpp_protocol_version_to_string(this->connection_options.ocpp_version).c_str());
+    i.protocol = strdup(ocpp_versions.c_str());
     i.local_protocol_name = local_protocol_name;
     i.pwsi = &local_data->wsi;
     i.userdata = local_data.get(); // See lws_context 'user'
@@ -706,6 +727,8 @@ bool WebsocketLibwebsockets::connect() {
     EVLOG_info << "Connecting to uri: " << this->connection_options.csms_uri.string() << " with security-profile "
                << this->connection_options.security_profile
                << (this->connection_options.use_tpm_tls ? " with TPM keys" : "");
+
+    this->connected_ocpp_version = OcppProtocolVersion::Unknown;
 
     // new connection context
     std::shared_ptr<ConnectionData> local_data = std::make_shared<ConnectionData>();
@@ -884,7 +907,7 @@ void WebsocketLibwebsockets::close(const WebsocketCloseReason code, const std::s
 }
 
 void WebsocketLibwebsockets::on_conn_connected() {
-    EVLOG_info << "OCPP client successfully connected to server";
+    EVLOG_info << "OCPP client successfully connected to server with version: " << this->connected_ocpp_version;
 
     this->connection_attempts = 1; // reset connection attempts
     this->m_is_connected = true;
@@ -895,7 +918,7 @@ void WebsocketLibwebsockets::on_conn_connected() {
 
     this->push_deferred_callback([this]() {
         if (connected_callback) {
-            this->connected_callback(this->connection_options.security_profile);
+            this->connected_callback(this->connected_ocpp_version);
         } else {
             EVLOG_error << "Connected callback not registered!";
         }
@@ -1317,6 +1340,17 @@ int WebsocketLibwebsockets::process_callback(void* wsi_ptr, int callback_reason,
     case LWS_CALLBACK_CONNECTING:
         EVLOG_debug << "Client connecting...";
         data->update_state(EConnectionState::CONNECTING);
+        break;
+
+    case LWS_CALLBACK_CLIENT_FILTER_PRE_ESTABLISH:
+        try {
+            char buffer[16] = {0};
+            lws_hdr_copy(wsi, buffer, 16, WSI_TOKEN_PROTOCOL);
+            this->connected_ocpp_version = ocpp::conversions::string_to_ocpp_protocol_version(buffer);
+        } catch (StringToEnumException& e) {
+            EVLOG_warning << "CSMS did not select protocol: " << e.what();
+            this->connected_ocpp_version = OcppProtocolVersion::Unknown;
+        }
         break;
 
     case LWS_CALLBACK_CLIENT_ESTABLISHED:

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -651,7 +651,8 @@ void WebsocketLibwebsockets::client_loop() {
     auto& uri = this->connection_options.csms_uri;
 
     std::string ocpp_versions;
-    for (bool first = true; auto version : this->connection_options.ocpp_versions) {
+    bool first = true;
+    for (auto version : this->connection_options.ocpp_versions) {
         if (!first) {
             ocpp_versions += ", ";
         }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -288,7 +288,7 @@ void ChargePointImpl::init_websocket() {
     auto connection_options = this->get_ws_connection_options();
 
     this->websocket = std::make_unique<Websocket>(connection_options, this->evse_security, this->logging);
-    this->websocket->register_connected_callback([this](const int security_profile) {
+    this->websocket->register_connected_callback([this](OcppProtocolVersion protocol) {
         if (this->connection_state_changed_callback != nullptr) {
             this->connection_state_changed_callback(true);
         }
@@ -370,7 +370,7 @@ WebsocketConnectionOptions ChargePointImpl::get_ws_connection_options() {
     auto uri = Uri::parse_and_validate(this->configuration->getCentralSystemURI(),
                                        this->configuration->getChargePointId(), security_profile);
 
-    WebsocketConnectionOptions connection_options{OcppProtocolVersion::v16,
+    WebsocketConnectionOptions connection_options{{OcppProtocolVersion::v16},
                                                   uri,
                                                   security_profile,
                                                   this->configuration->getAuthorizationKey(),

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1137,9 +1137,13 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
                                               std::bind(&ChargePoint::message_callback, this, std::placeholders::_1));
 
     this->connectivity_manager->set_websocket_connected_callback(
-        std::bind(&ChargePoint::websocket_connected_callback, this, std::placeholders::_1, std::placeholders::_2));
+        [this](int configuration_slot, const NetworkConnectionProfile& network_connection_profile, auto) {
+            this->websocket_connected_callback(configuration_slot, network_connection_profile);
+        });
     this->connectivity_manager->set_websocket_disconnected_callback(
-        std::bind(&ChargePoint::websocket_disconnected_callback, this, std::placeholders::_1, std::placeholders::_2));
+        [this](int configuration_slot, const NetworkConnectionProfile& network_connection_profile, auto) {
+            this->websocket_disconnected_callback(configuration_slot, network_connection_profile);
+        });
     this->connectivity_manager->set_websocket_connection_failed_callback(
         std::bind(&ChargePoint::websocket_connection_failed, this, std::placeholders::_1));
 

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -226,7 +226,7 @@ void ConnectivityManager::try_connect_websocket() {
         this->websocket = std::make_unique<Websocket>(connection_options.value(), this->evse_security, this->logging);
 
         this->websocket->register_connected_callback(
-            std::bind(&ConnectivityManager::on_websocket_connected, this, std::placeholders::_1));
+            [this](OcppProtocolVersion protocol) { this->on_websocket_connected(protocol); });
         this->websocket->register_disconnected_callback(
             std::bind(&ConnectivityManager::on_websocket_disconnected, this));
         this->websocket->register_closed_callback(
@@ -330,7 +330,7 @@ ConnectivityManager::get_ws_connection_options(const int32_t configuration_slot)
             network_connection_profile.securityProfile);
 
         WebsocketConnectionOptions connection_options{
-            OcppProtocolVersion::v201,
+            {OcppProtocolVersion::v201},
             uri,
             network_connection_profile.securityProfile,
             this->device_model.get_optional_value<std::string>(ControllerComponentVariables::BasicAuthPassword),
@@ -367,7 +367,7 @@ ConnectivityManager::get_ws_connection_options(const int32_t configuration_slot)
     return std::nullopt;
 }
 
-void ConnectivityManager::on_websocket_connected([[maybe_unused]] int security_profile) {
+void ConnectivityManager::on_websocket_connected([[maybe_unused]] OcppProtocolVersion protocol) {
     const int actual_configuration_slot = get_active_network_configuration_slot();
     std::optional<NetworkConnectionProfile> network_connection_profile =
         this->get_network_connection_profile(actual_configuration_slot);


### PR DESCRIPTION
## Describe your changes

We can now fill in an array in connectivity options and libwebsockets will forward that to the CSMS. The CSMS must pick a protocol and we return that to the connectivity manager and charge point.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

