### PR TITLE
Feature/890 move reservations callbacks and handlers to new functional block

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -31,7 +31,6 @@
 #include "ocpp/v201/messages/Get15118EVCertificate.hpp"
 #include <ocpp/v201/messages/Authorize.hpp>
 #include <ocpp/v201/messages/BootNotification.hpp>
-#include <ocpp/v201/messages/CancelReservation.hpp>
 #include <ocpp/v201/messages/CertificateSigned.hpp>
 #include <ocpp/v201/messages/ChangeAvailability.hpp>
 #include <ocpp/v201/messages/ClearCache.hpp>
@@ -63,7 +62,6 @@
 #include <ocpp/v201/messages/ReportChargingProfiles.hpp>
 #include <ocpp/v201/messages/RequestStartTransaction.hpp>
 #include <ocpp/v201/messages/RequestStopTransaction.hpp>
-#include <ocpp/v201/messages/ReserveNow.hpp>
 #include <ocpp/v201/messages/Reset.hpp>
 #include <ocpp/v201/messages/SecurityEventNotification.hpp>
 #include <ocpp/v201/messages/SendLocalList.hpp>

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -9,6 +9,7 @@
 
 #include <ocpp/common/message_dispatcher.hpp>
 #include <ocpp/v201/functional_blocks/data_transfer.hpp>
+#include <ocpp/v201/functional_blocks/reservation.hpp>
 
 #include <ocpp/common/charging_station_base.hpp>
 
@@ -390,6 +391,7 @@ private:
 
     std::unique_ptr<MessageDispatcherInterface<MessageType>> message_dispatcher;
     std::unique_ptr<DataTransferInterface> data_transfer;
+    std::unique_ptr<ReservationInterface> reservation;
 
     // utility
     std::shared_ptr<MessageQueue<v201::MessageType>> message_queue;
@@ -735,11 +737,6 @@ private:
     void handle_change_availability_req(Call<ChangeAvailabilityRequest> call);
     void handle_heartbeat_response(CallResult<HeartbeatResponse> call);
 
-    // Function Block H: Reservations
-    void handle_reserve_now_request(Call<ReserveNowRequest> call);
-    void handle_cancel_reservation_callback(Call<CancelReservationRequest> call);
-    void send_reserve_now_rejected_response(const MessageId& unique_id, const std::string& status_info);
-
     // Functional Block I: TariffAndCost
     void handle_costupdated_req(const Call<CostUpdatedRequest> call);
 
@@ -977,6 +974,8 @@ public:
     std::optional<int> get_priority_from_configuration_slot(const int configuration_slot) const override;
 
     const std::vector<int>& get_network_connection_slots() const override;
+
+    void send_not_implemented_error(const MessageId unique_message_id, const MessageTypeId message_type_id);
 
     /// \brief Requests a value of a VariableAttribute specified by combination of \p component_id and \p variable_id
     /// from the device model

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -41,7 +41,7 @@ public:
     /// \param connector_type   The connector type to check.
     /// \return True if connector type is unknown or this evse has the given connector type.
     ///
-    virtual bool does_connector_exist(ConnectorEnum connector_type) = 0;
+    virtual bool does_connector_exist(ConnectorEnum connector_type) const = 0;
 
     ///
     /// \brief Get connector status.
@@ -121,7 +121,7 @@ public:
     virtual void clear_idle_meter_values() = 0;
 
     /// \brief Returns a pointer to the connector with ID \param connector_id in this EVSE.
-    virtual Connector* get_connector(int32_t connector_id) = 0;
+    virtual Connector* get_connector(int32_t connector_id) const = 0;
 
     /// \brief Gets the effective Operative/Inoperative status of this EVSE
     virtual OperationalStatusEnum get_effective_operational_status() = 0;
@@ -223,7 +223,7 @@ private:
     /// \param connector_id     Connector id
     /// \return The connector type. If evse or connector id is not correct: std::nullopt.
     ///
-    std::optional<ConnectorEnum> get_evse_connector_type(const uint32_t connector_id);
+    std::optional<ConnectorEnum> get_evse_connector_type(const uint32_t connector_id) const;
 
 public:
     /// \brief Construct a new Evse object
@@ -247,7 +247,7 @@ public:
     int32_t get_id() const;
 
     uint32_t get_number_of_connectors() const;
-    bool does_connector_exist(const ConnectorEnum connector_type) override;
+    bool does_connector_exist(const ConnectorEnum connector_type) const override;
     std::optional<ConnectorStatusEnum> get_connector_status(std::optional<ConnectorEnum> connector_type) override;
 
     void open_transaction(const std::string& transaction_id, const int32_t connector_id, const DateTime& timestamp,
@@ -273,7 +273,7 @@ public:
     MeterValue get_idle_meter_value();
     void clear_idle_meter_values();
 
-    Connector* get_connector(int32_t connector_id);
+    Connector* get_connector(int32_t connector_id) const;
 
     OperationalStatusEnum get_effective_operational_status();
     void set_evse_operative_status(OperationalStatusEnum new_status, bool persist);

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -25,6 +25,12 @@ public:
     /// \note If \p id is not present this could throw an EvseOutOfRangeException
     virtual const EvseInterface& get_evse(int32_t id) const = 0;
 
+    /// \brief Check if the connector exists on the given evse id.
+    /// \param evse_id          The evse id to check for.
+    /// \param connector_type   The connector type.
+    /// \return False if evse id does not exist or evse does not have the given connector type.
+    virtual bool does_connector_exist(const int32_t evse_id, ConnectorEnum connector_type) const = 0;
+
     /// \brief Check if an evse with \p id exists
     virtual bool does_evse_exist(int32_t id) const = 0;
 
@@ -52,6 +58,7 @@ public:
     EvseInterface& get_evse(int32_t id) override;
     const EvseInterface& get_evse(const int32_t id) const override;
 
+    virtual bool does_connector_exist(const int32_t evse_id, const ConnectorEnum connector_type) const override;
     bool does_evse_exist(const int32_t id) const override;
 
     size_t get_number_of_evses() const override;

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -22,7 +22,7 @@ typedef std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const 
 
 class ReservationInterface : public MessageHandlerInterface {
 public:
-    virtual ~ReservationInterface() {};
+    virtual ~ReservationInterface(){};
     virtual void on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) = 0;
     virtual ocpp::ReservationCheckStatus
     is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -73,14 +73,6 @@ private: // Functions
     /// \return False if evse id does not exist or evse does not have the given connector type.
     ///
     bool does_connector_exist(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type);
-
-    ///
-    /// \brief Check if there is a connector available with the given connector type.
-    /// \param evse_id          The evse to check for.
-    /// \param connector_type   The connector type.
-    /// \return True when a connector is available and the evse id exists.
-    ///
-    bool is_connector_available(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type);
 };
 
 } // namespace ocpp::v201

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -16,7 +16,7 @@ class EvseManagerInterface;
 
 class ReservationInterface : public MessageHandlerInterface {
 public:
-    virtual ~ReservationInterface() {};
+    virtual ~ReservationInterface(){};
     virtual void on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) = 0;
     virtual ocpp::ReservationCheckStatus
     is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
@@ -61,7 +61,6 @@ public:
     virtual void on_reservation_cleared(const int32_t evse_id, const int32_t connector_id) override;
 
 private: // Functions
