### PR TITLE
Converte boolean to true/false string equvivalent of CustomDisplayCostAndPrice

### DIFF
--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2502,7 +2502,7 @@ KeyValue ChargePointConfiguration::getCustomDisplayCostAndPriceEnabledKeyValue()
     const bool enabled = getCustomDisplayCostAndPriceEnabled();
     KeyValue kv;
     kv.key = "CustomDisplayCostAndPrice";
-    kv.value = std::to_string(enabled);
+    kv.value = ocpp::conversions::bool_to_string(enabled);
     kv.readonly = true;
     return kv;
 }


### PR DESCRIPTION
## Describe your changes
On GetConfiguration.key of CustomDisplayCostAndPrice return string "false" or "true" instead of 0/1.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

