### PR TITLE
Make supported OCPP protocol version configurable (v201, v21)

### DIFF
--- a/config/v201/component_config/standardized/InternalCtrlr.json
+++ b/config/v201/component_config/standardized/InternalCtrlr.json
@@ -824,17 +824,17 @@
           "characteristics": {
               "supportsMonitoring": true,
               "dataType": "SequenceList",
-              "valuesList": "v201,v21"
+              "valuesList": "ocpp2.0.1,ocpp2.1"
           },
           "attributes": [
               {
                   "type": "Actual",
                   "mutability": "ReadOnly",
-                  "value": "v21,v201"
+                  "value": "ocpp2.1,ocpp2.0.1"
               }
           ],
           "description": "List of supported OCPP versions in order of preference",
-          "default": "v21,v201",
+          "default": "ocpp2.1,ocpp2.0.1",
           "type": "string"
       }
   },

--- a/config/v201/component_config/standardized/InternalCtrlr.json
+++ b/config/v201/component_config/standardized/InternalCtrlr.json
@@ -818,6 +818,24 @@
           "description": "If enabled we allow connections using security level 0. This does pose a security risk and is not allowed according to the OCPP spec",
           "default": false,
           "type": "boolean"
+      },
+      "SupportedOcppVersions": {
+          "variable_name": "SupportedOcppVersions",
+          "characteristics": {
+              "supportsMonitoring": true,
+              "dataType": "SequenceList",
+              "valuesList": "v201,v21"
+          },
+          "attributes": [
+              {
+                  "type": "Actual",
+                  "mutability": "ReadOnly",
+                  "value": "v21,v201"
+              }
+          ],
+          "description": "List of supported OCPP versions in order of preference",
+          "default": "v21,v201",
+          "type": "string"
       }
   },
   "required": [
@@ -830,6 +848,7 @@
     "NetworkConnectionProfiles",
     "NumberOfConnectors",
     "SupportedCiphers12",
-    "SupportedCiphers13"
+    "SupportedCiphers13",
+    "SupportedOcppVersions"
   ]
 }

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -420,6 +420,8 @@ private:
 
     // states
     std::atomic<RegistrationStatusEnum> registration_status;
+    std::atomic<OcppProtocolVersion> ocpp_version =
+        OcppProtocolVersion::Unknown; // version that is currently in use, selected by CSMS in websocket handshake
     FirmwareStatusEnum firmware_status;
     // The request ID in the last firmware update status received
     std::optional<int32_t> firmware_status_id;
@@ -477,7 +479,8 @@ private:
     void scheduled_check_client_certificate_expiration();
     void scheduled_check_v2g_certificate_expiration();
     void websocket_connected_callback(const int configuration_slot,
-                                      const NetworkConnectionProfile& network_connection_profile);
+                                      const NetworkConnectionProfile& network_connection_profile,
+                                      const OcppProtocolVersion ocpp_version);
     void websocket_disconnected_callback(const int configuration_slot,
                                          const NetworkConnectionProfile& network_connection_profile);
     void websocket_connection_failed(ConnectionFailedReason reason);

--- a/include/ocpp/v201/charge_point_callbacks.hpp
+++ b/include/ocpp/v201/charge_point_callbacks.hpp
@@ -145,7 +145,8 @@ struct Callbacks {
 
     /// \brief Callback function is called when the websocket connection status changes
     std::optional<std::function<void(const bool is_connected, const int configuration_slot,
-                                     const NetworkConnectionProfile& network_connection_profile)>>
+                                     const NetworkConnectionProfile& network_connection_profile,
+                                     const OcppProtocolVersion ocpp_version)>>
         connection_state_changed_callback;
 
     /// \brief Callback functions called for get / set / clear display messages

--- a/include/ocpp/v201/connectivity_manager.hpp
+++ b/include/ocpp/v201/connectivity_manager.hpp
@@ -15,8 +15,9 @@ namespace v201 {
 
 class DeviceModel;
 
-using WebsocketConnectionCallback = std::function<void(
-    int configuration_slot, const NetworkConnectionProfile& network_connection_profile, OcppProtocolVersion version)>;
+using WebsocketConnectionCallback =
+    std::function<void(int configuration_slot, const NetworkConnectionProfile& network_connection_profile,
+                       const OcppProtocolVersion version)>;
 using WebsocketConnectionFailedCallback = std::function<void(ConnectionFailedReason reason)>;
 using ConfigureNetworkConnectionProfileCallback = std::function<std::future<ConfigNetworkResult>(
     const int32_t configuration_slot, const NetworkConnectionProfile& network_connection_profile)>;

--- a/include/ocpp/v201/ctrlr_component_variables.hpp
+++ b/include/ocpp/v201/ctrlr_component_variables.hpp
@@ -87,6 +87,7 @@ extern const ComponentVariable MessageQueueSizeThreshold;
 extern const ComponentVariable MaxMessageSize;
 extern const ComponentVariable ResumeTransactionsOnBoot;
 extern const ComponentVariable AllowSecurityLevelZeroConnections;
+extern const RequiredComponentVariable SupportedOcppVersions;
 extern const ComponentVariable AlignedDataCtrlrEnabled;
 extern const ComponentVariable AlignedDataCtrlrAvailable;
 extern const RequiredComponentVariable AlignedDataInterval;

--- a/include/ocpp/v201/utils.hpp
+++ b/include/ocpp/v201/utils.hpp
@@ -76,6 +76,9 @@ bool is_critical(const std::string& security_event);
 /// \brief Converts the given \p csl of ChargingProfilePurpose strings into a std::set<ChargingProfilePurposeEnum>
 std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string& csl, const bool is_offline);
 
