### PR TITLE
Move functional block O: DisplayMessage

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -12,6 +12,7 @@
 #include <ocpp/v201/functional_blocks/data_transfer.hpp>
 #include <ocpp/v201/functional_blocks/reservation.hpp>
 #include <ocpp/v201/functional_blocks/security.hpp>
+#include <ocpp/v201/functional_blocks/display_message.hpp>
 
 #include <ocpp/common/aligned_timer.hpp>
 #include <ocpp/common/charging_station_base.hpp>
@@ -36,7 +37,6 @@
 #include <ocpp/v201/messages/BootNotification.hpp>
 #include <ocpp/v201/messages/ChangeAvailability.hpp>
 #include <ocpp/v201/messages/ClearChargingProfile.hpp>
-#include <ocpp/v201/messages/ClearDisplayMessage.hpp>
 #include <ocpp/v201/messages/ClearVariableMonitoring.hpp>
 #include <ocpp/v201/messages/CostUpdated.hpp>
 #include <ocpp/v201/messages/CustomerInformation.hpp>
@@ -45,7 +45,6 @@
 #include <ocpp/v201/messages/GetBaseReport.hpp>
 #include <ocpp/v201/messages/GetChargingProfiles.hpp>
 #include <ocpp/v201/messages/GetCompositeSchedule.hpp>
-#include <ocpp/v201/messages/GetDisplayMessages.hpp>
 #include <ocpp/v201/messages/GetInstalledCertificateIds.hpp>
 #include <ocpp/v201/messages/GetLog.hpp>
 #include <ocpp/v201/messages/GetMonitoringReport.hpp>
@@ -64,7 +63,6 @@
 #include <ocpp/v201/messages/RequestStopTransaction.hpp>
 #include <ocpp/v201/messages/Reset.hpp>
 #include <ocpp/v201/messages/SetChargingProfile.hpp>
-#include <ocpp/v201/messages/SetDisplayMessage.hpp>
 #include <ocpp/v201/messages/SetMonitoringBase.hpp>
 #include <ocpp/v201/messages/SetMonitoringLevel.hpp>
 #include <ocpp/v201/messages/SetNetworkProfile.hpp>
@@ -389,6 +387,7 @@ private:
     std::unique_ptr<ReservationInterface> reservation;
     std::unique_ptr<AuthorizationInterface> authorization;
     std::unique_ptr<SecurityInterface> security;
+    std::unique_ptr<DisplayMessageInterface> display_message;
 
     // utility
     std::shared_ptr<MessageQueue<v201::MessageType>> message_queue;
@@ -515,14 +514,6 @@ private:
 
     /// \brief Restores all connectors to their persisted state
     void restore_all_connector_states();
-
-    ///
-    /// \brief Get evseid for the given transaction id.
-    /// \param transaction_id   The transactionid
-    /// \return The evse id belonging the the transaction id. std::nullopt if there is no transaction with the given
-    ///         transaction id.
-    ///
-    std::optional<int32_t> get_transaction_evseid(const CiString<36>& transaction_id);
 
     ///
     /// \brief Check if EVSE connector is reserved for another than the given id token and / or group id token.
@@ -714,11 +705,6 @@ private:
     void handle_set_variable_monitoring_req(const EnhancedMessage<v201::MessageType>& message);
     void handle_get_monitoring_report_req(Call<GetMonitoringReportRequest> call);
     void handle_clear_variable_monitoring_req(Call<ClearVariableMonitoringRequest> call);
-
-    // Functional Block O: DisplayMessage
-    void handle_get_display_message(Call<GetDisplayMessagesRequest> call);
-    void handle_set_display_message(Call<SetDisplayMessageRequest> call);
-    void handle_clear_display_message(Call<ClearDisplayMessageRequest> call);
 
     // Generates async sending callbacks
     template <class RequestType, class ResponseType>

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -10,9 +10,9 @@
 #include <ocpp/common/message_dispatcher.hpp>
 #include <ocpp/v201/functional_blocks/authorization.hpp>
 #include <ocpp/v201/functional_blocks/data_transfer.hpp>
+#include <ocpp/v201/functional_blocks/display_message.hpp>
 #include <ocpp/v201/functional_blocks/reservation.hpp>
 #include <ocpp/v201/functional_blocks/security.hpp>
-#include <ocpp/v201/functional_blocks/display_message.hpp>
 
 #include <ocpp/common/aligned_timer.hpp>
 #include <ocpp/common/charging_station_base.hpp>

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -37,6 +37,13 @@ public:
     /// \brief Get the number of evses
     virtual size_t get_number_of_evses() const = 0;
 
+    /// \brief Get evseid for the given transaction id.
+    /// \param transaction_id   The transactionid
+    /// \return The evse id belonging the the transaction id. std::nullopt if there is no transaction with the given
+    ///         transaction id.
+    ///
+    virtual std::optional<int32_t> get_transaction_evseid(const CiString<36>& transaction_id) const = 0;
+
     /// \brief Gets an iterator pointing to the first evse
     virtual EvseIterator begin() = 0;
     /// \brief Gets an iterator pointing past the last evse
