### PR TITLE
Defer websocket connect()

### DIFF
--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -104,6 +104,7 @@ private:
     std::queue<std::string> recv_message_queue;
     std::condition_variable recv_message_cv;
     std::string recv_buffered_message;
+    std::mutex thread_mutex;
 
     std::unique_ptr<std::thread> deferred_callback_thread;
     std::queue<std::function<void()>> deferred_callback_queue;

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1073,7 +1073,7 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->bootreason = bootreason;
     this->init_state_machine(connector_status_map);
     this->init_websocket();
-    this->websocket_timer.timeout([this]() { this->websocket->connect(); }, std::chrono::seconds(0));
+    std::thread([this]() { this->websocket->connect(); }).detach();
     // push transaction messages including SecurityEventNotification.req onto the message queue
     this->message_queue->get_persisted_messages_from_db(this->configuration->getDisableSecurityEventNotifications());
     this->boot_notification();

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -398,7 +398,7 @@ WebsocketConnectionOptions ChargePointImpl::get_ws_connection_options() {
 void ChargePointImpl::connect_websocket() {
     if (!this->websocket->is_connected()) {
         this->init_websocket();
-        this->websocket->connect();
+        this->websocket_timer.timeout([this]() { this->websocket->connect(); }, std::chrono::seconds(0));
     }
 }
 
@@ -1073,7 +1073,7 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->bootreason = bootreason;
     this->init_state_machine(connector_status_map);
     this->init_websocket();
-    this->websocket->connect();
+    this->websocket_timer.timeout([this]() { this->websocket->connect(); }, std::chrono::seconds(0));
     // push transaction messages including SecurityEventNotification.req onto the message queue
     this->message_queue->get_persisted_messages_from_db(this->configuration->getDisableSecurityEventNotifications());
     this->boot_notification();

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -135,7 +135,7 @@ void ConnectivityManager::connect(std::optional<int32_t> configuration_slot_opt)
         // After the websocket gets closed a reconnect will be triggered
         this->websocket->disconnect(WebsocketCloseReason::ServiceRestart);
     } else {
-        this->try_connect_websocket();
+        this->websocket_timer.timeout([this] { this->try_connect_websocket(); }, WEBSOCKET_INIT_DELAY);
     }
 }
 

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -135,7 +135,7 @@ void ConnectivityManager::connect(std::optional<int32_t> configuration_slot_opt)
         // After the websocket gets closed a reconnect will be triggered
         this->websocket->disconnect(WebsocketCloseReason::ServiceRestart);
     } else {
-        this->websocket_timer.timeout([this] { this->try_connect_websocket(); }, WEBSOCKET_INIT_DELAY);
+        this->websocket_timer.timeout([this] { this->try_connect_websocket(); }, std::chrono::seconds(0));
     }
 }
 

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -135,7 +135,7 @@ void ConnectivityManager::connect(std::optional<int32_t> configuration_slot_opt)
         // After the websocket gets closed a reconnect will be triggered
         this->websocket->disconnect(WebsocketCloseReason::ServiceRestart);
     } else {
-        this->websocket_timer.timeout([this] { this->try_connect_websocket(); }, std::chrono::seconds(0));
+        std::thread([this]() { this->try_connect_websocket(); }).detach();
     }
 }
 


### PR DESCRIPTION
## Describe your changes
The `start()` function of the charge_point could be blocking until a connection timeout occured when connection the websocket for the first time. This change defers the call to the connect() function so that the start() function does not block anymore.

Additionally introduced thread_mutex protecting access to threads of libwebsockets when the ~WebsocketLibwebsockets destructor was called it attempted to acquire a lock for the connection_mutex and joins the websocket_thread . But the websocket_thread runs the client_loop that also requires the lock when calling on_conn_fail, so the client_loop which could result in a deadlock

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