+/// \brief Converts the given \p csl of OcppProtocolVersion strings into a std::vector<OcppProtocolVersion>
+std::vector<OcppProtocolVersion> get_ocpp_protocol_versions(const std::string& csl);
+
 } // namespace utils
 } // namespace v201
 } // namespace ocpp

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -338,7 +338,7 @@ ConnectivityManager::get_ws_connection_options(const int32_t configuration_slot)
             this->device_model.get_value<std::string>(ControllerComponentVariables::SecurityCtrlrIdentity),
             network_connection_profile.securityProfile);
 
-        std::vector<OcppProtocolVersion> ocpp_versions = utils::get_ocpp_protocol_versions(
+        const auto ocpp_versions = utils::get_ocpp_protocol_versions(
             this->device_model.get_value<std::string>(ControllerComponentVariables::SupportedOcppVersions));
 
         WebsocketConnectionOptions connection_options{

--- a/lib/ocpp/v201/connectivity_manager.cpp
+++ b/lib/ocpp/v201/connectivity_manager.cpp
@@ -6,6 +6,7 @@
 #include <everest/logging.hpp>
 #include <ocpp/v201/ctrlr_component_variables.hpp>
 #include <ocpp/v201/device_model.hpp>
+#include <ocpp/v201/utils.hpp>
 
 namespace {
 const auto WEBSOCKET_INIT_DELAY = std::chrono::seconds(2);
@@ -337,8 +338,11 @@ ConnectivityManager::get_ws_connection_options(const int32_t configuration_slot)
             this->device_model.get_value<std::string>(ControllerComponentVariables::SecurityCtrlrIdentity),
             network_connection_profile.securityProfile);
 
+        std::vector<OcppProtocolVersion> ocpp_versions = utils::get_ocpp_protocol_versions(
+            this->device_model.get_value<std::string>(ControllerComponentVariables::SupportedOcppVersions));
+
         WebsocketConnectionOptions connection_options{
-            {OcppProtocolVersion::v201},
+            ocpp_versions,
             uri,
             network_connection_profile.securityProfile,
             this->device_model.get_optional_value<std::string>(ControllerComponentVariables::BasicAuthPassword),

--- a/lib/ocpp/v201/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v201/ctrlr_component_variables.cpp
@@ -380,6 +380,11 @@ const ComponentVariable AllowSecurityLevelZeroConnections = {
         "AllowSecurityLevelZeroConnections",
     }),
 };
+const RequiredComponentVariable SupportedOcppVersions = {
+    ControllerComponents::InternalCtrlr,
+    std::nullopt,
+    std::optional<Variable>({"SupportedOcppVersions"}),
+};
 const ComponentVariable AlignedDataCtrlrEnabled = {
     ControllerComponents::AlignedDataCtrlr,
     std::nullopt,

--- a/lib/ocpp/v201/utils.cpp
+++ b/lib/ocpp/v201/utils.cpp
@@ -210,6 +210,23 @@ std::set<ChargingProfilePurposeEnum> get_purposes_to_ignore(const std::string& c
     return purposes_to_ignore;
 }
 
+std::vector<OcppProtocolVersion> get_ocpp_protocol_versions(const std::string& csl) {
+    if (csl.empty()) {
+        return {};
+    }
+
+    std::vector<OcppProtocolVersion> ocpp_versions;
+    const auto ocpp_versions_str = ocpp::split_string(csl, ',');
+    for (const auto ocpp_version_str : ocpp_versions_str) {
+        try {
+            ocpp_versions.push_back(ocpp::conversions::string_to_ocpp_protocol_version(ocpp_version_str));
+        } catch (std::out_of_range& e) {
+            EVLOG_warning << "Error while converting ocpp protocol version: " << ocpp_version_str;
+        }
+    }
+    return ocpp_versions;
+}
+
 } // namespace utils
 } // namespace v201
 } // namespace ocpp


### PR DESCRIPTION
## Describe your changes
* Added internal variable SupportedOcppVersions that allows to specify the supported protocol versions in order of preference
* Added member variable ocpp_version to ChargePoint to indicate the selected version
* ConnectivityManager now uses the configured value to set up the WebsocketConnectionOptions

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

