### PR TITLE
Bugfix/libwebsocket dtor deadlock

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.21.0
+    VERSION 0.22.0
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/common/safe_queue.hpp
+++ b/include/ocpp/common/safe_queue.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+// Copyright 2020 - 2024 Pionix GmbH and Contributors to EVerest
 
 #pragma once
 
@@ -9,19 +9,10 @@
 
 namespace ocpp {
 
-enum class EThreadNotifyPolicy {
-    // Never notify the waiting thread
-    ThreadNotify_Never,
-    // Notify the waiting thread when we push an element in the queue
-    ThreadNotify_Push,
-    // Notify the waiting thread when we pop an element from the queue
-    ThreadNotify_Pop,
-    // Always notify a waiting thread on all operations
-    ThreadNotify_Always,
-};
-
-/// \brief Thread safe message queue
-template <typename T, EThreadNotifyPolicy Policy = EThreadNotifyPolicy::ThreadNotify_Push> class SafeQueue {
+/// \brief Thread safe message queue. Holds a conditional variable
+/// that can be waited upon. Will take up the waiting thread on each
+/// operation of push/pop/clear
+template <typename T> class SafeQueue {
     using safe_queue_reference = typename std::queue<T>::reference;
     using safe_queue_const_reference = typename std::queue<T>::const_reference;
 
@@ -52,10 +43,7 @@ public:
         // Unlock here and notify
         lock.unlock();
 
-        if constexpr (Policy == EThreadNotifyPolicy::ThreadNotify_Always ||
-                      Policy == EThreadNotifyPolicy::ThreadNotify_Pop) {
-            notify_waiting_thread();
-        }
+        notify_waiting_thread();
 
         return front;
     }
@@ -67,10 +55,7 @@ public:
             queue.push(value);
         }
 
-        if constexpr (Policy == EThreadNotifyPolicy::ThreadNotify_Always ||
-                      Policy == EThreadNotifyPolicy::ThreadNotify_Push) {
-            notify_waiting_thread();
-        }
+        notify_waiting_thread();
     }
 
     /// \brief Queues an element and notifies any threads waiting on the internal conditional variable
@@ -80,10 +65,7 @@ public:
             queue.push(value);
         }
 
-        if constexpr (Policy == EThreadNotifyPolicy::ThreadNotify_Always ||
-                      Policy == EThreadNotifyPolicy::ThreadNotify_Push) {
-            notify_waiting_thread();
-        }
+        notify_waiting_thread();
     }
 
     /// \brief Clears the queue
@@ -95,23 +77,19 @@ public:
             empty.swap(queue);
         }
 
-        if constexpr (Policy != EThreadNotifyPolicy::ThreadNotify_Never) {
-            // Clear should make all waiting threads
-            // wake to check for other states
-            notify_waiting_thread();
-        }
+        notify_waiting_thread();
     }
 
     /// \brief Waits for the queue to receive an element
     /// \param timeout to wait for an element, pass in a value <= 0 to wait indefinitely
     inline void wait_on_queue_element(std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) {
-        wait_on_queue_element_predicate([]() { return false; }, timeout);
+        wait_on_queue_element_or_predicate([]() { return false; }, timeout);
     }
 
     /// \brief Same as 'wait_on_queue' but receives an additional predicate to wait upon
     template <class Predicate>
