### PR TITLE
Correct remaining booleans in CostAndPrice

### DIFF
--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2832,7 +2832,7 @@ std::optional<KeyValue> ChargePointConfiguration::getCustomIdleFeeAfterStopKeyVa
     if (idle_fee.has_value()) {
         result = KeyValue();
         result->key = "CustomIdleFeeAfterStop";
-        result->value = std::to_string(idle_fee.value());
+        result->value = ocpp::conversions::bool_to_string(idle_fee.value());
         result->readonly = false;
     }
 
@@ -2854,7 +2854,7 @@ std::optional<KeyValue> ChargePointConfiguration::getCustomMultiLanguageMessages
     if (multi_language.has_value()) {
         result = KeyValue();
         result->key = "CustomMultiLanguageMessages";
-        result->value = std::to_string(multi_language.value());
+        result->value = ocpp::conversions::bool_to_string(multi_language.value());
         result->readonly = true;
     }
 


### PR DESCRIPTION
## Describe your changes
Fix realted to boolean conversion inside CostAndPrice object to "true"/"false".
## Issue ticket number and link

## Checklist before requesting a review
- [x ] I have performed a self-review of my code
- [ x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

