### PR TITLE
Apply validation on the Custom part on ChangeConfiguration.req

### DIFF
--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2953,9 +2953,9 @@ ConfigurationStatus ChargePointConfiguration::setCustomKey(CiString<50> key, CiS
 
         // validate the updated key against the schema
         Schemas schema(custom_schema);
-        json model;
-        model[key] = new_value;
-        schema.get_validator()->validate(model); // throws exception on error
+        json modelUnderTest=config["Custom"];
+        modelUnderTest[key] = new_value;
+        schema.get_validator()->validate(modelUnderTest); // throws exception on error
         config["Custom"][key] = new_value;
     } catch (const std::exception& e) {
         EVLOG_warning << "Could not set custom configuration key: " << e.what();

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2953,7 +2953,7 @@ ConfigurationStatus ChargePointConfiguration::setCustomKey(CiString<50> key, CiS
 
         // validate the updated key against the schema
         Schemas schema(custom_schema);
-        json modelUnderTest=config["Custom"];
+        json modelUnderTest = config["Custom"];
         modelUnderTest[key] = new_value;
         schema.get_validator()->validate(modelUnderTest); // throws exception on error
         config["Custom"][key] = new_value;


### PR DESCRIPTION
## Describe your changes
The json which is validated against the Custom profile, is used based on the config.json. Otherwise, it misses keys and throws an exception.
## Issue ticket number and link

## Checklist before requesting a review
- [x ] I have performed a self-review of my code
- [ x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