-    inline void wait_on_queue_element_predicate(Predicate pred,
-                                                std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) {
+    inline void wait_on_queue_element_or_predicate(Predicate pred,
+                                                   std::chrono::milliseconds timeout = std::chrono::milliseconds(0)) {
         std::unique_lock<std::mutex> lock(mutex);
 
         if (timeout.count() > 0) {

--- a/include/ocpp/common/safe_queue.hpp
+++ b/include/ocpp/common/safe_queue.hpp
@@ -10,9 +10,13 @@
 namespace ocpp {
 
 enum class EThreadNotifyPolicy {
+    // Never notify the waiting thread
     ThreadNotify_Never,
+    // Notify the waiting thread when we push an element in the queue
     ThreadNotify_Push,
+    // Notify the waiting thread when we pop an element from the queue
     ThreadNotify_Pop,
+    // Always notify a waiting thread on all operations
     ThreadNotify_Always,
 };
 
@@ -91,9 +95,11 @@ public:
             empty.swap(queue);
         }
 
-        // Clear should make all waiting threads
-        // wake to check for other states
-        notify_waiting_thread();
+        if constexpr (Policy != EThreadNotifyPolicy::ThreadNotify_Never) {
+            // Clear should make all waiting threads
+            // wake to check for other states
+            notify_waiting_thread();
+        }
     }
 
     /// \brief Waits for the queue to receive an element

--- a/include/ocpp/common/safe_queue.hpp
+++ b/include/ocpp/common/safe_queue.hpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 - 2023 Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+
+namespace ocpp {
+
+/// \brief Thread safe message queue
+template <typename T> class SafeQueue {
+    using safe_queue_reference = typename std::queue<T>::reference;
+    using safe_queue_const_reference = typename std::queue<T>::const_reference;
+
+public:
+    /// \return True if the queue is empty
+    inline bool empty() const {
+        std::lock_guard lock(mutex);
+        return queue.empty();
+    }
+
+    inline safe_queue_reference front() const {
+        std::lock_guard lock(mutex);
+        return queue.front();
+    }
+
+    inline safe_queue_const_reference front() {
+        std::lock_guard lock(mutex);
+        return queue.front();
+    }
+
+    /// \return retrieves and removes the first element in the queue. Undefined behavior if the queue is empty
+    inline T pop() {
+        std::lock_guard lock(mutex);
+
+        T front = std::move(queue.front());
+        queue.pop();
+
+        return front;
+    }
+
+    /// \brief Queues an element and notifies any threads waiting on the internal conditional variable
+    inline void push(T&& value) {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            queue.push(value);
+        }
+
+        notify_waiting_thread();
+    }
+
+    /// \brief Queues an element and notifies any threads waiting on the internal conditional variable
+    inline void push(const T& value) {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            queue.push(value);
+        }
+
+        notify_waiting_thread();
+    }
+
+    /// \brief Clears the queue
+    inline void clear() {
+        std::lock_guard<std::mutex> lock(mutex);
+
+        std::queue<T> empty;
+        empty.swap(queue);
+    }
+
+    /// \brief Waits seconds for the queue to receive an element
+    /// \param seconds Count of seconds to wait, pass in a value <= 0 to wait indefinitely
+    inline void wait_on_queue(int seconds = -1) {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        if (seconds > 0) {
+            cv.wait_for(lock, std::chrono::seconds(seconds), [&]() { return (false == queue.empty()); });
+        } else {
+            cv.wait(lock, [&]() { return (false == queue.empty()); });
+        }
+    }
+
+    /// \brief Same as 'wait_on_queue' but receives an additional predicate to wait upon
+    template <class Predicate> inline void wait_on_queue(Predicate pred, int seconds = -1) {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        if (seconds > 0) {
+            cv.wait_for(lock, std::chrono::seconds(seconds), [&]() { return (false == queue.empty()) or pred(); });
+        } else {
+            cv.wait(lock, [&]() { return (false == queue.empty()) or pred(); });
+        }
+    }
+
+    /// \brief Waits on the queue for a custom event
+    template <class Predicate> inline void wait_on_custom(Predicate pred, int seconds = -1) {
+        std::unique_lock<std::mutex> lock(mutex);
+
+        if (seconds > 0) {
+            cv.wait_for(lock, std::chrono::seconds(seconds), [&]() { return pred(); });
+        } else {
+            cv.wait(lock, [&]() { return pred(); });
+        }
+    }
+
+    /// \brief Notifies a single waiting thread to wake up
+    inline void notify_waiting_thread() {
+        cv.notify_one();
+    }
+
+private:
+    std::queue<T> queue;
+
+    mutable std::mutex mutex;
+    std::condition_variable cv;
+};
+
+} // namespace ocpp

--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -28,8 +28,11 @@ public:
                        std::shared_ptr<EvseSecurity> evse_security, std::shared_ptr<MessageLogging> logging);
     ~Websocket();
 
-    /// \brief connect to a websocket (TLS or non-TLS depending on the central system uri in the configuration).
-    bool connect();
+    /// \brief Starts the connection attempts. It will try to initialize the connection options and the
+    ///        security context
+    /// \returns true if the websocket successfully initialized the connection options and security context and
+    ///          if it successfully started the connection thread. Does not wait for a successful connection
+    bool start_connecting();
 
     void set_connection_options(const WebsocketConnectionOptions& connection_options);
 