-
     void handle_reserve_now_request(Call<ReserveNowRequest> call);
     void handle_cancel_reservation_callback(Call<CancelReservationRequest> call);
 

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -12,7 +12,7 @@
 namespace ocpp::v201 {
 
 class EvseInterface;
-class EvseManager;
+class EvseManagerInterface;
 
 class ReservationInterface : public MessageHandlerInterface {
 public:
@@ -29,7 +29,7 @@ class Reservation : public ReservationInterface {
 private: // Members
     MessageDispatcherInterface<MessageType>& message_dispatcher;
     std::shared_ptr<DeviceModel> device_model;
-    EvseManager& evse_manager;
+    EvseManagerInterface& evse_manager;
 
     /// \brief Callback function is called when a reservation request is received from the CSMS
     std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback;
@@ -45,7 +45,7 @@ private: // Members
 
 public:
     Reservation(MessageDispatcherInterface<MessageType>& message_dispatcher, std::shared_ptr<DeviceModel> device_model,
-                EvseManager& evse_manager,
+                EvseManagerInterface& evse_manager,
                 std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback,
                 std::function<bool(const int32_t reservationId)> cancel_reservation_callback,
                 const std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -14,9 +14,15 @@ namespace ocpp::v201 {
 class EvseInterface;
 class EvseManagerInterface;
 
+typedef std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> ReserveNowCallback;
+typedef std::function<bool(const int32_t reservationId)> CancelReservationCallback;
+typedef std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,
+                                                   const std::optional<CiString<36>> groupIdToken)>
+    IsReservationForTokenCallback;
+
 class ReservationInterface : public MessageHandlerInterface {
 public:
-    virtual ~ReservationInterface(){};
+    virtual ~ReservationInterface() {};
     virtual void on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) = 0;
     virtual ocpp::ReservationCheckStatus
     is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
@@ -28,29 +34,24 @@ public:
 class Reservation : public ReservationInterface {
 private: // Members
     MessageDispatcherInterface<MessageType>& message_dispatcher;
-    std::shared_ptr<DeviceModel> device_model;
+    DeviceModel& device_model;
     EvseManagerInterface& evse_manager;
 
     /// \brief Callback function is called when a reservation request is received from the CSMS
-    std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback;
+    ReserveNowCallback reserve_now_callback;
     /// \brief Callback function is called when a cancel reservation request is received from the CSMS
-    std::function<bool(const int32_t reservationId)> cancel_reservation_callback;
+    CancelReservationCallback cancel_reservation_callback;
     ///
     /// \brief Check if the current reservation for the given evse id is made for the id token / group id token.
     /// \return The reservation check status of this evse / id token.
     ///
-    const std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,
-                                                     const std::optional<CiString<36>> groupIdToken)>
-        is_reservation_for_token_callback;
+    IsReservationForTokenCallback is_reservation_for_token_callback;
 
 public:
-    Reservation(MessageDispatcherInterface<MessageType>& message_dispatcher, std::shared_ptr<DeviceModel> device_model,
-                EvseManagerInterface& evse_manager,
-                std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback,
-                std::function<bool(const int32_t reservationId)> cancel_reservation_callback,
-                const std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,
-                                                                 const std::optional<CiString<36>> groupIdToken)>
-                    is_reservation_for_token_callback);
+    Reservation(MessageDispatcherInterface<MessageType>& message_dispatcher, DeviceModel& device_model,
+                EvseManagerInterface& evse_manager, ReserveNowCallback reserve_now_callback,
+                CancelReservationCallback cancel_reservation_callback,
+                const IsReservationForTokenCallback is_reservation_for_token_callback);
     virtual void handle_message(const ocpp::EnhancedMessage<MessageType>& message) override;
 
     virtual void on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) override;
@@ -63,16 +64,7 @@ public:
 private: // Functions
     void handle_reserve_now_request(Call<ReserveNowRequest> call);
     void handle_cancel_reservation_callback(Call<CancelReservationRequest> call);
-
     void send_reserve_now_rejected_response(const MessageId& unique_id, const std::string& status_info);
-
-    ///
-    /// \brief Check if the connector exists on the given evse id.
-    /// \param evse_id          The evse id to check for.
-    /// \param connector_type   The connector type.
-    /// \return False if evse id does not exist or evse does not have the given connector type.
-    ///
-    bool does_connector_exist(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type);
 };
 
 } // namespace ocpp::v201

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -60,10 +60,11 @@ public:
     virtual void on_reserved(const int32_t evse_id, const int32_t connector_id) override;
     virtual void on_reservation_cleared(const int32_t evse_id, const int32_t connector_id) override;
 
+private: // Functions
+
     void handle_reserve_now_request(Call<ReserveNowRequest> call);
     void handle_cancel_reservation_callback(Call<CancelReservationRequest> call);
 
-private: // Functions
     void send_reserve_now_rejected_response(const MessageId& unique_id, const std::string& status_info);
 
     ///

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v201/message_dispatcher.hpp>
+#include <ocpp/v201/message_handler.hpp>
+#include <ocpp/v201/messages/CancelReservation.hpp>
+#include <ocpp/v201/messages/ReservationStatusUpdate.hpp>
+#include <ocpp/v201/messages/ReserveNow.hpp>
+
+#pragma once
+
+namespace ocpp::v201 {
+
+class EvseInterface;
+class EvseManager;
+
+class ReservationInterface : public MessageHandlerInterface {
+public:
+    virtual ~ReservationInterface() {};
+    virtual void on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) = 0;
+    virtual ocpp::ReservationCheckStatus
+    is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
+                               const std::optional<IdToken>& group_id_token) const = 0;
+    virtual void on_reserved(const int32_t evse_id, const int32_t connector_id) = 0;
+    virtual void on_reservation_cleared(const int32_t evse_id, const int32_t connector_id) = 0;
+};
+
+class Reservation : public ReservationInterface {
+private: // Members
+    MessageDispatcherInterface<MessageType>& message_dispatcher;
+    std::shared_ptr<DeviceModel> device_model;
+    EvseManager& evse_manager;
+
+    /// \brief Callback function is called when a reservation request is received from the CSMS
+    std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback;
+    /// \brief Callback function is called when a cancel reservation request is received from the CSMS
+    std::function<bool(const int32_t reservationId)> cancel_reservation_callback;
+    ///
+    /// \brief Check if the current reservation for the given evse id is made for the id token / group id token.
+    /// \return The reservation check status of this evse / id token.
+    ///
+    const std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,
+                                                     const std::optional<CiString<36>> groupIdToken)>
+        is_reservation_for_token_callback;
+
+public:
+    Reservation(MessageDispatcherInterface<MessageType>& message_dispatcher, std::shared_ptr<DeviceModel> device_model,
+                EvseManager& evse_manager,
+                std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback,
+                std::function<bool(const int32_t reservationId)> cancel_reservation_callback,
+                const std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,
+                                                                 const std::optional<CiString<36>> groupIdToken)>
+                    is_reservation_for_token_callback);
+    virtual void handle_message(const ocpp::EnhancedMessage<MessageType>& message) override;
+
+    virtual void on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) override;
+    virtual ocpp::ReservationCheckStatus
+    is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
+                               const std::optional<IdToken>& group_id_token) const override;
+    virtual void on_reserved(const int32_t evse_id, const int32_t connector_id) override;
+    virtual void on_reservation_cleared(const int32_t evse_id, const int32_t connector_id) override;
+
+    void handle_reserve_now_request(Call<ReserveNowRequest> call);
+    void handle_cancel_reservation_callback(Call<CancelReservationRequest> call);
+
+private: // Functions
+    void send_reserve_now_rejected_response(const MessageId& unique_id, const std::string& status_info);
+
+    ///
+    /// \brief Check if the connector exists on the given evse id.
+    /// \param evse_id          The evse id to check for.
+    /// \param connector_type   The connector type.
+    /// \return False if evse id does not exist or evse does not have the given connector type.
+    ///
+    bool does_connector_exist(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type);
+
+    ///
+    /// \brief Check if there is a connector available with the given connector type.
+    /// \param evse_id          The evse to check for.
+    /// \param connector_type   The connector type.
+    /// \return True when a connector is available and the evse id exists.
+    ///
+    bool is_connector_available(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type);
+};
+
+} // namespace ocpp::v201

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -83,6 +83,7 @@ if(LIBOCPP_ENABLE_V201)
             ocpp/v201/connectivity_manager.cpp
             ocpp/v201/message_dispatcher.cpp
             ocpp/v201/functional_blocks/data_transfer.cpp
+            ocpp/v201/functional_blocks/reservation.cpp
     )
     add_subdirectory(ocpp/v201/messages)
 endif()

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -737,11 +737,15 @@ void ChargePoint::on_fault_cleared(const int32_t evse_id, const int32_t connecto
 }
 
 void ChargePoint::on_reserved(const int32_t evse_id, const int32_t connector_id) {
-    this->evse_manager->get_evse(evse_id).submit_event(connector_id, ConnectorEvent::Reserve);
+    if (this->reservation != nullptr) {
+        this->reservation->on_reserved(evse_id, connector_id);
+    }
 }
 
 void ChargePoint::on_reservation_cleared(const int32_t evse_id, const int32_t connector_id) {
-    this->evse_manager->get_evse(evse_id).submit_event(connector_id, ConnectorEvent::ReservationCleared);
+    if (this->reservation != nullptr) {
+        this->reservation->on_reservation_cleared(evse_id, connector_id);
+    }
 }
 
 bool ChargePoint::on_charging_state_changed(const uint32_t evse_id, const ChargingStateEnum charging_state,
@@ -1057,12 +1061,9 @@ void ChargePoint::on_variable_changed(const SetVariableData& set_variable_data) 
 }
 
 void ChargePoint::on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) {
-    ReservationStatusUpdateRequest req;
-    req.reservationId = reservation_id;
-    req.reservationUpdateStatus = status;
-
-    ocpp::Call<ReservationStatusUpdateRequest> call(req);
-    this->message_dispatcher->dispatch_call(call);
+    if (reservation != nullptr) {
+        this->reservation->on_reservation_status(reservation_id, status);
+    }
 }
 
 void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_structure,