@@ -62,6 +69,8 @@ public:
     bool does_evse_exist(const int32_t id) const override;
 
     size_t get_number_of_evses() const override;
+
+    std::optional<int32_t> get_transaction_evseid(const CiString<36>& transaction_id) const override;
 
     EvseIterator begin() override;
     EvseIterator end() override;

--- a/include/ocpp/v201/functional_blocks/display_message.hpp
+++ b/include/ocpp/v201/functional_blocks/display_message.hpp
@@ -40,7 +40,7 @@ typedef std::function<ClearDisplayMessageResponse(const ClearDisplayMessageReque
 
 class DisplayMessageInterface : public MessageHandlerInterface {
 public:
-    virtual ~DisplayMessageInterface() {};
+    virtual ~DisplayMessageInterface(){};
 };
 
 class DisplayMessageBlock : public DisplayMessageInterface {

--- a/include/ocpp/v201/functional_blocks/display_message.hpp
+++ b/include/ocpp/v201/functional_blocks/display_message.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <ocpp/v201/evse_manager.hpp>
+#include <ocpp/v201/message_dispatcher.hpp>
+#include <ocpp/v201/message_handler.hpp>
+#include <ocpp/v201/messages/ClearDisplayMessage.hpp>
+#include <ocpp/v201/messages/GetDisplayMessages.hpp>
+#include <ocpp/v201/messages/SetDisplayMessage.hpp>
+
+namespace ocpp::v201 {
+
+///
+/// \brief Convert message content from OCPP spec to DisplayMessageContent.
+/// \param message_content  The struct to convert.
+/// \return The converted struct.
+///
+DisplayMessageContent message_content_to_display_message_content(const MessageContent& message_content);
+///
+/// \brief Convert display message to MessageInfo from OCPP.
+/// \param display_message  The struct to convert.
+/// \return The converted struct.
+///
+std::optional<MessageInfo> display_message_to_message_info_type(const DisplayMessage& display_message);
+///
+/// \brief Convert message info from OCPP to DisplayMessage.
+/// \param message_info The struct to convert.
+/// \return The converted struct.
+///
+DisplayMessage message_info_to_display_message(const MessageInfo& message_info);
+
+typedef std::function<std::vector<ocpp::DisplayMessage>(const GetDisplayMessagesRequest& request)>
+    GetDisplayMessageCallback;
+typedef std::function<SetDisplayMessageResponse(const std::vector<DisplayMessage>& display_messages)>
+    SetDisplayMessageCallback;
+typedef std::function<ClearDisplayMessageResponse(const ClearDisplayMessageRequest& request)>
+    ClearDisplayMessageCallback;
+
+class DisplayMessageInterface : public MessageHandlerInterface {
+public:
+    virtual ~DisplayMessageInterface() {};
+};
+
+class DisplayMessageBlock : public DisplayMessageInterface {
+
+public:
+    DisplayMessageBlock(MessageDispatcherInterface<MessageType>& message_dispatcher, DeviceModel& device_model,
+                        EvseManagerInterface& evse_manager, GetDisplayMessageCallback get_display_message_callback,
+                        SetDisplayMessageCallback set_display_message_callback,
+                        ClearDisplayMessageCallback clear_display_message_callback);
+    virtual void handle_message(const ocpp::EnhancedMessage<MessageType>& message) override;
+
+private:
+    MessageDispatcherInterface<MessageType>& message_dispatcher;
+    DeviceModel& device_model;
+    EvseManagerInterface& evse_manager;
+
+    GetDisplayMessageCallback get_display_message_callback;
+    SetDisplayMessageCallback set_display_message_callback;
+    ClearDisplayMessageCallback clear_display_message_callback;
+
+    void handle_get_display_message(Call<GetDisplayMessagesRequest> call);
+    void handle_set_display_message(Call<SetDisplayMessageRequest> call);
+    void handle_clear_display_message(Call<ClearDisplayMessageRequest> call);
+};
+
+} // namespace ocpp::v201

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -98,6 +98,7 @@ if(LIBOCPP_ENABLE_V201)
             ocpp/v201/functional_blocks/security.cpp
             ocpp/v201/functional_blocks/data_transfer.cpp
             ocpp/v201/functional_blocks/reservation.cpp
+            ocpp/v201/functional_blocks/display_message.cpp
     )
     add_subdirectory(ocpp/v201/messages)
 endif()

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -939,7 +939,7 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
                                                           *this->connectivity_manager.get(),
                                                           *this->database_handler.get(), *this->evse_security.get());
     this->authorization->start_auth_cache_cleanup_thread();