--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -18,7 +18,7 @@ private:
     std::unique_ptr<WebsocketBase> websocket;
     std::function<void(OcppProtocolVersion protocol)> connected_callback;
     std::function<void()> disconnected_callback;
-    std::function<void(const WebsocketCloseReason reason)> closed_callback;
+    std::function<void(const WebsocketCloseReason reason)> stopped_connecting_callback;
     std::function<void(const std::string& message)> message_callback;
     std::shared_ptr<MessageLogging> logging;
 
@@ -50,9 +50,9 @@ public:
     /// \brief register a \p callback that is called when the websocket connection is disconnected
     void register_disconnected_callback(const std::function<void()>& callback);
 
-    /// \brief register a \p callback that is called when the websocket connection has been closed and will not attempt
+    /// \brief register a \p callback that is called when the websocket connection has been stopped and will not attempt
     /// to reconnect
-    void register_closed_callback(const std::function<void(const WebsocketCloseReason)>& callback);
+    void register_stopped_connecting_callback(const std::function<void(const WebsocketCloseReason)>& callback);
 
     /// \brief register a \p callback that is called when the websocket receives a message
     void register_message_callback(const std::function<void(const std::string& message)>& callback);

--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -28,10 +28,9 @@ public:
                        std::shared_ptr<EvseSecurity> evse_security, std::shared_ptr<MessageLogging> logging);
     ~Websocket();
 
-    /// \brief Starts the connection attempts. It will try to initialize the connection options and the
-    ///        security context
-    /// \returns true if the websocket successfully initialized the connection options and security context and
-    ///          if it successfully started the connection thread. Does not wait for a successful connection
+    /// \brief Starts the connection attempts. It will init the websocket processing thread
+    /// \returns true if the websocket is successfully initialized, false otherwise. Does
+    ///          not wait for a successful connection
     bool start_connecting();
 
     void set_connection_options(const WebsocketConnectionOptions& connection_options);

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -90,10 +90,9 @@ public:
     explicit WebsocketBase();
     virtual ~WebsocketBase();
 
-    /// \brief Starts the connection attempts. It will try to initialize the connection options and the
-    ///        security context
-    /// \returns true if the websocket successfully initialized the connection options and security context and
-    ///          if it successfully started the connection thread. Does not wait for a successful connection
+    /// \brief Starts the connection attempts. It will init the websocket processing thread
+    /// \returns true if the websocket is successfully initialized, false otherwise. Does
+    ///          not wait for a successful connection
     virtual bool start_connecting() = 0;
 
     /// \brief sets this connection_options to the given \p connection_options and resets the connection_attempts

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -90,9 +90,11 @@ public:
     explicit WebsocketBase();
     virtual ~WebsocketBase();
 
-    /// \brief connect to a websocket
-    /// \returns true if the websocket is initialized and a connection attempt is made
-    virtual bool connect() = 0;
+    /// \brief Starts the connection attempts. It will try to initialize the connection options and the
+    ///        security context
+    /// \returns true if the websocket successfully initialized the connection options and security context and
+    ///          if it successfully started the connection thread. Does not wait for a successful connection
+    virtual bool start_connecting() = 0;
 
     /// \brief sets this connection_options to the given \p connection_options and resets the connection_attempts
     virtual void set_connection_options(const WebsocketConnectionOptions& connection_options) = 0;

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -49,7 +49,7 @@ protected:
     WebsocketConnectionOptions connection_options;
     std::function<void(OcppProtocolVersion protocol)> connected_callback;
     std::function<void()> disconnected_callback;
-    std::function<void(const WebsocketCloseReason reason)> closed_callback;
+    std::function<void(const WebsocketCloseReason reason)> stopped_connecting_callback;
     std::function<void(const std::string& message)> message_callback;
     std::function<void(ConnectionFailedReason)> connection_failed_callback;
     std::shared_ptr<boost::asio::steady_timer> reconnect_timer;
@@ -119,7 +119,7 @@ public:
 
     /// \brief register a \p callback that is called when the websocket connection has been closed and will not attempt
     /// to reconnect