@@ -1185,6 +1186,13 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
     this->data_transfer = std::make_unique<DataTransfer>(
         *this->message_dispatcher, this->callbacks.data_transfer_callback, DEFAULT_WAIT_FOR_FUTURE_TIMEOUT);
 
+    if (device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
+            .value_or(false)) {
+        this->reservation = std::make_unique<Reservation>(
+            *this->message_dispatcher, device_model, *this->evse_manager, this->callbacks.reserve_now_callback.value(),
+            this->callbacks.cancel_reservation_callback.value(), this->callbacks.is_reservation_for_token_callback);
+    }
+
     if (this->callbacks.configure_network_connection_profile_callback.has_value()) {
         this->connectivity_manager->set_configure_network_connection_profile_callback(
             this->callbacks.configure_network_connection_profile_callback.value());
@@ -1281,10 +1289,12 @@ void ChargePoint::handle_message(const EnhancedMessage<v201::MessageType>& messa
             this->handle_heartbeat_response(json_message);
             break;
         case MessageType::ReserveNow:
-            this->handle_reserve_now_request(json_message);
-            break;
         case MessageType::CancelReservation:
-            this->handle_cancel_reservation_callback(json_message);
+            if (this->reservation != nullptr) {
+                this->reservation->handle_message(message);
+            } else {
+                send_not_implemented_error(message.uniqueId, message.messageTypeId);
+            }
             break;
         case MessageType::SendLocalList:
             this->handle_send_local_authorization_list_req(json_message);
@@ -1350,18 +1360,12 @@ void ChargePoint::handle_message(const EnhancedMessage<v201::MessageType>& messa
             this->handle_costupdated_req(json_message);
             break;
         default:
-            if (message.messageTypeId == MessageTypeId::CALL) {
-                const auto call_error = CallError(message.uniqueId, "NotImplemented", "", json({}));
-                this->message_dispatcher->dispatch_call_error(call_error);
-            }
+            send_not_implemented_error(message.uniqueId, message.messageTypeId);
             break;
         }
     } catch (const MessageTypeNotImplementedException& e) {
         EVLOG_warning << e.what();
-        if (message.messageTypeId == MessageTypeId::CALL) {
-            const auto call_error = CallError(message.uniqueId, "NotImplemented", "", json({}));
-            this->message_dispatcher->dispatch_call_error(call_error);
-        }
+        send_not_implemented_error(message.uniqueId, message.messageTypeId);
     }
 }
 
@@ -1930,10 +1934,11 @@ std::optional<int32_t> ChargePoint::get_transaction_evseid(const CiString<36>& t
 ocpp::ReservationCheckStatus
 ChargePoint::is_evse_reserved_for_other(EvseInterface& evse, const IdToken& id_token,
                                         const std::optional<IdToken>& group_id_token) const {
-    const std::optional<CiString<36>> groupIdToken =
-        group_id_token.has_value() ? group_id_token.value().idToken : std::optional<CiString<36>>{};
+    if (this->reservation != nullptr) {
+        return this->reservation->is_evse_reserved_for_other(evse, id_token, group_id_token);
+    }
 
-    return callbacks.is_reservation_for_token_callback(evse.get_id(), id_token.idToken, groupIdToken);
+    return ReservationCheckStatus::NotReserved;
 }
 
 bool ChargePoint::is_evse_connector_available(EvseInterface& evse) const {
@@ -3312,142 +3317,6 @@ void ChargePoint::handle_heartbeat_response(CallResult<HeartbeatResponse> call) 
     }
 }
 
