### PR TITLE
Block possibility of using a stale reference in SafeQueue

### DIFF
--- a/include/ocpp/common/safe_queue.hpp
+++ b/include/ocpp/common/safe_queue.hpp
@@ -13,9 +13,6 @@ namespace ocpp {
 /// that can be waited upon. Will take up the waiting thread on each
 /// operation of push/pop/clear
 template <typename T> class SafeQueue {
-    using safe_queue_reference = typename std::queue<T>::reference;
-    using safe_queue_const_reference = typename std::queue<T>::const_reference;
-
 public:
     /// \return True if the queue is empty
     inline bool empty() const {
@@ -23,12 +20,9 @@ public:
         return queue.empty();
     }
 
-    inline safe_queue_reference front() {
-        std::lock_guard lock(mutex);
-        return queue.front();
-    }
-
-    inline safe_queue_const_reference front() const {
+    /// \brief We return a copy here, since while might be accessing the
+    /// reference while another thread uses pop and makes the reference stale
+    inline T front() {
         std::lock_guard lock(mutex);
         return queue.front();
     }

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1515,13 +1515,13 @@ void WebsocketLibwebsockets::on_conn_writable() {
 
     // Execute while we have messages that were polled
     while (true) {
-        WebsocketMessage* message = nullptr;
+        std::shared_ptr<WebsocketMessage> message;
 
         // Break if we have en empty queue
         if (message_queue.empty())
             break;
 
-        message = message_queue.front().get();
+        message = message_queue.front();
 
         if (message == nullptr) {
             EVLOG_AND_THROW(std::runtime_error("Null message in queue, fatal error!"));
@@ -1548,7 +1548,7 @@ void WebsocketLibwebsockets::on_conn_writable() {
         // Poll a single message
         EVLOG_debug << "Client writable, sending message part!";
 
-        WebsocketMessage* message = message_queue.front().get();
+        std::shared_ptr<WebsocketMessage> message = message_queue.front();
 
         if (message == nullptr) {
             EVLOG_AND_THROW(std::runtime_error("Null message in queue, fatal error!"));
@@ -1559,7 +1559,7 @@ void WebsocketLibwebsockets::on_conn_writable() {
         }
 
         // Continue sending message part, for a single message only
-        bool sent = send_internal(local_data->get_conn(), message);
+        bool sent = send_internal(local_data->get_conn(), message.get());
 
         // If we failed, attempt again later
         if (!sent) {

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1515,13 +1515,11 @@ void WebsocketLibwebsockets::on_conn_writable() {
 
     // Execute while we have messages that were polled
     while (true) {
-        std::shared_ptr<WebsocketMessage> message;
-
         // Break if we have en empty queue
         if (message_queue.empty())
             break;
 
-        message = message_queue.front();
+        auto message = message_queue.front();
 
         if (message == nullptr) {
             EVLOG_AND_THROW(std::runtime_error("Null message in queue, fatal error!"));
@@ -1548,7 +1546,7 @@ void WebsocketLibwebsockets::on_conn_writable() {
         // Poll a single message
         EVLOG_debug << "Client writable, sending message part!";
 
-        std::shared_ptr<WebsocketMessage> message = message_queue.front();
+        auto message = message_queue.front();
 
         if (message == nullptr) {
             EVLOG_AND_THROW(std::runtime_error("Null message in queue, fatal error!"));


### PR DESCRIPTION
Fixed a possible dangling stale reference usage when using 'front' that returns a reference to the front member in the SafeQueue. The reference can be 'pop'-ed from another thread that will result in accessing stale data.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

