### PR TITLE
Converting reading context of meter value to Other

### DIFF
--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -645,8 +645,7 @@ void Evse::send_meter_value_on_pricing_trigger(const MeterValue& meter_value) {
         // Send metervalue anyway since we have no previous metervalue stored and don't know if we should send any
         if (!meter_value_sent) {
             // Only send metervalue if it is not sent yet, otherwise only the last triggered metervalue is set.
-            const MeterValue mv =
-                        utils::set_meter_value_reading_context(meter_value, ReadingContextEnum::Other);
+            const MeterValue mv = utils::set_meter_value_reading_context(meter_value, ReadingContextEnum::Other);
             this->send_metervalue_function({mv});
         }
         this->last_triggered_metervalue_power_kw = active_power_meter_value.value() / 1000;

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -645,7 +645,9 @@ void Evse::send_meter_value_on_pricing_trigger(const MeterValue& meter_value) {
         // Send metervalue anyway since we have no previous metervalue stored and don't know if we should send any
         if (!meter_value_sent) {
             // Only send metervalue if it is not sent yet, otherwise only the last triggered metervalue is set.
-            this->send_metervalue_function({meter_value});
+            const MeterValue mv =
+                        utils::set_meter_value_reading_context(meter_value, ReadingContextEnum::Other);
+            this->send_metervalue_function({mv});
         }
         this->last_triggered_metervalue_power_kw = active_power_meter_value.value() / 1000;
     }


### PR DESCRIPTION
## Describe your changes

Triggering metervalues sometimes did not change the context to 'other' while it should because it was triggered by a cost and price trigger.

Needed by https://github.com/EVerest/everest-core/pull/975

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