-void ChargePoint::handle_reserve_now_request(Call<ReserveNowRequest> call) {
-    ReserveNowResponse response;
-    response.status = ReserveNowStatusEnum::Rejected;
-    bool reservation_available = true;
-
-    std::string status_info;
-
-    if (!this->callbacks.reserve_now_callback.has_value()) {
-        reservation_available = false;
-        status_info = "Reservation is not implemented";
-    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
-                    .value_or(false)) {
-        status_info = "Reservation is not available";
-        reservation_available = false;
-    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)) {
-        reservation_available = false;
-        status_info = "Reservation is not enabled";
-    }
-
-    if (!reservation_available) {
-        // Reservation not available / implemented, return 'Rejected'.
-        // H01.FR.01
-        EVLOG_info << "Receiving a reservation request, but reservation is not enabled or implemented.";
-        send_reserve_now_rejected_response(call.uniqueId, status_info);
-        return;
-    }
-
-    // Check if we need a specific evse id during a reservation and if that is the case, if we recevied an evse id.
-    const ReserveNowRequest request = call.msg;
-    if (!request.evseId.has_value() &&
-        !this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrNonEvseSpecific)
-             .value_or(false)) {
-        // H01.FR.19
-        EVLOG_warning << "Trying to make a reservation, but no evse id was given while it should be sent in the "
-                         "request when NonEvseSpecific is disabled.";
-        send_reserve_now_rejected_response(
-            call.uniqueId,
-            "No evse id was given while it should be sent in the request when NonEvseSpecific is disabled");
-        return;
-    }
-
-    const std::optional<int32_t> evse_id = request.evseId;
-
-    if (evse_id.has_value()) {
-        if (evse_id <= 0 || !evse_manager->does_evse_exist(evse_id.value())) {
-            EVLOG_error << "Trying to make a reservation, but evse " << evse_id.value() << " is not a valid evse id.";
-            send_reserve_now_rejected_response(call.uniqueId, "Evse id does not exist");
-            return;
-        }
-
-        // Check if there is a connector available for this evse id.
-        if (!does_connector_exist(static_cast<uint32_t>(evse_id.value()), request.connectorType)) {
-            EVLOG_info << "Trying to make a reservation for connector type "
-                       << conversions::connector_enum_to_string(request.connectorType.value_or(ConnectorEnum::Unknown))
-                       << " for evse " << evse_id.value() << ", but this connector type does not exist.";
-            send_reserve_now_rejected_response(call.uniqueId, "Connector type does not exist");
-            return;
-        }
-    } else {
-        // No evse id. Just search for all evse's if there is something available for reservation
-        const uint64_t number_of_evses = evse_manager->get_number_of_evses();
-        if (number_of_evses <= 0) {
-            send_reserve_now_rejected_response(call.uniqueId, "No evse's found in charging station");
-            EVLOG_error << "Trying to make a reservation, but number of evse's is 0";
-            return;
-        }
-
-        bool connector_exists = false;
-        for (uint64_t i = 1; i <= number_of_evses; i++) {
-            if (this->does_connector_exist(i, request.connectorType)) {
-                connector_exists = true;
-            }
-
-            if (this->is_connector_available(i, request.connectorType)) {
-                // There is at least one connector available!
-                break;
-            }
-        }
-
-        if (!connector_exists) {
-            send_reserve_now_rejected_response(call.uniqueId, "Could not get status info from connector");
-            return;
-        }
-    }
-
-    // Connector exists and might or might not be available, but if the reservation id is already existing, reservation
-    // should be overwritten.
-
-    // Call reserve now callback and wait for the response.
-    const ReserveNowRequest reservation_request = call.msg;
-    response.status = this->callbacks.reserve_now_callback.value()(reservation_request);
-
-    // Reply with the response from the callback.
-    const ocpp::CallResult<ReserveNowResponse> call_result(response, call.uniqueId);
-    this->message_dispatcher->dispatch_call_result(call_result);
-
-    if (response.status == ReserveNowStatusEnum::Accepted) {
-        EVLOG_debug << "Reservation with id " << reservation_request.id << " for "
-                    << (reservation_request.evseId.has_value()
-                            ? " evse_id: " + std::to_string(reservation_request.evseId.value())
-                            : "")
-                    << " is accepted";
-    }
-}
-
-void ChargePoint::handle_cancel_reservation_callback(Call<CancelReservationRequest> call) {
-
-    CancelReservationResponse response;
-    if (!this->callbacks.cancel_reservation_callback.has_value() ||
-        !this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
-             .value_or(false) ||
-        !this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)
-             .value_or(false)) {
-        // Reservation not available / implemented, return 'Rejected'.
-        // H01.FR.01
-        EVLOG_info << "Receiving a cancel reservation request, but reservation is not implemented.";
-        response.status = CancelReservationStatusEnum::Rejected;
-    } else {
-        response.status = (this->callbacks.cancel_reservation_callback.value()(call.msg.reservationId)
-                               ? CancelReservationStatusEnum::Accepted
-                               : CancelReservationStatusEnum::Rejected);
-    }
-
-    const ocpp::CallResult<CancelReservationResponse> call_result(response, call.uniqueId);
-    this->message_dispatcher->dispatch_call_result(call_result);
-}
-
-void ChargePoint::send_reserve_now_rejected_response(const MessageId& unique_id, const std::string& status_info) {
-    ReserveNowResponse response;
-    response.status = ReserveNowStatusEnum::Rejected;
-    response.statusInfo = StatusInfo();
-    response.statusInfo->additionalInfo = status_info;
-    const ocpp::CallResult<ReserveNowResponse> call_result(response, unique_id);
-    this->message_dispatcher->dispatch_call_result(call_result);
-}
-
 void ChargePoint::handle_costupdated_req(const Call<CostUpdatedRequest> call) {
     CostUpdatedResponse response;
     ocpp::CallResult<CostUpdatedResponse> call_result(response, call.uniqueId);
@@ -4664,6 +4533,13 @@ std::optional<int> ChargePoint::get_priority_from_configuration_slot(const int c
 
 const std::vector<int>& ChargePoint::get_network_connection_slots() const {
     return this->connectivity_manager->get_network_connection_slots();
+}
+
+void ChargePoint::send_not_implemented_error(const MessageId unique_message_id, const MessageTypeId message_type_id) {
+    if (message_type_id == MessageTypeId::CALL) {
+        const auto call_error = CallError(unique_message_id, "NotImplemented", "", json({}));
+        this->message_dispatcher->dispatch_call_error(call_error);
+    }
 }
 
 // Static functions

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -10,7 +10,6 @@
 #include <ocpp/v201/messages/FirmwareStatusNotification.hpp>
 #include <ocpp/v201/messages/LogStatusNotification.hpp>
 #include <ocpp/v201/messages/NotifyDisplayMessages.hpp>
-#include <ocpp/v201/messages/ReservationStatusUpdate.hpp>
 #include <ocpp/v201/notify_report_requests_splitter.hpp>
 
 #include <optional>
@@ -1189,8 +1188,9 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
     if (device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
             .value_or(false)) {
         this->reservation = std::make_unique<Reservation>(
-            *this->message_dispatcher, device_model, *this->evse_manager, this->callbacks.reserve_now_callback.value(),
-            this->callbacks.cancel_reservation_callback.value(), this->callbacks.is_reservation_for_token_callback);
+            *this->message_dispatcher, *this->device_model, *this->evse_manager,
+            this->callbacks.reserve_now_callback.value(), this->callbacks.cancel_reservation_callback.value(),
+            this->callbacks.is_reservation_for_token_callback);
     }
 
     if (this->callbacks.configure_network_connection_profile_callback.has_value()) {

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -86,7 +86,7 @@ uint32_t Evse::get_number_of_connectors() const {
     return static_cast<uint32_t>(this->id_connector_map.size());
 }
 
-bool Evse::does_connector_exist(const ConnectorEnum connector_type) {
+bool Evse::does_connector_exist(const ConnectorEnum connector_type) const {
     const uint32_t number_of_connectors = this->get_number_of_connectors();
     if (number_of_connectors == 0) {
         return false;
@@ -110,7 +110,7 @@ bool Evse::does_connector_exist(const ConnectorEnum connector_type) {
             continue;
         }
 
-        ConnectorEnum type = this->get_evse_connector_type(i).value_or(ConnectorEnum::Unknown);
+        const ConnectorEnum type = this->get_evse_connector_type(i).value_or(ConnectorEnum::Unknown);
         if (type == ConnectorEnum::Unknown || type == connector_type) {
             return true;
         }
@@ -205,7 +205,7 @@ void Evse::delete_database_transaction() {
     }
 }
 
-std::optional<ConnectorEnum> Evse::get_evse_connector_type(const uint32_t connector_id) {
+std::optional<ConnectorEnum> Evse::get_evse_connector_type(const uint32_t connector_id) const {
 
     auto connector = this->get_connector(static_cast<int32_t>(connector_id));
     if (connector == nullptr) {
@@ -668,7 +668,7 @@ OperationalStatusEnum Evse::get_effective_operational_status() {
     return this->component_state_manager->get_evse_effective_operational_status(this->evse_id);
 }
 
-Connector* Evse::get_connector(int32_t connector_id) {
+Connector* Evse::get_connector(int32_t connector_id) const {
     if (connector_id <= 0 or connector_id > this->get_number_of_connectors()) {
         std::stringstream err_msg;
         err_msg << "ConnectorID " << connector_id << " out of bounds for EVSE " << this->evse_id;

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -43,6 +43,18 @@ const EvseInterface& EvseManager::get_evse(const int32_t id) const {
     return *this->evses.at(id - 1);
 }
 
+bool EvseManager::does_connector_exist(const int32_t evse_id, const ConnectorEnum connector_type) const {
+    const EvseInterface* evse;
+    try {
+        evse = &this->get_evse(evse_id);
+    } catch (const EvseOutOfRangeException&) {
+        EVLOG_error << "Evse id " << evse_id << " is not a valid evse id.";
+        return false;
+    }
+
+    return evse->does_connector_exist(connector_type);
+}
+
 bool EvseManager::does_evse_exist(const int32_t id) const {
     return id >= 0 && static_cast<uint64_t>(id) <= this->evses.size();
 }

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -137,11 +137,6 @@ void Reservation::handle_reserve_now_request(Call<ReserveNowRequest> call) {
         for (uint64_t i = 1; i <= number_of_evses; i++) {
             if (this->does_connector_exist(i, request.connectorType)) {
                 connector_exists = true;
-            }
-
-            // TODO mz do something with the result from is_connector_available or leave the call away.
-            if (connector_exists && this->is_connector_available(i, request.connectorType)) {
-                // There is at least one connector available!
                 break;
             }
         }

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -210,22 +210,4 @@ bool Reservation::does_connector_exist(const uint32_t evse_id, std::optional<Con
     return evse->does_connector_exist(connector_type.value_or(ConnectorEnum::Unknown));
 }
 
-bool Reservation::is_connector_available(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type) {
-    EvseInterface* evse;
-    try {
-        evse = &evse_manager.get_evse(static_cast<int32_t>(evse_id));
-    } catch (const EvseOutOfRangeException&) {
-        EVLOG_error << "Evse id " << evse_id << " is not a valid evse id.";
-        return false;
-    }
-
-    std::optional<ConnectorStatusEnum> status =
-        evse->get_connector_status(connector_type.value_or(ConnectorEnum::Unknown));
-    if (!status.has_value()) {
-        return false;
-    }
-
-    return status.value() == ConnectorStatusEnum::Available;
-}
-
 } // namespace ocpp::v201

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -127,7 +127,7 @@ void Reservation::handle_reserve_now_request(Call<ReserveNowRequest> call) {
     } else {
         // No evse id. Just search for all evse's if there is something available for reservation
         const uint64_t number_of_evses = evse_manager.get_number_of_evses();
-        if (number_of_evses <= 0) {
+        if (number_of_evses == 0) {
             send_reserve_now_rejected_response(call.uniqueId, "No evse's found in charging station");
             EVLOG_error << "Trying to make a reservation, but number of evse's is 0";
             return;

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -10,7 +10,7 @@
 namespace ocpp::v201 {
 Reservation::Reservation(
     MessageDispatcherInterface<MessageType>& message_dispatcher, std::shared_ptr<DeviceModel> device_model,
-    EvseManager& evse_manager,
+    EvseManagerInterface& evse_manager,
     std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback,
     std::function<bool(const int32_t reservationId)> cancel_reservation_callback,
     const std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -48,8 +48,7 @@ ocpp::ReservationCheckStatus
 Reservation::is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
                                         const std::optional<IdToken>& group_id_token) const {
     const std::optional<CiString<36>> no = std::nullopt;
-    const std::optional<CiString<36>> groupIdToken =
-        group_id_token.has_value() ? group_id_token.value().idToken : no;
+    const std::optional<CiString<36>> groupIdToken = group_id_token.has_value() ? group_id_token.value().idToken : no;
 
     return this->is_reservation_for_token_callback(evse.get_id(), id_token.idToken, groupIdToken);
 }

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -79,7 +79,7 @@ void Reservation::handle_reserve_now_request(Call<ReserveNowRequest> call) {
                     .value_or(false)) {
         status_info = "Reservation is not available";
         reservation_available = false;
-    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)) {
+    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled).value_or(false)) {
         reservation_available = false;
         status_info = "Reservation is not enabled";
     }
@@ -138,7 +138,8 @@ void Reservation::handle_reserve_now_request(Call<ReserveNowRequest> call) {
                 connector_exists = true;
             }
 
-            if (this->is_connector_available(i, request.connectorType)) {
+            // TODO mz do something with the result from is_connector_available or leave the call away.
+            if (connector_exists && this->is_connector_available(i, request.connectorType)) {
                 // There is at least one connector available!
                 break;
             }

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -79,7 +79,8 @@ void Reservation::handle_reserve_now_request(Call<ReserveNowRequest> call) {
                     .value_or(false)) {
         status_info = "Reservation is not available";
         reservation_available = false;
-    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled).value_or(false)) {
+    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)
+                    .value_or(false)) {
         reservation_available = false;
         status_info = "Reservation is not enabled";
     }

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/common/constants.hpp>
+#include <ocpp/v201/ctrlr_component_variables.hpp>
+#include <ocpp/v201/evse.hpp>
+#include <ocpp/v201/evse_manager.hpp>
+#include <ocpp/v201/functional_blocks/reservation.hpp>
+
+namespace ocpp::v201 {
+Reservation::Reservation(
+    MessageDispatcherInterface<MessageType>& message_dispatcher, std::shared_ptr<DeviceModel> device_model,
+    EvseManager& evse_manager,
+    std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback,
+    std::function<bool(const int32_t reservationId)> cancel_reservation_callback,
+    const std::function<ocpp::ReservationCheckStatus(const int32_t evse_id, const CiString<36> idToken,
+                                                     const std::optional<CiString<36>> groupIdToken)>
+        is_reservation_for_token_callback) :
+    message_dispatcher(message_dispatcher),
+    device_model(device_model),
+    evse_manager(evse_manager),
+    reserve_now_callback(reserve_now_callback),
+    cancel_reservation_callback(cancel_reservation_callback),
+    is_reservation_for_token_callback(is_reservation_for_token_callback) {
+}
+
+void Reservation::handle_message(const ocpp::EnhancedMessage<MessageType>& message) {
+    const auto& json_message = message.message;
+
+    switch (message.messageType) {
+    case MessageType::ReserveNow:
+        this->handle_reserve_now_request(json_message);
+        break;
+    case MessageType::CancelReservation:
+        this->handle_cancel_reservation_callback(json_message);
+        break;
+    default:
+        throw MessageTypeNotImplementedException(message.messageType);
+    }
+}
+
+void Reservation::on_reservation_status(const int32_t reservation_id, const ReservationUpdateStatusEnum status) {
+    ReservationStatusUpdateRequest req;
+    req.reservationId = reservation_id;
+    req.reservationUpdateStatus = status;
+
+    ocpp::Call<ReservationStatusUpdateRequest> call(req);
+    this->message_dispatcher.dispatch_call(call);
+}
+
+ocpp::ReservationCheckStatus
+Reservation::is_evse_reserved_for_other(const EvseInterface& evse, const IdToken& id_token,
+                                        const std::optional<IdToken>& group_id_token) const {
+    const std::optional<CiString<36>> groupIdToken =
+        group_id_token.has_value() ? group_id_token.value().idToken : std::optional<CiString<36>>{};
+
+    return this->is_reservation_for_token_callback(evse.get_id(), id_token.idToken, groupIdToken);
+}
+
+void Reservation::on_reserved(const int32_t evse_id, const int32_t connector_id) {
+    this->evse_manager.get_evse(evse_id).submit_event(connector_id, ConnectorEvent::Reserve);
+}
+
+void Reservation::on_reservation_cleared(const int32_t evse_id, const int32_t connector_id) {
+    this->evse_manager.get_evse(evse_id).submit_event(connector_id, ConnectorEvent::ReservationCleared);
+}
+
+void Reservation::handle_reserve_now_request(Call<ReserveNowRequest> call) {
+    ReserveNowResponse response;
+    response.status = ReserveNowStatusEnum::Rejected;
+    bool reservation_available = true;
+
+    std::string status_info;
+
+    if (this->reserve_now_callback == nullptr) {
+        reservation_available = false;
+        status_info = "Reservation is not implemented";
+    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
+                    .value_or(false)) {
+        status_info = "Reservation is not available";
+        reservation_available = false;
+    } else if (!this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)) {
+        reservation_available = false;
+        status_info = "Reservation is not enabled";
+    }
+
+    if (!reservation_available) {
+        // Reservation not available / implemented, return 'Rejected'.
+        // H01.FR.01
+        EVLOG_info << "Receiving a reservation request, but reservation is not enabled or implemented.";
+        send_reserve_now_rejected_response(call.uniqueId, status_info);
+        return;
+    }
+
+    // Check if we need a specific evse id during a reservation and if that is the case, if we recevied an evse id.
+    const ReserveNowRequest request = call.msg;
+    if (!request.evseId.has_value() &&
+        !this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrNonEvseSpecific)
+             .value_or(false)) {
+        // H01.FR.19
+        EVLOG_warning << "Trying to make a reservation, but no evse id was given while it should be sent in the "
+                         "request when NonEvseSpecific is disabled.";
+        send_reserve_now_rejected_response(
+            call.uniqueId,
+            "No evse id was given while it should be sent in the request when NonEvseSpecific is disabled");
+        return;
+    }
+
+    const std::optional<int32_t> evse_id = request.evseId;
+
+    if (evse_id.has_value()) {
+        if (evse_id <= 0 || !evse_manager.does_evse_exist(evse_id.value())) {
+            EVLOG_error << "Trying to make a reservation, but evse " << evse_id.value() << " is not a valid evse id.";
+            send_reserve_now_rejected_response(call.uniqueId, "Evse id does not exist");
+            return;
+        }
+
+        // Check if there is a connector available for this evse id.
+        if (!does_connector_exist(static_cast<uint32_t>(evse_id.value()), request.connectorType)) {
+            EVLOG_info << "Trying to make a reservation for connector type "
+                       << conversions::connector_enum_to_string(request.connectorType.value_or(ConnectorEnum::Unknown))
+                       << " for evse " << evse_id.value() << ", but this connector type does not exist.";
+            send_reserve_now_rejected_response(call.uniqueId, "Connector type does not exist");
+            return;
+        }
+    } else {
+        // No evse id. Just search for all evse's if there is something available for reservation
+        const uint64_t number_of_evses = evse_manager.get_number_of_evses();
+        if (number_of_evses <= 0) {
+            send_reserve_now_rejected_response(call.uniqueId, "No evse's found in charging station");
+            EVLOG_error << "Trying to make a reservation, but number of evse's is 0";
+            return;
+        }
+
+        bool connector_exists = false;
+        for (uint64_t i = 1; i <= number_of_evses; i++) {
+            if (this->does_connector_exist(i, request.connectorType)) {
+                connector_exists = true;
+            }
+
+            if (this->is_connector_available(i, request.connectorType)) {
+                // There is at least one connector available!
+                break;
+            }
+        }
+
+        if (!connector_exists) {
+            send_reserve_now_rejected_response(call.uniqueId, "Could not get status info from connector");
+            return;
+        }
+    }
+
+    // Connector exists and might or might not be available, but if the reservation id is already existing, reservation
+    // should be overwritten.
+
+    // Call reserve now callback and wait for the response.
+    const ReserveNowRequest reservation_request = call.msg;
+    response.status = this->reserve_now_callback(reservation_request);
+
+    // Reply with the response from the callback.
+    const ocpp::CallResult<ReserveNowResponse> call_result(response, call.uniqueId);
+    this->message_dispatcher.dispatch_call_result(call_result);
+
+    if (response.status == ReserveNowStatusEnum::Accepted) {
+        EVLOG_debug << "Reservation with id " << reservation_request.id << " for "
+                    << (reservation_request.evseId.has_value()
+                            ? " evse_id: " + std::to_string(reservation_request.evseId.value())
+                            : "")
+                    << " is accepted";
+    }
+}
+
+void Reservation::handle_cancel_reservation_callback(Call<CancelReservationRequest> call) {
+
+    CancelReservationResponse response;
+    if (this->cancel_reservation_callback == nullptr ||
+        !this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
+             .value_or(false) ||
+        !this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)
+             .value_or(false)) {
+        // Reservation not available / implemented, return 'Rejected'.
+        // H01.FR.01
+        EVLOG_info << "Receiving a cancel reservation request, but reservation is not implemented.";
+        response.status = CancelReservationStatusEnum::Rejected;
+    } else {
+        response.status =
+            (this->cancel_reservation_callback(call.msg.reservationId) ? CancelReservationStatusEnum::Accepted
+                                                                       : CancelReservationStatusEnum::Rejected);
+    }
+
+    const ocpp::CallResult<CancelReservationResponse> call_result(response, call.uniqueId);
+    this->message_dispatcher.dispatch_call_result(call_result);
+}
+
+void Reservation::send_reserve_now_rejected_response(const MessageId& unique_id, const std::string& status_info) {
+    ReserveNowResponse response;
+    response.status = ReserveNowStatusEnum::Rejected;
+    response.statusInfo = StatusInfo();
+    response.statusInfo->additionalInfo = status_info;
+    const ocpp::CallResult<ReserveNowResponse> call_result(response, unique_id);
+    this->message_dispatcher.dispatch_call_result(call_result);
+}
+
+bool Reservation::does_connector_exist(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type) {
+    EvseInterface* evse;
+    try {
+        evse = &evse_manager.get_evse(static_cast<int32_t>(evse_id));
+    } catch (const EvseOutOfRangeException&) {
+        EVLOG_error << "Evse id " << evse_id << " is not a valid evse id.";
+        return false;
+    }
+
+    return evse->does_connector_exist(connector_type.value_or(ConnectorEnum::Unknown));
+}
+
+bool Reservation::is_connector_available(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type) {
+    EvseInterface* evse;
+    try {
+        evse = &evse_manager.get_evse(static_cast<int32_t>(evse_id));
+    } catch (const EvseOutOfRangeException&) {
+        EVLOG_error << "Evse id " << evse_id << " is not a valid evse id.";
+        return false;
+    }
+
+    std::optional<ConnectorStatusEnum> status =
+        evse->get_connector_status(connector_type.value_or(ConnectorEnum::Unknown));
+    if (!status.has_value()) {
+        return false;
+    }
+
+    return status.value() == ConnectorStatusEnum::Available;
+}
+
+} // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/functional_blocks/CMakeLists.txt
+++ b/tests/lib/ocpp/v201/functional_blocks/CMakeLists.txt
@@ -3,4 +3,5 @@ target_include_directories(libocpp_unit_tests PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_sources(libocpp_unit_tests PRIVATE
-        test_data_transfer.cpp)
+        test_data_transfer.cpp
+        test_reservation.cpp)

--- a/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
@@ -26,40 +26,482 @@ using ::testing::Return;
 
 class ReservationTest : public ::testing::Test {
 public:
-protected:  // Functions
+protected: // Functions
+    ReservationTest() :
+        database_connection(std::make_unique<ocpp::common::DatabaseConnection>(DEVICE_MODEL_DB_IN_MEMORY_PATH)) {
+        database_connection->open_connection();
+        this->device_model = create_device_model();
+        this->reservation = std::make_unique<Reservation>(
+            mock_dispatcher, this->device_model, evse_manager, reserve_now_callback_mock.AsStdFunction(),
+            cancel_reservation_callback_mock.AsStdFunction(), is_reservation_for_token_callback_mock.AsStdFunction());
+    }
+
     void create_device_model_db(const std::string& path) {
         InitDeviceModelDb db(path, MIGRATION_FILES_PATH);
         db.initialize_database(CONFIG_PATH, true);
     }
 
-    std::shared_ptr<DeviceModel> create_device_model(const bool is_reservation_available) {
+    std::shared_ptr<DeviceModel> create_device_model(const bool is_reservation_available = true,
+                                                     const bool non_evse_specific_enabled = true) {
         create_device_model_db(DEVICE_MODEL_DB_IN_MEMORY_PATH);
         auto device_model_storage = std::make_unique<DeviceModelStorageSqlite>(DEVICE_MODEL_DB_IN_MEMORY_PATH);
         auto device_model = std::make_shared<DeviceModel>(std::move(device_model_storage));
         // Defaults
-        const auto& reservation_available = ControllerComponentVariables::ReservationCtrlrAvailable;
-        const auto& reservation_enabled = ControllerComponentVariables::ReservationCtrlrAvailable;
-        device_model->set_value(reservation_available.component, reservation_available.variable.value(),
-                                AttributeEnum::Actual, (is_reservation_available ? "true" : "false"), "test", true);
-        device_model->set_value(reservation_enabled.component, reservation_enabled.variable.value(), AttributeEnum::Actual,
-                                "true", "test", true);
+        set_reservation_available(device_model, is_reservation_available);
+        set_reservation_enabled(device_model, true);
+        set_non_evse_specific(device_model, non_evse_specific_enabled);
+
+        // Check values
+        const bool reservation_available_in_device_model =
+            device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
+                .value_or(false);
+        EXPECT_EQ(reservation_available_in_device_model, is_reservation_available);
+
+        const bool reservation_enabled_in_device_model =
+            device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)
+                .value_or(false);
+        EXPECT_EQ(reservation_enabled_in_device_model, true);
+
+        const bool non_evse_specific_enabled_device_model =
+            device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrNonEvseSpecific)
+                .value_or(false);
+        EXPECT_EQ(non_evse_specific_enabled_device_model, non_evse_specific_enabled);
+
         return device_model;
     }
 
-protected:    // Members
+    void set_reservation_enabled(std::shared_ptr<DeviceModel> device_model, const bool enabled) {
+
+        const auto& reservation_enabled = ControllerComponentVariables::ReservationCtrlrEnabled;
+        EXPECT_EQ(device_model->set_value(reservation_enabled.component, reservation_enabled.variable.value(),
+                                          AttributeEnum::Actual, enabled ? "true" : "false", "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_reservation_available(std::shared_ptr<DeviceModel> device_model, const bool available) {
+        const auto& reservation_available = ControllerComponentVariables::ReservationCtrlrAvailable;
+        EXPECT_EQ(device_model->set_value(reservation_available.component, reservation_available.variable.value(),
+                                          AttributeEnum::Actual, (available ? "true" : "false"), "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    void set_non_evse_specific(std::shared_ptr<DeviceModel> device_model, const bool non_evse_specific_enabled) {
+        const auto& non_evse_specific = ControllerComponentVariables::ReservationCtrlrNonEvseSpecific;
+        EXPECT_EQ(device_model->set_value(non_evse_specific.component, non_evse_specific.variable.value(),
+                                          AttributeEnum::Actual, (non_evse_specific_enabled ? "true" : "false"),
+                                          "default", true),
+                  SetVariableStatusEnum::Accepted);
+    }
+
+    ocpp::EnhancedMessage<MessageType>
+    create_example_reserve_now_request(const std::optional<int32_t> evse_id = std::nullopt,
+                                       const std::optional<ConnectorEnum> connector_type = std::nullopt) {
+        ReserveNowRequest request;
+        request.connectorType = connector_type;
+        request.evseId = evse_id;
+        request.id = 1;
+        IdToken id_token;
+        id_token.idToken = "SOME_TOKEN";
+        id_token.type = IdTokenEnum::ISO14443;
+        request.idToken = id_token;
+        ocpp::Call<ReserveNowRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::ReserveNow;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+    ocpp::EnhancedMessage<MessageType> create_example_cancel_reservation_request(const int32_t reservation_id) {
+        CancelReservationRequest request;
+        request.reservationId = reservation_id;
+        ocpp::Call<CancelReservationRequest> call(request);
+        ocpp::EnhancedMessage<MessageType> enhanced_message;
+        enhanced_message.messageType = MessageType::CancelReservation;
+        enhanced_message.message = call;
+        return enhanced_message;
+    }
+
+protected: // Members
+    // DatabaseConnection as member so the database keeps open and is not destroyed (because this is an in memory
+    // database).
+    std::unique_ptr<ocpp::common::DatabaseConnection> database_connection;
     MockMessageDispatcher mock_dispatcher;
     EvseManagerFake evse_manager{NR_OF_EVSES};
-    std::shared_ptr<DeviceModel> device_model = create_device_model(true);
+    std::shared_ptr<DeviceModel> device_model;
     MockFunction<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback_mock;
     MockFunction<bool(const int32_t reservationId)> cancel_reservation_callback_mock;
     MockFunction<ocpp::ReservationCheckStatus(const int32_t evse_id, const ocpp::CiString<36> idToken,
                                               const std::optional<ocpp::CiString<36>> groupIdToken)>
         is_reservation_for_token_callback_mock;
+    // Make reservation a unique ptr so we can create it after creating the device model.
+    std::unique_ptr<Reservation> reservation;
 };
 
-TEST_F(ReservationTest, handle_reserve_now) {
-    Reservation reservation(mock_dispatcher, device_model, evse_manager, reserve_now_callback_mock.AsStdFunction(),
-                            cancel_reservation_callback_mock.AsStdFunction(),
-                            is_reservation_for_token_callback_mock.AsStdFunction());
-    auto bla = NR_OF_EVSES;
+TEST_F(ReservationTest, handle_reserve_now_reservation_not_available) {
+    set_reservation_available(this->device_model, false);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "Reservation is not available");
+    }));
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EvseMock& m2 = evse_manager.get_mock(2);
+
+    EXPECT_CALL(m1, get_connector_status(_)).Times(0);
+    EXPECT_CALL(m2, get_connector_status(_)).Times(0);
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request();
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_callback_nullptr) {
+    Reservation r{mock_dispatcher,
+                  this->device_model,
+                  evse_manager,
+                  nullptr,
+                  cancel_reservation_callback_mock.AsStdFunction(),
+                  is_reservation_for_token_callback_mock.AsStdFunction()};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "Reservation is not implemented");
+    }));
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EvseMock& m2 = evse_manager.get_mock(2);
+
+    EXPECT_CALL(m1, get_connector_status(_)).Times(0);
+    EXPECT_CALL(m2, get_connector_status(_)).Times(0);
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request();
+    r.handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_reservation_disabled) {
+    set_reservation_enabled(this->device_model, false);
+
+    const bool reservation_enabled_in_device_model =
+        this->device_model->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)
+            .value_or(false);
+    EXPECT_EQ(reservation_enabled_in_device_model, false);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "Reservation is not enabled");
+    }));
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EvseMock& m2 = evse_manager.get_mock(2);
+
+    EXPECT_CALL(m1, get_connector_status(_)).Times(0);
+    EXPECT_CALL(m2, get_connector_status(_)).Times(0);
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request();
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_non_evse_specific_disabled) {
+    set_non_evse_specific(this->device_model, false);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(),
+                  "No evse id was given while it should be sent in the request when NonEvseSpecific is disabled");
+    }));
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EvseMock& m2 = evse_manager.get_mock(2);
+
+    EXPECT_CALL(m1, get_connector_status(_)).Times(0);
+    EXPECT_CALL(m2, get_connector_status(_)).Times(0);
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request();
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_evse_not_existing) {
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "Evse id does not exist");
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request(5);
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_connector_not_existing) {
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::Pan)).WillOnce(Return(false));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "Connector type does not exist");
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request(1, ConnectorEnum::Pan);
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_connectors_not_existing) {
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cG105)).WillOnce(Return(false));
+
+    EvseMock& m2 = evse_manager.get_mock(2);
+    EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cG105)).WillOnce(Return(false));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Rejected);
+        ASSERT_TRUE(response.statusInfo.has_value());
+        ASSERT_TRUE(response.statusInfo.value().additionalInfo.has_value());
+        EXPECT_EQ(response.statusInfo.value().additionalInfo.value(), "Could not get status info from connector");
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request =
+        create_example_reserve_now_request(std::nullopt, ConnectorEnum::cG105);
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_one_connector_not_existing) {
+    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
+
+    const ocpp::EnhancedMessage<MessageType> request =
+        create_example_reserve_now_request(std::nullopt, ConnectorEnum::cTesla);
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(false));
+
+    EvseMock& m2 = evse_manager.get_mock(2);
+    EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
+    EXPECT_CALL(m2, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Unavailable));
+
+    EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Accepted));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Accepted);
+    }));
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_all_connectors_not_available) {
+    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
+
+    const ocpp::EnhancedMessage<MessageType> request =
+        create_example_reserve_now_request(std::nullopt, ConnectorEnum::cTesla);
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
+    EXPECT_CALL(m1, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Unavailable));
+
+    EvseMock& m2 = evse_manager.get_mock(2);
+    EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
+    EXPECT_CALL(m2, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Unavailable));
+
+    EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Accepted));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Accepted);
+    }));
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_non_specific_evse_successful) {
+    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
+
+    const ocpp::EnhancedMessage<MessageType> request =
+        create_example_reserve_now_request(std::nullopt, ConnectorEnum::cTesla);
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
+    EXPECT_CALL(m1, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Available));
+
+    EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Accepted));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Accepted);
+    }));
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_specific_evse_successful) {
+    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request(2, ConnectorEnum::cTesla);
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cTesla)).Times(0);
+    EXPECT_CALL(m1, get_connector_status(tesla_connector_type)).Times(0);
+
+    EvseMock& m2 = evse_manager.get_mock(2);
+    EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
+
+    EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Accepted));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Accepted);
+    }));
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_reserve_now_specific_evse_occupied) {
+    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_reserve_now_request(2, ConnectorEnum::cTesla);
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cTesla)).Times(0);
+    EXPECT_CALL(m1, get_connector_status(tesla_connector_type)).Times(0);
+
+    EvseMock& m2 = evse_manager.get_mock(2);
+    EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
+
+    EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Occupied));
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<ReserveNowResponse>();
+        EXPECT_EQ(response.status, ReserveNowStatusEnum::Occupied);
+    }));
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_cancel_reservation_reservation_not_available) {
+    set_reservation_available(this->device_model, false);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<CancelReservationResponse>();
+        EXPECT_EQ(response.status, CancelReservationStatusEnum::Rejected);
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_cancel_reservation_request(2);
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_cancel_reservation_reservation_not_enabled) {
+    set_reservation_enabled(this->device_model, false);
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<CancelReservationResponse>();
+        EXPECT_EQ(response.status, CancelReservationStatusEnum::Rejected);
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_cancel_reservation_request(2);
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_cancel_reservation_callback_nullptr) {
+    Reservation r{mock_dispatcher, this->device_model,
+                  evse_manager,    reserve_now_callback_mock.AsStdFunction(),
+                  nullptr,         is_reservation_for_token_callback_mock.AsStdFunction()};
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<CancelReservationResponse>();
+        EXPECT_EQ(response.status, CancelReservationStatusEnum::Rejected);
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_cancel_reservation_request(2);
+
+    r.handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_cancel_reservation_accepted) {
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<CancelReservationResponse>();
+        EXPECT_EQ(response.status, CancelReservationStatusEnum::Accepted);
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_cancel_reservation_request(2);
+
+    EXPECT_CALL(cancel_reservation_callback_mock, Call(_)).WillOnce(Return(true));
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, handle_cancel_reservation_rejected) {
+    EXPECT_CALL(mock_dispatcher, dispatch_call_result(_)).WillOnce(Invoke([](const json& call_result) {
+        auto response = call_result[ocpp::CALLRESULT_PAYLOAD].get<CancelReservationResponse>();
+        EXPECT_EQ(response.status, CancelReservationStatusEnum::Rejected);
+    }));
+
+    const ocpp::EnhancedMessage<MessageType> request = create_example_cancel_reservation_request(2);
+
+    EXPECT_CALL(cancel_reservation_callback_mock, Call(_)).WillOnce(Return(false));
+
+    this->reservation->handle_message(request);
+}
+
+TEST_F(ReservationTest, on_reservation_status) {
+    ReservationStatusUpdateRequest request;
+    request.reservationId = 3;
+    request.reservationUpdateStatus = ReservationUpdateStatusEnum::Removed;
+    ocpp::Call<ReservationStatusUpdateRequest> call(request);
+    ocpp::EnhancedMessage<MessageType> enhanced_message;
+    enhanced_message.messageType = MessageType::CancelReservation;
+    enhanced_message.message = call;
+
+    EXPECT_CALL(mock_dispatcher, dispatch_call(_, _)).WillOnce(Invoke([](const json& call, bool triggered) {
+        auto response = call[ocpp::CALL_PAYLOAD].get<ReservationStatusUpdateRequest>();
+        EXPECT_EQ(response.reservationUpdateStatus, ReservationUpdateStatusEnum::Removed);
+        EXPECT_EQ(response.reservationId, 3);
+        EXPECT_FALSE(triggered);
+    }));
+
+    reservation->on_reservation_status(3, ReservationUpdateStatusEnum::Removed);
+}
+
+TEST_F(ReservationTest, is_evse_reserved_for_other) {
+    EXPECT_CALL(is_reservation_for_token_callback_mock, Call(42, _, _))
+        .WillOnce(Return(ocpp::ReservationCheckStatus::NotReserved));
+
+    EvseMock& m1 = evse_manager.get_mock(1);
+    IdToken id_token;
+    id_token.idToken = "ID_TOKEN_THINGIE";
+
+    EXPECT_CALL(m1, get_id).WillOnce(Return(42));
+
+    EXPECT_EQ(reservation->is_evse_reserved_for_other(m1, id_token, std::nullopt),
+              ocpp::ReservationCheckStatus::NotReserved);
+}
+
+TEST_F(ReservationTest, on_reserved) {
+    EvseMock& m1 = evse_manager.get_mock(2);
+    EXPECT_CALL(m1, submit_event(1, ConnectorEvent::Reserve)).Times(1);
+
+    reservation->on_reserved(2, 1);
+}
+
+TEST_F(ReservationTest, on_reservation_cleared) {
+    EvseMock& m1 = evse_manager.get_mock(1);
+    EXPECT_CALL(m1, submit_event(1, ConnectorEvent::ReservationCleared)).Times(1);
+
+    reservation->on_reserved(1, 1);
 }

