### PR TITLE
Make centralSystemURI accessible via changeConfiguration, reject if readOnly

### DIFF
--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -18,6 +18,7 @@ class ChargePointConfiguration {
 private:
     json config;
     json custom_schema;
+    json internal_schema;
     fs::path user_config_path;
 
     std::set<SupportedFeatureProfiles> supported_feature_profiles;
@@ -47,6 +48,7 @@ public:
     std::string getChargePointId();
     KeyValue getChargePointIdKeyValue();
     std::string getCentralSystemURI();
+    void setCentralSystemURI(std::string ocpp_uri);
     KeyValue getCentralSystemURIKeyValue();
     std::string getChargeBoxSerialNumber();
     KeyValue getChargeBoxSerialNumberKeyValue();

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -44,12 +44,9 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
 
     try {
         const auto internal_schema_path = schemas_path / "Internal.json";
-        if (fs::exists(internal_schema_path)) {
-            std::ifstream ifs(internal_schema_path.c_str());
-            std::string internal_schema_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-            this->internal_schema = json::parse(internal_schema_file);
-            EVLOG_debug << "value check: " << internal_schema["properties"]["CentralSystemURI"]["readOnly"];
-        }
+        std::ifstream ifs(internal_schema_path.c_str());
+        std::string internal_schema_file((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+        this->internal_schema = json::parse(internal_schema_file);
     } catch (const json::parse_error& e) {
         EVLOG_error << "Error while parsing Internal.json file.";
         EVLOG_AND_THROW(e);
@@ -2980,6 +2977,7 @@ ConfigurationStatus ChargePointConfiguration::setCustomKey(CiString<50> key, CiS
 }
 
 void ChargePointConfiguration::setCentralSystemURI(std::string centralSystemUri) {
+    EVLOG_warning << "CentralSystemURI changed to: " << centralSystemUri;
     this->config["Internal"]["CentralSystemURI"] = centralSystemUri;
     this->setInUserConfig("Internal", "CentralSystemURI", centralSystemUri);
 }
@@ -3894,6 +3892,7 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
 
     if (key == "CentralSystemURI") {
         this->setCentralSystemURI(value.get());
+        return ConfigurationStatus::RebootRequired;
     }
 
     if (this->config.contains("Custom") and this->config["Custom"].contains(key.get())) {


### PR DESCRIPTION
## Describe your changes
Make centralSystemURI accessible via changeConfiguration.req, reject if readOnly

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/901
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

