### PR TITLE
Check supported_feature_profiles for CostAndPrice before attempt to retrieve configuration key

### DIFF
--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -3289,12 +3289,12 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
         }
     }
 
-    // California Pricing
-    if (key == "CustomDisplayCostAndPrice") {
-        return this->getCustomDisplayCostAndPriceEnabledKeyValue();
-    }
+    if (this->supported_feature_profiles.count(SupportedFeatureProfiles::CostAndPrice)) {
+        // California Pricing
+        if (key == "CustomDisplayCostAndPrice") {
+            return this->getCustomDisplayCostAndPriceEnabledKeyValue();
+        }
 
-    if (getCustomDisplayCostAndPriceEnabled()) {
         if (key == "NumberOfDecimalsForCostValues") {
             return this->getPriceNumberOfDecimalsForCostValuesKeyValue();
         }


### PR DESCRIPTION
## Describe your changes
Checking supported_feature_profiles for CostAndPrice before attepting to get respective conigutation keys

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