--- a/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
@@ -65,18 +65,15 @@ protected: // Functions
 
         // Check values
         const bool reservation_available_in_device_model =
-            dm->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable)
-                .value_or(false);
+            dm->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrAvailable).value_or(false);
         EXPECT_EQ(reservation_available_in_device_model, is_reservation_available);
 
         const bool reservation_enabled_in_device_model =
-            dm->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled)
-                .value_or(false);
+            dm->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrEnabled).value_or(false);
         EXPECT_EQ(reservation_enabled_in_device_model, is_reservation_enabled);
 
         const bool non_evse_specific_enabled_device_model =
-            dm->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrNonEvseSpecific)
-                .value_or(false);
+            dm->get_optional_value<bool>(ControllerComponentVariables::ReservationCtrlrNonEvseSpecific).value_or(false);
         EXPECT_EQ(non_evse_specific_enabled_device_model, non_evse_specific_enabled);
 
         return dm;

--- a/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "evse_manager_fake.hpp"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <message_dispatcher_mock.hpp>
+
+#include <ocpp/v201/functional_blocks/reservation.hpp>
+
+#include <ocpp/v201/ctrlr_component_variables.hpp>
+#include <ocpp/v201/device_model_storage_sqlite.hpp>
+#include <ocpp/v201/init_device_model_db.hpp>
+
+const static std::string MIGRATION_FILES_PATH = "./resources/v201/device_model_migration_files";
+const static std::string CONFIG_PATH = "./resources/example_config/v201/component_config";
+const static std::string DEVICE_MODEL_DB_IN_MEMORY_PATH = "file::memory:?cache=shared";
+const static uint32_t NR_OF_EVSES = 2;
+
+using namespace ocpp::v201;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::MockFunction;
+using ::testing::Return;
+
+class ReservationTest : public ::testing::Test {
+public:
+protected:  // Functions
+    void create_device_model_db(const std::string& path) {
+        InitDeviceModelDb db(path, MIGRATION_FILES_PATH);
+        db.initialize_database(CONFIG_PATH, true);
+    }
+
+    std::shared_ptr<DeviceModel> create_device_model(const bool is_reservation_available) {
+        create_device_model_db(DEVICE_MODEL_DB_IN_MEMORY_PATH);
+        auto device_model_storage = std::make_unique<DeviceModelStorageSqlite>(DEVICE_MODEL_DB_IN_MEMORY_PATH);
+        auto device_model = std::make_shared<DeviceModel>(std::move(device_model_storage));
+        // Defaults
+        const auto& reservation_available = ControllerComponentVariables::ReservationCtrlrAvailable;
+        const auto& reservation_enabled = ControllerComponentVariables::ReservationCtrlrAvailable;
+        device_model->set_value(reservation_available.component, reservation_available.variable.value(),
+                                AttributeEnum::Actual, (is_reservation_available ? "true" : "false"), "test", true);
+        device_model->set_value(reservation_enabled.component, reservation_enabled.variable.value(), AttributeEnum::Actual,
+                                "true", "test", true);
+        return device_model;
+    }
+
+protected:    // Members
+    MockMessageDispatcher mock_dispatcher;
+    EvseManagerFake evse_manager{NR_OF_EVSES};
+    std::shared_ptr<DeviceModel> device_model = create_device_model(true);
+    MockFunction<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback_mock;
+    MockFunction<bool(const int32_t reservationId)> cancel_reservation_callback_mock;
+    MockFunction<ocpp::ReservationCheckStatus(const int32_t evse_id, const ocpp::CiString<36> idToken,
+                                              const std::optional<ocpp::CiString<36>> groupIdToken)>
+        is_reservation_for_token_callback_mock;
+};
+
+TEST_F(ReservationTest, handle_reserve_now) {
+    Reservation reservation(mock_dispatcher, device_model, evse_manager, reserve_now_callback_mock.AsStdFunction(),
+                            cancel_reservation_callback_mock.AsStdFunction(),
+                            is_reservation_for_token_callback_mock.AsStdFunction());
+    auto bla = NR_OF_EVSES;
+}

