### PR TITLE
Add in helper vector with transactionsId already send triggered by tansaction_queue

### DIFF
--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -580,7 +580,8 @@ public:
     }
 
     /// \brief Gets all persisted messages of normal message queue and persisted message queue from the database
-    void get_persisted_messages_from_db(bool ignore_security_event_notifications = false) {
+    void get_persisted_messages_from_db(std::vector<int>& transactionInFlight,
+                                        bool ignore_security_event_notifications = false) {
         std::vector<QueueType> queue_types = {QueueType::Normal, QueueType::Transaction};
         // do for Normal and Transaction queue
         for (const auto queue_type : queue_types) {
@@ -610,6 +611,8 @@ public:
                             normal_message_queue.push_back(message);
                         } else if (queue_type == QueueType::Transaction) {
                             transaction_message_queue.push_back(message);
+                            Call<v16::StopTransactionRequest> call = persisted_message.json_message;
+                            transactionInFlight.push_back(call.msg.transactionId);
                         }
                     }
                 }

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -247,7 +247,8 @@ private:
     /// resuming_session_ids contain the internal session_id, this function attempts to resume the transaction by
     /// initializing it and adding it to the \ref transaction_handler. If the session_id is not part of \p
     /// resuming_session_ids a StopTransaction.req is initiated to properly close the transaction.
-    void try_resume_transactions(const std::set<std::string>& resuming_session_ids);
+    void try_resume_transactions(const std::vector<int> transactionIdsInFlight,
+                                 const std::set<std::string>& resuming_session_ids);
     void stop_all_transactions();
     void stop_all_transactions(Reason reason);
     bool validate_against_cache_entries(CiString<20> id_tag);


### PR DESCRIPTION
## Describe your changes
In the case a charging process is ongping, the conenction to the backend is disconnected and the charging process is stopped.
It is stored inside the transaction databse with csms_ack=0 and the stoptransaction.req is stored inside the transaction_queue.

On boot up, the transaction_queue is emptied and the transactions with csms_ack=0 are resend. If the message_queue is alredy emptied before the check of the open transcations, then the stopTransaction.req is sent again.

In order to avoid that a helper vector with transacitonids in flight is added.

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/907

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