-    void register_closed_callback(const std::function<void(const WebsocketCloseReason reason)>& callback);
+    void register_stopped_connecting_callback(const std::function<void(const WebsocketCloseReason reason)>& callback);
 
     /// \brief register a \p callback that is called when the websocket receives a message
     void register_message_callback(const std::function<void(const std::string& message)>& callback);

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -4,6 +4,7 @@
 #define OCPP_WEBSOCKET_TLS_TPM_HPP
 
 #include <ocpp/common/evse_security.hpp>
+#include <ocpp/common/safe_queue.hpp>
 #include <ocpp/common/websocket/websocket_base.hpp>
 
 #include <condition_variable>
@@ -19,112 +20,6 @@ namespace ocpp {
 
 struct ConnectionData;
 struct WebsocketMessage;
-
-/// \brief Thread safe message queue
-template <typename T> class SafeQueue {
-    using safe_queue_reference = typename std::queue<T>::reference;
-    using safe_queue_const_reference = typename std::queue<T>::const_reference;
-
-public:
-    /// \return True if the queue is empty
-    inline bool empty() const {
-        std::lock_guard lock(mutex);
-        return queue.empty();
-    }
-
-    inline safe_queue_reference front() const {
-        std::lock_guard lock(mutex);
-        return queue.front();
-    }
-
-    inline safe_queue_const_reference front() {
-        std::lock_guard lock(mutex);
-        return queue.front();
-    }
-
-    /// \return retrieves and removes the first element in the queue. Undefined behavior if the queue is empty
-    inline T pop() {
-        std::lock_guard lock(mutex);
-
-        T front = std::move(queue.front());
-        queue.pop();
-
-        return front;
-    }
-
-    /// \brief Queues an element and notifies any threads waiting on the internal conditional variable
-    inline void push(T&& value) {
-        {
-            std::lock_guard<std::mutex> lock(mutex);
-            queue.push(value);
-        }
-
-        notify_waiting_thread();
-    }
-
-    /// \brief Queues an element and notifies any threads waiting on the internal conditional variable
-    inline void push(const T& value) {
-        {
-            std::lock_guard<std::mutex> lock(mutex);
-            queue.push(value);
-        }
-
-        notify_waiting_thread();
-    }
-
-    /// \brief Clears the queue
-    inline void clear() {
-        std::lock_guard<std::mutex> lock(mutex);
-
-        std::queue<T> empty;
-        empty.swap(queue);
-    }
-
-    /// \brief Waits seconds for the queue to receive an element
-    /// \param seconds Count of seconds to wait, pass in a value <= 0 to wait indefinitely
-    inline void wait_on_queue(int seconds = -1) {
-        std::unique_lock<std::mutex> lock(mutex);
-
-        if (seconds > 0) {
-            cv.wait_for(lock, std::chrono::seconds(seconds), [&]() { return (false == queue.empty()); });
-        } else {
-            cv.wait(lock, [&]() { return (false == queue.empty()); });
-        }
-    }
-
-    /// \brief Same as 'wait_on_queue' but receives an additional predicate to wait upon
-    template <class Predicate> inline void wait_on_queue(Predicate pred, int seconds = -1) {
-        std::unique_lock<std::mutex> lock(mutex);
-
-        if (seconds > 0) {
-            cv.wait_for(lock, std::chrono::seconds(seconds), [&]() { return (false == queue.empty()) or pred(); });
-        } else {
-            cv.wait(lock, [&]() { return (false == queue.empty()) or pred(); });
-        }
-    }
-
-    /// \brief Waits on the queue for a custom event
-    template <class Predicate> inline void wait_on_custom(Predicate pred, int seconds = -1) {
-        std::unique_lock<std::mutex> lock(mutex);
-
-        if (seconds > 0) {
-            cv.wait_for(lock, std::chrono::seconds(seconds), [&]() { return pred(); });
-        } else {
-            cv.wait(lock, [&]() { return pred(); });
-        }
-    }
-
-    /// \brief Notifies a single waiting thread to wake up
-    inline void notify_waiting_thread() {
-        cv.notify_one();
-    }
-
-private:
-    std::queue<T> queue;
-
-    mutable std::mutex mutex;
-    std::condition_variable cv;
-};
 
 /// \brief Experimental libwebsockets TLS connection
 class WebsocketLibwebsockets final : public WebsocketBase {

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -70,13 +70,13 @@ private:
     void thread_deferred_callback_queue();
 
     /// \brief Called when a TLS websocket connection is established, calls the connected callback
-    void on_conn_connected();
+    void on_conn_connected(ConnectionData* conn_data);
 
     /// \brief Called when a TLS websocket connection is closed
-    void on_conn_close();
+    void on_conn_close(ConnectionData* conn_data);
 
     /// \brief Called when a TLS websocket connection fails to be established
-    void on_conn_fail();
+    void on_conn_fail(ConnectionData* conn_data);
 
     /// \brief When the connection can send data
     void on_conn_writable();

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -179,7 +179,8 @@ public:
     ///          if it successfully started the connection thread. Does not wait for a successful connection
     bool start_connecting() override;
 
-    /// \brief Reconnects the websocket using the delay, a reason for this reconnect can be provided with the
+    /// \brief Reconnects the websocket after the delay. Will stop the current connection attempts
+    ///        and will call the 'start_connecting' after the delay
     /// \param reason parameter
     /// \param delay delay of the reconnect attempt
     void reconnect(long delay) override;
@@ -198,6 +199,10 @@ public:
     int process_callback(void* wsi_ptr, int callback_reason, void* user, void* in, size_t len);
 
 private:
+    /// \brief Initializes the connection options, including the security info
+    /// \return True if it was successful, false otherwise
+    bool initialize_connection_options(std::shared_ptr<ConnectionData>& new_connection_data);
+
     bool tls_init(struct ssl_ctx_st* ctx, const std::string& path_chain, const std::string& path_key, bool custom_key,
                   std::optional<std::string>& password);
     void client_loop();
@@ -235,7 +240,6 @@ private:
     Everest::SteadyTimer reconnect_timer_tpm;
     std::unique_ptr<std::thread> websocket_thread;
     std::shared_ptr<ConnectionData> conn_data;
-    std::condition_variable conn_cv;
 
     // Queue of outgoing messages
     SafeQueue<std::shared_ptr<WebsocketMessage>> message_queue;

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -167,6 +167,10 @@ public:
     int process_callback(void* wsi_ptr, int callback_reason, void* user, void* in, size_t len);
 
 private:
+    bool is_trying_to_connect_internal();
+    void close_internal(const WebsocketCloseReason code, const std::string& reason);
+
+private:
     /// \brief Initializes the connection options, including the security info
     /// \return True if it was successful, false otherwise
     bool initialize_connection_options(std::shared_ptr<ConnectionData>& new_connection_data);
@@ -194,11 +198,12 @@ private:
     void on_conn_fail();
 
     /// \brief When the connection can send data
-    void on_writable();
+    void on_conn_writable();
 
     /// \brief Called when a message is received over the TLS websocket, calls the message callback
-    void on_message(std::string&& message);
+    void on_conn_message(std::string&& message);
 
+    /// \brief Requests a message write, awakes the websocket loop from 'poll'
     void request_write();
 
     void poll_message(const std::shared_ptr<WebsocketMessage>& msg);

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -106,8 +106,8 @@ private:
     std::unique_ptr<std::thread> websocket_thread;
     std::shared_ptr<ConnectionData> conn_data;
 
-    // Queue of outgoing messages
-    SafeQueue<std::shared_ptr<WebsocketMessage>> message_queue;
+    // Queue of outgoing messages, notify thread only when we remove messages
+    SafeQueue<std::shared_ptr<WebsocketMessage>, EThreadNotifyPolicy::ThreadNotify_Pop> message_queue;
 
     std::unique_ptr<std::thread> recv_message_thread;
     SafeQueue<std::string> recv_message_queue;

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -7,11 +7,8 @@
 #include <ocpp/common/safe_queue.hpp>
 #include <ocpp/common/websocket/websocket_base.hpp>
 
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <optional>
-#include <queue>
 #include <string>
 
 struct ssl_ctx_st;
@@ -32,29 +29,19 @@ public:
 
     void set_connection_options(const WebsocketConnectionOptions& connection_options) override;
 
-    /// \brief Starts the connection attempts. It will init the websocket processing thread
-    /// \returns true if the websocket is successfully initialized, false otherwise. Does
-    ///          not wait for a successful connection
     bool start_connecting() override;
 
-    /// \brief Reconnects the websocket after the delay. Will stop the current connection attempts
-    ///        and will call the 'start_connecting' after the delay
-    /// \param reason parameter
-    /// \param delay delay of the reconnect attempt
     void reconnect(long delay) override;
 
-    /// \brief closes the websocket
     void close(const WebsocketCloseReason code, const std::string& reason) override;
 
-    /// \brief send a \p message over the websocket
-    /// \returns true if the message was sent successfully
     bool send(const std::string& message) override;
 
-    /// \brief send a websocket ping
     void ping() override;
 
     /// \brief Indicates if the websocket has a valid connection data and is trying to
     ///        connect/reconnect internally even if for the moment it might not be connected
+    /// \return True if the websocket is connected or trying to connect, false otherwise
     bool is_trying_to_connect();
 
 public:

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -107,7 +107,7 @@ private:
     std::shared_ptr<ConnectionData> conn_data;
 
     // Queue of outgoing messages, notify thread only when we remove messages
-    SafeQueue<std::shared_ptr<WebsocketMessage>, EThreadNotifyPolicy::ThreadNotify_Pop> message_queue;
+    SafeQueue<std::shared_ptr<WebsocketMessage>> message_queue;
 
     std::unique_ptr<std::thread> recv_message_thread;
     SafeQueue<std::string> recv_message_queue;

--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -137,10 +137,9 @@ public:
 
     void set_connection_options(const WebsocketConnectionOptions& connection_options) override;
 
-    /// \brief Starts the connection attempts. It will try to initialize the connection options and the
-    ///        security context
-    /// \returns true if the websocket successfully initialized the connection options and security context and
-    ///          if it successfully started the connection thread. Does not wait for a successful connection
+    /// \brief Starts the connection attempts. It will init the websocket processing thread
+    /// \returns true if the websocket is successfully initialized, false otherwise. Does
+    ///          not wait for a successful connection
     bool start_connecting() override;
 
     /// \brief Reconnects the websocket after the delay. Will stop the current connection attempts
@@ -148,10 +147,6 @@ public:
     /// \param reason parameter
     /// \param delay delay of the reconnect attempt
     void reconnect(long delay) override;
-
-    /// \brief Indicates if the websocket has a valid connection data and is trying to
-    ///        connect/reconnect internally even if for the moment it might not be connected
-    bool is_trying_to_connect();
 
     /// \brief closes the websocket
     void close(const WebsocketCloseReason code, const std::string& reason) override;
@@ -162,6 +157,10 @@ public:
 
     /// \brief send a websocket ping
     void ping() override;
+
+    /// \brief Indicates if the websocket has a valid connection data and is trying to
+    ///        connect/reconnect internally even if for the moment it might not be connected
+    bool is_trying_to_connect();
 
 public:
     int process_callback(void* wsi_ptr, int callback_reason, void* user, void* in, size_t len);

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -168,9 +168,10 @@ private:
     ///
     void on_websocket_disconnected();
 
-    /// \brief Function invoked when the web socket closes
+    /// \brief Function invoked when the web socket stops connecting
+    ///        and does not re-attempt to connect again
     ///
-    void on_websocket_closed(ocpp::WebsocketCloseReason reason);
+    void on_websocket_stopped_connecting(ocpp::WebsocketCloseReason reason);
 
     ///
     /// \brief Get the active network configuration slot in use.

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -63,10 +63,11 @@ void Websocket::register_disconnected_callback(const std::function<void()>& call
     });
 }
 