--- a/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
@@ -327,8 +327,6 @@ TEST_F(ReservationTest, handle_reserve_now_connectors_not_existing) {
 TEST_F(ReservationTest, handle_reserve_now_one_connector_not_existing) {
     // Try to make a non evse specific reservation. One connector does not have the given connector, but the other does,
     // so the reservation request should be accepted.
-    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
-
     const ocpp::EnhancedMessage<MessageType> request =
         create_example_reserve_now_request(std::nullopt, ConnectorEnum::cTesla);
 
@@ -337,7 +335,6 @@ TEST_F(ReservationTest, handle_reserve_now_one_connector_not_existing) {
 
     EvseMock& m2 = evse_manager.get_mock(2);
     EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
-    EXPECT_CALL(m2, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Unavailable));
 
     EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Accepted));
 
@@ -353,18 +350,14 @@ TEST_F(ReservationTest, handle_reserve_now_all_connectors_not_available) {
     // Try to make a reservation with all connectors unavailable. Since the evse manager has the last word in this,
     // we try to do the request and it can be accepted anyway (or at least the correct reason for not accepting the
     // reservation can be returned, if this is a real scenario).
-    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
-
     const ocpp::EnhancedMessage<MessageType> request =
         create_example_reserve_now_request(std::nullopt, ConnectorEnum::cTesla);
 
     EvseMock& m1 = evse_manager.get_mock(1);
     EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
-    EXPECT_CALL(m1, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Unavailable));
 
     EvseMock& m2 = evse_manager.get_mock(2);
