### PR TITLE
Integrate of send Triggermessage (MeterValues) in empty Connector case of present connectors or reject if non is present

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2439,8 +2439,9 @@ void ChargePointImpl::handleTriggerMessageRequest(ocpp::Call<TriggerMessageReque
         if (call.msg.connectorId.has_value()) {
             trigger_message = this->connectors.at(call.msg.connectorId.value())->measurement.has_value();
         } else {
-            trigger_message = std::any_of(this->connectors.begin(), this->connectors.end(),
-                                          [](const auto& connector) { return connector.second->measurement.has_value(); });
+            trigger_message = std::any_of(this->connectors.begin(), this->connectors.end(), [](const auto& connector) {
+                return connector.second->measurement.has_value();
+            });
         }
         if (not trigger_message) {
             response.status = TriggerMessageStatus::Rejected;

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2495,7 +2495,7 @@ void ChargePointImpl::handleTriggerMessageRequest(ocpp::Call<TriggerMessageReque
                 const auto meter_value = this->get_latest_meter_value(
                     c, this->configuration->getMeterValuesSampledDataVector(), ReadingContext::Trigger);
                 if (meter_value.has_value()) {
-                    this->send_meter_value_trigger(c, meter_value.value(), true);
+                    this->send_meter_value(c, meter_value.value(), true);
                 } else {
                     EVLOG_warning << "Could not send triggered meter value for uninitialized measurement at connector#"
                                   << c;


### PR DESCRIPTION
## Describe your changes
Handle the emptyConnector case for TriggerMessage of type meterValues.

Inside the OCPP 1.6 5.17. TriggerMessage:

"Inversely, if the connectorId is relevant but absent, this should be interpreted as “for all allowed connectorId
values”. For example, a request for a statusNotification for connectorId 0 is a request for the status of the
Charge Point. A request for a statusNotification without connectorId is a request for multiple statusNotifications:
the notification for the Charge Point itself and a notification for each of its connectors."

It is proposed to handle a TriggerMessage with requestedMessage MeterValues and empty ConnectorId the same, and send MeterValues.req for each connectorId having a MeterValue.

In the case, the _connectorId_ is empty, it is checked if at least one _connectorId_ is present and has a _Metervalue_ to be send othwise, the answer to the TriggerMessage.req is 'Rejected'

"The Charge Point SHALL first send the _TriggerMessage_ response, before sending the requested message. In the
_TriggerMessage.conf_ the Charge Point SHALL indicate whether it will send it or not, by returning ACCEPTED or
REJECTED. It is up to the Charge Point if it accepts or rejects the request to send. If the requested message is
unknown or not implemented the Charge Point SHALL return NOT_IMPLEMENTED". 

Option is to send "NOT_IMPLEMENTED".



## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/897

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