-void Websocket::register_closed_callback(const std::function<void(const WebsocketCloseReason reason)>& callback) {
-    this->closed_callback = callback;
-    this->websocket->register_closed_callback(
-        [this](const WebsocketCloseReason reason) { this->closed_callback(reason); });
+void Websocket::register_stopped_connecting_callback(
+    const std::function<void(const WebsocketCloseReason reason)>& callback) {
+    this->stopped_connecting_callback = callback;
+    this->websocket->register_stopped_connecting_callback(
+        [this](const WebsocketCloseReason reason) { this->stopped_connecting_callback(reason); });
 }
 
 void Websocket::register_message_callback(const std::function<void(const std::string& message)>& callback) {

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -22,9 +22,9 @@ Websocket::Websocket(const WebsocketConnectionOptions& connection_options, std::
 Websocket::~Websocket() {
 }
 
-bool Websocket::connect() {
+bool Websocket::start_connecting() {
     this->logging->sys("Connecting");
-    return this->websocket->connect();
+    return this->websocket->start_connecting();
 }
 
 void Websocket::set_connection_options(const WebsocketConnectionOptions& connection_options) {

--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -10,7 +10,7 @@ namespace ocpp {
 WebsocketBase::WebsocketBase() :
     m_is_connected(false),
     connected_callback(nullptr),
-    closed_callback(nullptr),
+    stopped_connecting_callback(nullptr),
     message_callback(nullptr),
     reconnect_timer(nullptr),
     connection_attempts(1),
@@ -44,8 +44,9 @@ void WebsocketBase::register_disconnected_callback(const std::function<void()>& 
     this->disconnected_callback = callback;
 }
 
-void WebsocketBase::register_closed_callback(const std::function<void(const WebsocketCloseReason reason)>& callback) {
-    this->closed_callback = callback;
+void WebsocketBase::register_stopped_connecting_callback(
+    const std::function<void(const WebsocketCloseReason reason)>& callback) {
+    this->stopped_connecting_callback = callback;
 }
 
 void WebsocketBase::register_message_callback(const std::function<void(const std::string& message)>& callback) {
@@ -61,7 +62,7 @@ bool WebsocketBase::initialized() {
         EVLOG_error << "Not properly initialized: please register connected callback.";
         return false;
     }
-    if (this->closed_callback == nullptr) {
+    if (this->stopped_connecting_callback == nullptr) {
         EVLOG_error << "Not properly initialized: please closed_callback.";
         return false;
     }

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -686,7 +686,7 @@ void WebsocketLibwebsockets::thread_websocket_client_loop(std::shared_ptr<Connec
                     auto state = local_data->get_state();
                     processing = (!local_data->is_interupted()) &&
                                  (state != EConnectionState::FINALIZED && state != EConnectionState::ERROR);
-                    
+
                     if (processing && !message_queue.empty()) {
                         lws_callback_on_writable(local_data->get_conn());
                     }
@@ -868,7 +868,7 @@ void WebsocketLibwebsockets::close(const WebsocketCloseReason code, const std::s
 
     std::scoped_lock lock(this->connection_mutex);
 
-    // Close any incoming thread
+    // Close any ongoing thread
     safe_close_threads();
 
     // Release the connection data and state

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -8,8 +8,10 @@
 #include <libwebsockets.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 
@@ -797,7 +799,6 @@ void WebsocketLibwebsockets::thread_websocket_client_loop(std::shared_ptr<Connec
         if (local_data->is_interupted() || local_data->get_state() == EConnectionState::FINALIZED) {
             EVLOG_info << "Connection interrupted or cleanly finalized, exiting websocket loop";
             try_reconnect = false;
-            // TODO:
         } else if (local_data->get_state() != EConnectionState::CONNECTED) {
             // Any other failure than a successful connect
 

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1581,7 +1581,7 @@ void WebsocketLibwebsockets::thread_deferred_callback_queue() {
     while (true) {
         std::function<void()> callback;
         {
-            this->deferred_callback_queue.wait_on_queue_element_predicate(
+            this->deferred_callback_queue.wait_on_queue_element_or_predicate(
                 [this]() { return this->stop_deferred_handler.load(); });
 
             if (stop_deferred_handler and this->deferred_callback_queue.empty()) {

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -361,12 +361,6 @@ WebsocketLibwebsockets::~WebsocketLibwebsockets() {
         }
     }
 
-    // Stop the dangling timer
-    {
-        std::lock_guard<std::mutex> lk(this->reconnect_mutex);
-        this->reconnect_timer_tpm.stop();
-    }
-
     if (this->m_is_connected || is_trying_to_connect_internal()) {
         this->close_internal(WebsocketCloseReason::Normal, "websocket destructor");
     }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -397,7 +397,6 @@ WebsocketConnectionOptions ChargePointImpl::get_ws_connection_options() {
 
 void ChargePointImpl::connect_websocket() {
     if (!this->websocket->is_connected()) {
-        this->init_websocket();
         this->websocket->start_connecting();
     }
 }
@@ -1840,7 +1839,6 @@ void ChargePointImpl::switchSecurityProfile(int32_t new_security_profile, int32_
     // we need to reinitialize because it could be plain or tls websocket
     this->websocket_timer.timeout(
         [this, max_connection_attempts, new_security_profile]() {
-            this->init_websocket();
             auto connection_options = this->get_ws_connection_options();
             connection_options.security_profile = new_security_profile;
             connection_options.max_connection_attempts = max_connection_attempts;

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -398,7 +398,7 @@ WebsocketConnectionOptions ChargePointImpl::get_ws_connection_options() {
 void ChargePointImpl::connect_websocket() {
     if (!this->websocket->is_connected()) {
         this->init_websocket();
-        this->websocket->connect();
+        this->websocket->start_connecting();
     }
 }
 
@@ -1080,7 +1080,7 @@ bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_st
     this->bootreason = bootreason;
     this->init_state_machine(connector_status_map);
     this->init_websocket();
-    this->websocket->connect();
+    this->websocket->start_connecting();
     // push transaction messages including SecurityEventNotification.req onto the message queue
     this->message_queue->get_persisted_messages_from_db(this->configuration->getDisableSecurityEventNotifications());
     this->boot_notification();
@@ -1845,7 +1845,7 @@ void ChargePointImpl::switchSecurityProfile(int32_t new_security_profile, int32_
             connection_options.security_profile = new_security_profile;
             connection_options.max_connection_attempts = max_connection_attempts;
             this->websocket->set_connection_options(connection_options);
-            this->websocket->connect();
+            this->websocket->start_connecting();
         },
         WEBSOCKET_INIT_DELAY);
 }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -323,7 +323,7 @@ void ChargePointImpl::init_websocket() {
             this->signal_set_charging_profiles_callback();
         }
     });
-    this->websocket->register_closed_callback([this](const WebsocketCloseReason reason) {
+    this->websocket->register_stopped_connecting_callback([this](const WebsocketCloseReason reason) {
         if (this->switch_security_profile_callback != nullptr) {
             this->switch_security_profile_callback();
         }

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -237,8 +237,8 @@ void ConnectivityManager::try_connect_websocket() {
             [this](OcppProtocolVersion protocol) { this->on_websocket_connected(protocol); });
         this->websocket->register_disconnected_callback(
             std::bind(&ConnectivityManager::on_websocket_disconnected, this));
-        this->websocket->register_closed_callback(
-            std::bind(&ConnectivityManager::on_websocket_closed, this, std::placeholders::_1));
+        this->websocket->register_stopped_connecting_callback(
+            std::bind(&ConnectivityManager::on_websocket_stopped_connecting, this, std::placeholders::_1));
     } else {
         this->websocket->set_connection_options(connection_options.value());
     }
@@ -397,7 +397,7 @@ void ConnectivityManager::on_websocket_disconnected() {
     }
 }
 
-void ConnectivityManager::on_websocket_closed(ocpp::WebsocketCloseReason reason) {
+void ConnectivityManager::on_websocket_stopped_connecting(ocpp::WebsocketCloseReason reason) {
     EVLOG_warning << "Closed websocket of NetworkConfigurationPriority: "
                   << this->active_network_configuration_priority + 1 << " which is configurationSlot "
                   << this->get_active_network_configuration_slot();

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -250,7 +250,7 @@ void ConnectivityManager::try_connect_websocket() {
 
     this->websocket->register_message_callback([this](const std::string& message) { this->message_callback(message); });
 
-    this->websocket->connect();
+    this->websocket->start_connecting();
 }
 
 std::optional<ConfigNetworkResult>


### PR DESCRIPTION
## Describe your changes

- Better split code and thread responsibilities
- Added a generic safe queue to simplify count of conditional variables and mutexes used
- Cleared the connection_mutex usage in websocket client threads
- Modified reconnect logic to internal reconnect logic on the websocket thread for better stability
- The `connect` in websocket is not sync any more, but only kickstarts the connections attempts

## Issue ticket number and link

Core CI: https://github.com/EVerest/everest-core/pull/984

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