-    
+
     if (device_model->get_optional_value<bool>(ControllerComponentVariables::DisplayMessageCtrlrAvailable)
             .value_or(false)) {
         this->display_message = std::make_unique<DisplayMessageBlock>(
@@ -1097,13 +1097,13 @@ void ChargePoint::handle_message(const EnhancedMessage<v201::MessageType>& messa
             this->handle_clear_variable_monitoring_req(json_message);
             break;
         case MessageType::GetDisplayMessages:
-            this->display_message->handle_message(message);
-            break;
         case MessageType::SetDisplayMessage:
-            this->display_message->handle_message(message);
-            break;
         case MessageType::ClearDisplayMessage:
-            this->display_message->handle_message(message);
+            if (this->display_message != nullptr) {
+                this->display_message->handle_message(message);
+            } else {
+                send_not_implemented_error(message.uniqueId, message.messageTypeId);
+            }
             break;
         case MessageType::CostUpdated:
             this->handle_costupdated_req(json_message);

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -9,7 +9,6 @@
 #include <ocpp/v201/message_dispatcher.hpp>
 #include <ocpp/v201/messages/FirmwareStatusNotification.hpp>
 #include <ocpp/v201/messages/LogStatusNotification.hpp>
-#include <ocpp/v201/messages/NotifyDisplayMessages.hpp>
 #include <ocpp/v201/notify_report_requests_splitter.hpp>
 
 #include <optional>
@@ -29,10 +28,6 @@ namespace v201 {
 const auto DEFAULT_BOOT_NOTIFICATION_RETRY_INTERVAL = std::chrono::seconds(30);
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
 const auto DEFAULT_MAX_MESSAGE_SIZE = 65000;
-
-static DisplayMessageContent message_content_to_display_message_content(const MessageContent& message_content);
-static std::optional<MessageInfo> display_message_to_message_info_type(const DisplayMessage& display_message);
-static DisplayMessage message_info_to_display_message(const MessageInfo& message_info);
 
 ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
                          std::shared_ptr<DeviceModel> device_model, std::shared_ptr<DatabaseHandler> database_handler,
@@ -944,6 +939,14 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
                                                           *this->connectivity_manager.get(),
                                                           *this->database_handler.get(), *this->evse_security.get());
     this->authorization->start_auth_cache_cleanup_thread();
+    
+    if (device_model->get_optional_value<bool>(ControllerComponentVariables::DisplayMessageCtrlrAvailable)
+            .value_or(false)) {
+        this->display_message = std::make_unique<DisplayMessageBlock>(
+            *this->message_dispatcher, *this->device_model, *this->evse_manager,
+            this->callbacks.get_display_message_callback.value(), this->callbacks.set_display_message_callback.value(),
+            this->callbacks.clear_display_message_callback.value());
+    }
 
     if (this->callbacks.configure_network_connection_profile_callback.has_value()) {
         this->connectivity_manager->set_configure_network_connection_profile_callback(
@@ -1094,13 +1097,13 @@ void ChargePoint::handle_message(const EnhancedMessage<v201::MessageType>& messa
             this->handle_clear_variable_monitoring_req(json_message);
             break;
         case MessageType::GetDisplayMessages:
-            this->handle_get_display_message(json_message);
+            this->display_message->handle_message(message);
             break;
         case MessageType::SetDisplayMessage:
-            this->handle_set_display_message(json_message);
+            this->display_message->handle_message(message);
             break;
         case MessageType::ClearDisplayMessage:
-            this->handle_clear_display_message(json_message);
+            this->display_message->handle_message(message);
             break;
         case MessageType::CostUpdated:
             this->handle_costupdated_req(json_message);
@@ -1591,18 +1594,6 @@ ChargePoint::set_variables_internal(const std::vector<SetVariableData>& set_vari
     }
 
     return response;
-}
-
-std::optional<int32_t> ChargePoint::get_transaction_evseid(const CiString<36>& transaction_id) {
-    for (auto& evse : *this->evse_manager) {
-        if (evse.has_active_transaction()) {
-            if (transaction_id == evse.get_transaction()->get_transaction().transactionId) {
-                return evse.get_id();
-            }
-        }
-    }
-
-    return std::nullopt;
 }
 
 ocpp::ReservationCheckStatus
@@ -2286,7 +2277,7 @@ void ChargePoint::handle_get_transaction_status(const Call<GetTransactionStatusR
     response.messagesInQueue = false;
 
     if (msg.transactionId.has_value()) {
-        if (this->get_transaction_evseid(msg.transactionId.value()).has_value()) {
+        if (this->evse_manager->get_transaction_evseid(msg.transactionId.value()).has_value()) {
             response.ongoingIndicator = true;
         } else {
             response.ongoingIndicator = false;
@@ -2621,7 +2612,7 @@ void ChargePoint::handle_remote_stop_transaction_request(Call<RequestStopTransac
     const auto msg = call.msg;
 
     RequestStopTransactionResponse response;
-    std::optional<int32_t> evseid = get_transaction_evseid(msg.transactionId);
+    std::optional<int32_t> evseid = this->evse_manager->get_transaction_evseid(msg.transactionId);
 
     if (evseid.has_value()) {
         // F03.FR.07: send 'accepted' if there was an ongoing transaction with the given transaction id
@@ -2757,7 +2748,8 @@ void ChargePoint::handle_costupdated_req(const Call<CostUpdatedRequest> call) {
     running_cost.cost = static_cast<double>(call.msg.totalCost);
     running_cost.transaction_id = call.msg.transactionId;
 
-    std::optional<int32_t> transaction_evse_id = get_transaction_evseid(running_cost.transaction_id);
+    std::optional<int32_t> transaction_evse_id =
+        this->evse_manager->get_transaction_evseid(running_cost.transaction_id);
     if (!transaction_evse_id.has_value()) {
         // We just put an error in the log as the spec does not define what to do here. It is not possible to return
         // a 'Rejected' or something in that manner.
@@ -2780,7 +2772,7 @@ void ChargePoint::handle_costupdated_req(const Call<CostUpdatedRequest> call) {
         return;
     }
 
-    const std::optional<int32_t> evse_id_opt = get_transaction_evseid(running_cost.transaction_id);
+    const std::optional<int32_t> evse_id_opt = this->evse_manager->get_transaction_evseid(running_cost.transaction_id);
     if (!evse_id_opt.has_value()) {
         EVLOG_warning << "Can not set running cost triggers as there is no evse id found with the transaction id from "
                          "the incoming CostUpdatedRequest";
@@ -3324,143 +3316,6 @@ void ChargePoint::handle_clear_variable_monitoring_req(Call<ClearVariableMonitor
     this->message_dispatcher->dispatch_call_result(call_result);
 }
 
-void ChargePoint::handle_get_display_message(const Call<GetDisplayMessagesRequest> call) {
-    GetDisplayMessagesResponse response;
-    if (!this->callbacks.get_display_message_callback.has_value()) {
-        response.status = GetDisplayMessagesStatusEnum::Unknown;
-        ocpp::CallResult<GetDisplayMessagesResponse> call_result(response, call.uniqueId);
-        this->message_dispatcher->dispatch_call_result(call_result);
-        return;
-    }
-
-    // Call 'get display message callback' to get all display messages from the charging station.
-    const std::vector<DisplayMessage> display_messages = this->callbacks.get_display_message_callback.value()(call.msg);
-
-    NotifyDisplayMessagesRequest messages_request;
-    messages_request.requestId = call.msg.requestId;
-    messages_request.messageInfo = std::vector<MessageInfo>();
-    // Convert all display messages from the charging station to the correct format. They will not be included if
-    // they do not have the required values. That's why we wait with sending the response until we converted all
-    // display messages, because we then know if there are any.
-    for (const auto& display_message : display_messages) {
-        const std::optional<MessageInfo> message_info = display_message_to_message_info_type(display_message);
-        if (message_info.has_value()) {
-            messages_request.messageInfo->push_back(message_info.value());
-        }
-    }
-
-    // Send 'accepted' back to the CSMS if there is at least one message and send all the messages in another
-    // request.
-    if (messages_request.messageInfo.value().empty()) {
-        response.status = GetDisplayMessagesStatusEnum::Unknown;
-        ocpp::CallResult<GetDisplayMessagesResponse> call_result(response, call.uniqueId);
-        this->message_dispatcher->dispatch_call_result(call_result);
-        return;
-    } else {
-        response.status = GetDisplayMessagesStatusEnum::Accepted;
-        ocpp::CallResult<GetDisplayMessagesResponse> call_result(response, call.uniqueId);
-        this->message_dispatcher->dispatch_call_result(call_result);
-    }
-
-    // Send display messages. The response is empty, so we don't have to get that back.
-    // Sending multiple messages is not supported for now, because there is no need to split them up (yet).
-    ocpp::Call<NotifyDisplayMessagesRequest> request(messages_request);
-    this->message_dispatcher->dispatch_call(request);
-}
-
-void ChargePoint::handle_set_display_message(const Call<SetDisplayMessageRequest> call) {
-    SetDisplayMessageResponse response;
-    if (!this->callbacks.set_display_message_callback.has_value()) {
-        response.status = DisplayMessageStatusEnum::Rejected;
-        ocpp::CallResult<SetDisplayMessageResponse> call_result(response, call.uniqueId);
-        this->message_dispatcher->dispatch_call_result(call_result);
-        return;
-    }
-
-    // Check if display messages are available, priority and message format are supported and if the given
-    // transaction is running, if a transaction id was included in the message.
-    bool error = false;
-    const std::optional<bool> display_message_available =
-        this->device_model->get_optional_value<bool>(ControllerComponentVariables::DisplayMessageCtrlrAvailable);
-    const std::string supported_priorities =
-        this->device_model->get_value<std::string>(ControllerComponentVariables::DisplayMessageSupportedPriorities);
-    const std::string supported_message_formats =
-        this->device_model->get_value<std::string>(ControllerComponentVariables::DisplayMessageSupportedFormats);
-
-    const std::vector<std::string> priorities = split_string(supported_priorities, ',', true);
-    const std::vector<std::string> formats = split_string(supported_message_formats, ',', true);
-    const auto& supported_priority_it = std::find(
-        priorities.begin(), priorities.end(), conversions::message_priority_enum_to_string(call.msg.message.priority));
-    const auto& supported_format_it = std::find(
-        formats.begin(), formats.end(), conversions::message_format_enum_to_string(call.msg.message.message.format));
-
-    // Check if transaction is valid: this is the case if there is no transaction id, or if the transaction id
-    // belongs to a running transaction.
-    const bool transaction_valid = (!call.msg.message.transactionId.has_value() or
-                                    get_transaction_evseid(call.msg.message.transactionId.value()) != std::nullopt);
-
-    // Check if display messages are available.
-    if (!display_message_available.has_value() or !display_message_available.value()) {
-        error = true;
-        response.status = DisplayMessageStatusEnum::Rejected;
-    }
-    // Check if the priority is supported.
-    else if (supported_priority_it == priorities.end()) {
-        error = true;
-        response.status = DisplayMessageStatusEnum::NotSupportedPriority;
-    }
-    // Check if the message format is supported.
-    else if (supported_format_it == formats.end()) {
-        error = true;
-        response.status = DisplayMessageStatusEnum::NotSupportedMessageFormat;
-    }
-    // Check if transaction is valid.
-    else if (!transaction_valid) {
-        error = true;
-        response.status = DisplayMessageStatusEnum::UnknownTransaction;
-    }
-    // Check if message state is supported.
-    else if (call.msg.message.state.has_value()) {
-        const std::optional<std::string> supported_states = this->device_model->get_optional_value<std::string>(
-            ControllerComponentVariables::DisplayMessageSupportedStates);
-        if (supported_states.has_value()) {
-            const std::vector<std::string> states = split_string(supported_states.value(), ',', true);
-            const auto& supported_states_it =
-                std::find(states.begin(), states.end(),
-                          conversions::message_state_enum_to_string(call.msg.message.state.value()));
-            if (supported_states_it == states.end()) {
-                error = true;
-                response.status = DisplayMessageStatusEnum::NotSupportedState;
-            }
-        }
-    }
-
-    if (error) {
-        ocpp::CallResult<SetDisplayMessageResponse> call_result(response, call.uniqueId);
-        this->message_dispatcher->dispatch_call_result(call_result);
-        return;
-    }
-
-    const DisplayMessage message = message_info_to_display_message(call.msg.message);
-    response = this->callbacks.set_display_message_callback.value()({message});
-    ocpp::CallResult<SetDisplayMessageResponse> call_result(response, call.uniqueId);
-    this->message_dispatcher->dispatch_call_result(call_result);
-}
-
-void ChargePoint::handle_clear_display_message(const Call<ClearDisplayMessageRequest> call) {
-    ClearDisplayMessageResponse response;
-    if (!this->callbacks.clear_display_message_callback.has_value()) {
-        EVLOG_error << "Received a clear display message request, but callback is not implemented.";
-        response.status = ClearMessageStatusEnum::Unknown;
-        ocpp::CallResult<ClearDisplayMessageResponse> call_result(response, call.uniqueId);
-        this->message_dispatcher->dispatch_call_result(call_result);
-    }
-
-    response = this->callbacks.clear_display_message_callback.value()(call.msg);
-    ocpp::CallResult<ClearDisplayMessageResponse> call_result(response, call.uniqueId);
-    this->message_dispatcher->dispatch_call_result(call_result);
-}
-
 std::optional<DataTransferResponse> ChargePoint::data_transfer_req(const CiString<255>& vendorId,
                                                                    const std::optional<CiString<50>>& messageId,
                                                                    const std::optional<json>& data) {
@@ -3830,77 +3685,6 @@ void ChargePoint::send_not_implemented_error(const MessageId unique_message_id, 
         const auto call_error = CallError(unique_message_id, "NotImplemented", "", json({}));
         this->message_dispatcher->dispatch_call_error(call_error);
     }
-}
-
-// Static functions
-
-///
-/// \brief Convert message content from OCPP spec to DisplayMessageContent.
-/// \param message_content  The struct to convert.
-/// \return The converted struct.
-///
-static DisplayMessageContent message_content_to_display_message_content(const MessageContent& message_content) {
-    DisplayMessageContent result;
-    result.message = message_content.content;
-    result.message_format = message_content.format;
-    result.language = message_content.language;
-    return result;
-}
-
-///
-/// \brief Convert display message to MessageInfo from OCPP.
-/// \param display_message  The struct to convert.
-/// \return The converted struct.
-///
-static std::optional<MessageInfo> display_message_to_message_info_type(const DisplayMessage& display_message) {
-    // Each display message should have an id and p[riority, this is required for OCPP.
-    if (!display_message.id.has_value()) {
-        EVLOG_error << "Can not convert DisplayMessage to MessageInfo: No id is provided, which is required by OCPP.";
-        return std::nullopt;
-    }
-
-    if (!display_message.priority.has_value()) {
-        EVLOG_error
-            << "Can not convert DisplayMessage to MessageInfo: No priority is provided, which is required by OCPP.";
-        return std::nullopt;
-    }
-
-    MessageInfo info;
-    info.message.content = display_message.message.message;
-    info.message.format =
-        (display_message.message.message_format.has_value() ? display_message.message.message_format.value()
-                                                            : MessageFormatEnum::UTF8);
-    info.message.language = display_message.message.language;
-    info.endDateTime = display_message.timestamp_to;
-    info.startDateTime = display_message.timestamp_from;
-    info.id = display_message.id.value();
-    info.priority = display_message.priority.value();
-    info.state = display_message.state;
-    info.transactionId = display_message.identifier_id;
-
-    // Note: component is (not yet?) supported for display messages in libocpp.
-
-    return info;
-}
-
-///
-/// \brief Convert message info from OCPP to DisplayMessage.
-/// \param message_info The struct to convert.
-/// \return The converted struct.
-///
-static DisplayMessage message_info_to_display_message(const MessageInfo& message_info) {
-    DisplayMessage display_message;
-
-    display_message.id = message_info.id;
-    display_message.priority = message_info.priority;
-    display_message.state = message_info.state;
-    display_message.timestamp_from = message_info.startDateTime;
-    display_message.timestamp_to = message_info.endDateTime;
-    display_message.identifier_id = message_info.transactionId;
-    display_message.identifier_type = IdentifierType::TransactionId;
-    display_message.message = message_content_to_display_message_content(message_info.message);
-
-    return display_message;
 }
 
 } // namespace v201

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -63,5 +63,17 @@ size_t EvseManager::get_number_of_evses() const {
     return this->evses.size();
 }
 
+std::optional<int32_t> EvseManager::get_transaction_evseid(const CiString<36>& transaction_id) const {
+    for (const auto& evse : this->evses) {
+        if (evse->has_active_transaction()) {
+            if (transaction_id == evse->get_transaction()->get_transaction().transactionId) {
+                return evse->get_id();
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
 } // namespace v201
 } // namespace ocpp

--- a/lib/ocpp/v201/functional_blocks/display_message.cpp
+++ b/lib/ocpp/v201/functional_blocks/display_message.cpp
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <ocpp/v201/functional_blocks/display_message.hpp>
+#include <ocpp/v201/messages/NotifyDisplayMessages.hpp>
+#include <ocpp/v201/ctrlr_component_variables.hpp>
+
+namespace ocpp::v201 {
+
+DisplayMessageBlock::DisplayMessageBlock(MessageDispatcherInterface<MessageType>& message_dispatcher,
+                                         DeviceModel& device_model,
+                                         EvseManagerInterface& evse_manager,
+                                         GetDisplayMessageCallback get_display_message_callback,
+                                         SetDisplayMessageCallback set_display_message_callback,
+                                         ClearDisplayMessageCallback clear_display_message_callback) :
+    message_dispatcher(message_dispatcher),
+    device_model(device_model),
+    evse_manager(evse_manager),
+    get_display_message_callback(get_display_message_callback),
+    set_display_message_callback(set_display_message_callback),
+    clear_display_message_callback(clear_display_message_callback) {
+}
+
+void DisplayMessageBlock::handle_message(const ocpp::EnhancedMessage<MessageType>& message) {
+}
+
+void DisplayMessageBlock::handle_get_display_message(const Call<GetDisplayMessagesRequest> call) {
+    GetDisplayMessagesResponse response;
+    response.status = GetDisplayMessagesStatusEnum::Unknown;
+    ocpp::CallResult<GetDisplayMessagesResponse> call_result(response, call.uniqueId);
+    this->message_dispatcher.dispatch_call_result(call_result);
+    return;
+
+    // Call 'get display message callback' to get all display messages from the charging station.
+    const std::vector<DisplayMessage> display_messages = this->get_display_message_callback(call.msg);
+
+    NotifyDisplayMessagesRequest messages_request;
+    messages_request.requestId = call.msg.requestId;
+    messages_request.messageInfo = std::vector<MessageInfo>();
+    // Convert all display messages from the charging station to the correct format. They will not be included if
+    // they do not have the required values. That's why we wait with sending the response until we converted all
+    // display messages, because we then know if there are any.
+    for (const auto& display_message : display_messages) {
+        const std::optional<MessageInfo> message_info = display_message_to_message_info_type(display_message);
+        if (message_info.has_value()) {
+            messages_request.messageInfo->push_back(message_info.value());
+        }
+    }
+
+    // Send 'accepted' back to the CSMS if there is at least one message and send all the messages in another
+    // request.
+    if (messages_request.messageInfo.value().empty()) {
+        response.status = GetDisplayMessagesStatusEnum::Unknown;
+        ocpp::CallResult<GetDisplayMessagesResponse> call_result(response, call.uniqueId);
+        this->message_dispatcher.dispatch_call_result(call_result);
+        return;
+    } else {
+        response.status = GetDisplayMessagesStatusEnum::Accepted;
+        ocpp::CallResult<GetDisplayMessagesResponse> call_result(response, call.uniqueId);
+        this->message_dispatcher.dispatch_call_result(call_result);
+    }
+
+    // Send display messages. The response is empty, so we don't have to get that back.
+    // Sending multiple messages is not supported for now, because there is no need to split them up (yet).
+    ocpp::Call<NotifyDisplayMessagesRequest> request(messages_request);
+    this->message_dispatcher.dispatch_call(request);
+}
+
+void DisplayMessageBlock::handle_set_display_message(const Call<SetDisplayMessageRequest> call) {
+    SetDisplayMessageResponse response;
+
+    // Check if display messages are available, priority and message format are supported and if the given
+    // transaction is running, if a transaction id was included in the message.
+    bool error = false;
+    const std::optional<bool> display_message_available =
+        this->device_model.get_optional_value<bool>(ControllerComponentVariables::DisplayMessageCtrlrAvailable);
+    const std::string supported_priorities =
+        this->device_model.get_value<std::string>(ControllerComponentVariables::DisplayMessageSupportedPriorities);
+    const std::string supported_message_formats =
+        this->device_model.get_value<std::string>(ControllerComponentVariables::DisplayMessageSupportedFormats);
+
+    const std::vector<std::string> priorities = split_string(supported_priorities, ',', true);
+    const std::vector<std::string> formats = split_string(supported_message_formats, ',', true);
+    const auto& supported_priority_it = std::find(
+        priorities.begin(), priorities.end(), conversions::message_priority_enum_to_string(call.msg.message.priority));
+    const auto& supported_format_it = std::find(
+        formats.begin(), formats.end(), conversions::message_format_enum_to_string(call.msg.message.message.format));
+
+    // Check if transaction is valid: this is the case if there is no transaction id, or if the transaction id
+    // belongs to a running transaction.
+    const bool transaction_valid = (!call.msg.message.transactionId.has_value() or
+                                    this->evse_manager.get_transaction_evseid(call.msg.message.transactionId.value()) != std::nullopt);
+
+    // Check if display messages are available.
+    if (!display_message_available.has_value() or !display_message_available.value()) {
+        error = true;
+        response.status = DisplayMessageStatusEnum::Rejected;
+    }
+    // Check if the priority is supported.
+    else if (supported_priority_it == priorities.end()) {
+        error = true;
+        response.status = DisplayMessageStatusEnum::NotSupportedPriority;
+    }
+    // Check if the message format is supported.
+    else if (supported_format_it == formats.end()) {
+        error = true;
+        response.status = DisplayMessageStatusEnum::NotSupportedMessageFormat;
+    }
+    // Check if transaction is valid.
+    else if (!transaction_valid) {
+        error = true;
+        response.status = DisplayMessageStatusEnum::UnknownTransaction;
+    }
+    // Check if message state is supported.
+    else if (call.msg.message.state.has_value()) {
+        const std::optional<std::string> supported_states = this->device_model.get_optional_value<std::string>(
+            ControllerComponentVariables::DisplayMessageSupportedStates);
+        if (supported_states.has_value()) {
+            const std::vector<std::string> states = split_string(supported_states.value(), ',', true);
+            const auto& supported_states_it =
+                std::find(states.begin(), states.end(),
+                          conversions::message_state_enum_to_string(call.msg.message.state.value()));
+            if (supported_states_it == states.end()) {
+                error = true;
+                response.status = DisplayMessageStatusEnum::NotSupportedState;
+            }
+        }
+    }
+
+    if (error) {
+        ocpp::CallResult<SetDisplayMessageResponse> call_result(response, call.uniqueId);
+        this->message_dispatcher.dispatch_call_result(call_result);
+        return;
+    }
+
+    const DisplayMessage message = message_info_to_display_message(call.msg.message);
+    response = this->set_display_message_callback({message});
+    ocpp::CallResult<SetDisplayMessageResponse> call_result(response, call.uniqueId);
+    this->message_dispatcher.dispatch_call_result(call_result);
+}
+
+void DisplayMessageBlock::handle_clear_display_message(const Call<ClearDisplayMessageRequest> call) {
+    ClearDisplayMessageResponse response;
+    response = this->clear_display_message_callback(call.msg);
+    ocpp::CallResult<ClearDisplayMessageResponse> call_result(response, call.uniqueId);
+    this->message_dispatcher.dispatch_call_result(call_result);
+}
+
+// Static functions
+
+///
+/// \brief Convert message content from OCPP spec to DisplayMessageContent.
+/// \param message_content  The struct to convert.
+/// \return The converted struct.
+///
+DisplayMessageContent message_content_to_display_message_content(const MessageContent& message_content) {
+    DisplayMessageContent result;
+    result.message = message_content.content;
+    result.message_format = message_content.format;
+    result.language = message_content.language;
+    return result;
+}
+
+///
+/// \brief Convert display message to MessageInfo from OCPP.
+/// \param display_message  The struct to convert.
+/// \return The converted struct.
+///
+std::optional<MessageInfo> display_message_to_message_info_type(const DisplayMessage& display_message) {
+    // Each display message should have an id and p[riority, this is required for OCPP.
+    if (!display_message.id.has_value()) {
+        EVLOG_error << "Can not convert DisplayMessage to MessageInfo: No id is provided, which is required by OCPP.";
+        return std::nullopt;
+    }
+
+    if (!display_message.priority.has_value()) {
+        EVLOG_error
+            << "Can not convert DisplayMessage to MessageInfo: No priority is provided, which is required by OCPP.";
+        return std::nullopt;
+    }
+
+    MessageInfo info;
+    info.message.content = display_message.message.message;
+    info.message.format =
+        (display_message.message.message_format.has_value() ? display_message.message.message_format.value()
+                                                            : MessageFormatEnum::UTF8);
+    info.message.language = display_message.message.language;
+    info.endDateTime = display_message.timestamp_to;
+    info.startDateTime = display_message.timestamp_from;
+    info.id = display_message.id.value();
+    info.priority = display_message.priority.value();
+    info.state = display_message.state;
+    info.transactionId = display_message.identifier_id;
+
+    // Note: component is (not yet?) supported for display messages in libocpp.
+
+    return info;
+}
+
+///
+/// \brief Convert message info from OCPP to DisplayMessage.
+/// \param message_info The struct to convert.
+/// \return The converted struct.
+///
+DisplayMessage message_info_to_display_message(const MessageInfo& message_info) {
+    DisplayMessage display_message;
+
+    display_message.id = message_info.id;
+    display_message.priority = message_info.priority;
+    display_message.state = message_info.state;
+    display_message.timestamp_from = message_info.startDateTime;
+    display_message.timestamp_to = message_info.endDateTime;
+    display_message.identifier_id = message_info.transactionId;
+    display_message.identifier_type = IdentifierType::TransactionId;
+    display_message.message = message_content_to_display_message_content(message_info.message);
+
+    return display_message;
+}
+
+} // namespace ocpp::v201

--- a/lib/ocpp/v201/functional_blocks/display_message.cpp
+++ b/lib/ocpp/v201/functional_blocks/display_message.cpp
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include <ocpp/v201/ctrlr_component_variables.hpp>
 #include <ocpp/v201/functional_blocks/display_message.hpp>
 #include <ocpp/v201/messages/NotifyDisplayMessages.hpp>
-#include <ocpp/v201/ctrlr_component_variables.hpp>
 
 namespace ocpp::v201 {
 
 DisplayMessageBlock::DisplayMessageBlock(MessageDispatcherInterface<MessageType>& message_dispatcher,
-                                         DeviceModel& device_model,
-                                         EvseManagerInterface& evse_manager,
+                                         DeviceModel& device_model, EvseManagerInterface& evse_manager,
                                          GetDisplayMessageCallback get_display_message_callback,
                                          SetDisplayMessageCallback set_display_message_callback,
                                          ClearDisplayMessageCallback clear_display_message_callback) :
@@ -88,8 +87,9 @@ void DisplayMessageBlock::handle_set_display_message(const Call<SetDisplayMessag
 
     // Check if transaction is valid: this is the case if there is no transaction id, or if the transaction id
     // belongs to a running transaction.
-    const bool transaction_valid = (!call.msg.message.transactionId.has_value() or
-                                    this->evse_manager.get_transaction_evseid(call.msg.message.transactionId.value()) != std::nullopt);
+    const bool transaction_valid =
+        (!call.msg.message.transactionId.has_value() or
+         this->evse_manager.get_transaction_evseid(call.msg.message.transactionId.value()) != std::nullopt);
 
     // Check if display messages are available.
     if (!display_message_available.has_value() or !display_message_available.value()) {
@@ -145,8 +145,6 @@ void DisplayMessageBlock::handle_clear_display_message(const Call<ClearDisplayMe
     ocpp::CallResult<ClearDisplayMessageResponse> call_result(response, call.uniqueId);
     this->message_dispatcher.dispatch_call_result(call_result);
 }
-
-// Static functions
 
 ///
 /// \brief Convert message content from OCPP spec to DisplayMessageContent.

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -68,6 +68,18 @@ public:
         return this->evses.size();
     }
 
+    std::optional<int32_t> get_transaction_evseid(const CiString<36>& transaction_id) const override {
+        for (const auto& evse : this->evses) {
+            if (evse->has_active_transaction()) {
+                if (transaction_id == evse->get_transaction()->get_transaction().transactionId) {
+                    return evse->get_id();
+                }
+            }
+        }
+
+        return std::nullopt;
+    }
+
     void open_transaction(int evse_id, const std::string& transaction_id) {
         auto& transaction = this->transactions.at(evse_id - 1);
         transaction = std::make_unique<EnhancedTransaction>(db_handler, false);


### PR DESCRIPTION
## Describe your changes
This PR moves the functionality of functional block O. that was previously implemented as part of the ChargePoint class into a dedicated class.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

