### PR TITLE
Allow Answer NotSupported if the key customDisplayCostAndPrice is not present

### DIFF
--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -445,8 +445,8 @@ public:
     KeyValue getWaitForStopTransactionsOnResetTimeoutKeyValue();
 
     // California Pricing Requirements
-    bool getCustomDisplayCostAndPriceEnabled();
-    KeyValue getCustomDisplayCostAndPriceEnabledKeyValue();
+    std::optional<bool> getCustomDisplayCostAndPriceEnabled();
+    std::optional<KeyValue> getCustomDisplayCostAndPriceEnabledKeyValue();
 
     std::optional<uint32_t> getPriceNumberOfDecimalsForCostValues();
     std::optional<KeyValue> getPriceNumberOfDecimalsForCostValuesKeyValue();

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2501,22 +2501,25 @@ KeyValue ChargePointConfiguration::getWaitForStopTransactionsOnResetTimeoutKeyVa
 }
 
 // California Pricing Requirements
-bool ChargePointConfiguration::getCustomDisplayCostAndPriceEnabled() {
+std::optional<bool> ChargePointConfiguration::getCustomDisplayCostAndPriceEnabled() {
     if (this->config.contains("CostAndPrice") and
         this->config.at("CostAndPrice").contains("CustomDisplayCostAndPrice")) {
         return this->config["CostAndPrice"]["CustomDisplayCostAndPrice"];
     }
 
-    return false;
+    return std::nullopt;
 }
 
-KeyValue ChargePointConfiguration::getCustomDisplayCostAndPriceEnabledKeyValue() {
-    const bool enabled = getCustomDisplayCostAndPriceEnabled();
-    KeyValue kv;
-    kv.key = "CustomDisplayCostAndPrice";
-    kv.value = std::to_string(enabled);
-    kv.readonly = true;
-    return kv;
+std::optional<KeyValue> ChargePointConfiguration::getCustomDisplayCostAndPriceEnabledKeyValue() {
+    const std::optional<bool> enabled = getCustomDisplayCostAndPriceEnabled();
+    std::optional<KeyValue> kv_opt = std::nullopt;
+    if (enabled.has_value()) {
+        kv_opt = KeyValue();
+        kv_opt->key = "CustomDisplayCostAndPrice";
+        kv_opt->value = ocpp::conversions::bool_to_string(enabled.value());
+        kv_opt->readonly = false;
+    }
+    return kv_opt;
 }
 
 std::optional<uint32_t> ChargePointConfiguration::getPriceNumberOfDecimalsForCostValues() {


### PR DESCRIPTION
## Describe your changes
Make customDisplayCostAndPrice an optional to allow answer NotSupported if not present.
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