-    EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
-    EXPECT_CALL(m2, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Unavailable));
+    EXPECT_CALL(m2, does_connector_exist(ConnectorEnum::cTesla)).Times(0);
 
     EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Accepted));
 
@@ -378,14 +371,11 @@ TEST_F(ReservationTest, handle_reserve_now_all_connectors_not_available) {
 
 TEST_F(ReservationTest, handle_reserve_now_non_specific_evse_successful) {
     // Try to make a non evse specific reservation which is accepted.
-    std::optional<ConnectorEnum> tesla_connector_type = ConnectorEnum::cTesla;
-
     const ocpp::EnhancedMessage<MessageType> request =
         create_example_reserve_now_request(std::nullopt, ConnectorEnum::cTesla);
 
     EvseMock& m1 = evse_manager.get_mock(1);
     EXPECT_CALL(m1, does_connector_exist(ConnectorEnum::cTesla)).WillOnce(Return(true));
-    EXPECT_CALL(m1, get_connector_status(tesla_connector_type)).WillOnce(Return(ConnectorStatusEnum::Available));
 
     EXPECT_CALL(reserve_now_callback_mock, Call(_)).WillOnce(Return(ReserveNowStatusEnum::Accepted));
 

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -52,6 +52,14 @@ public:
         return *this->evses.at(id - 1);
     }
 
+    virtual bool does_connector_exist(const int32_t evse_id, ConnectorEnum connector_type) const override {
+        if (evse_id > this->evses.size()) {
+            return false;
+        }
+
+        return get_evse(evse_id).does_connector_exist(connector_type);
+    }
+
     bool does_evse_exist(int32_t id) const override {
         return id <= this->evses.size();
     }

--- a/tests/lib/ocpp/v201/mocks/evse_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_mock.hpp
@@ -12,7 +12,7 @@ class EvseMock : public EvseInterface {
 public:
     MOCK_METHOD(int32_t, get_id, (), (const));
     MOCK_METHOD(uint32_t, get_number_of_connectors, (), (const));
-    MOCK_METHOD(bool, does_connector_exist, (ConnectorEnum connector_type));
+    MOCK_METHOD(bool, does_connector_exist, (ConnectorEnum connector_type), (const));
     MOCK_METHOD(std::optional<ConnectorStatusEnum>, get_connector_status,
                 (std::optional<ConnectorEnum> connector_type));
     MOCK_METHOD(void, open_transaction,
@@ -32,7 +32,7 @@ public:
     MOCK_METHOD(MeterValue, get_meter_value, ());
     MOCK_METHOD(MeterValue, get_idle_meter_value, ());
     MOCK_METHOD(void, clear_idle_meter_values, ());
-    MOCK_METHOD(Connector*, get_connector, (int32_t connector_id));
+    MOCK_METHOD(Connector*, get_connector, (int32_t connector_id), (const));
     MOCK_METHOD(OperationalStatusEnum, get_effective_operational_status, ());
     MOCK_METHOD(void, set_evse_operative_status, (OperationalStatusEnum new_status, bool persist));
     MOCK_METHOD(void, set_connector_operative_status,

--- a/tests/lib/ocpp/v201/test_charge_point.cpp
+++ b/tests/lib/ocpp/v201/test_charge_point.cpp
@@ -195,6 +195,7 @@ public:
     testing::MockFunction<void()> set_charging_profiles_callback_mock;
     testing::MockFunction<ReserveNowStatusEnum(const ReserveNowRequest& request)> reserve_now_callback_mock;
     testing::MockFunction<bool(const int32_t reservationId)> cancel_reservation_callback_mock;
+
     ocpp::v201::Callbacks callbacks;
 };
 


### PR DESCRIPTION
## Describe your changes
Create reservations functional block and move callbacks there. Create unit tests.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

