### PR TITLE
Move 'Availability' callbacks and handlers to new functional block

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -293,25 +293,6 @@ public:
     /// because the message timed out or the charging station is offline, std::nullopt is returned
     virtual std::optional<DataTransferResponse> data_transfer_req(const DataTransferRequest& request) = 0;
 
-    /// \brief Switches the operative status of the CS
-    /// \param new_status: The new operative status to switch to
-    /// \param persist: True if the updated state should be persisted in the database
-    virtual void set_cs_operative_status(OperationalStatusEnum new_status, bool persist) = 0;
-
-    /// \brief Switches the operative status of an EVSE
-    /// \param evse_id: The ID of the EVSE, empty if the CS is addressed
-    /// \param new_status: The new operative status to switch to
-    /// \param persist: True if the updated state should be persisted in the database
-    virtual void set_evse_operative_status(int32_t evse_id, OperationalStatusEnum new_status, bool persist) = 0;
-
-    /// \brief Switches the operative status of the CS, an EVSE, or a connector, and recomputes effective statuses
-    /// \param evse_id: The ID of the EVSE, empty if the CS is addressed
-    /// \param connector_id: The ID of the connector, empty if an EVSE or the CS is addressed
-    /// \param new_status: The new operative status to switch to
-    /// \param persist: True if the updated state should be persisted in the database
-    virtual void set_connector_operative_status(int32_t evse_id, int32_t connector_id, OperationalStatusEnum new_status,
-                                                bool persist) = 0;
-
     /// \brief Delay draining the message queue after reconnecting, so the CSMS can perform post-reconnect checks first
     /// \param delay The delay period (seconds)
     virtual void set_message_queue_resume_delay(std::chrono::seconds delay) = 0;
@@ -399,7 +380,6 @@ private:
     std::map<int32_t, std::pair<IdToken, int32_t>> remote_start_id_per_evse;
 
     // timers
-    Everest::SteadyTimer heartbeat_timer;
     Everest::SteadyTimer boot_notification_timer;
     Everest::SteadyTimer client_certificate_expiration_check_timer;
     Everest::SteadyTimer v2g_certificate_expiration_check_timer;
@@ -520,22 +500,6 @@ private:
     /// \return True if at least one connector is not faulted or unavailable.
     ///
     bool is_evse_connector_available(EvseInterface& evse) const;
-
-    ///
-    /// \brief Set all connectors of a given evse to unavailable.
-    /// \param evse The evse.
-    /// \param persist  True if unavailability should persist. If it is set to false, there will be a check per
-    ///                 connector if it was already set to true and if that is the case, it will be persisted anyway.
-    ///
-    void set_evse_connectors_unavailable(EvseInterface& evse, bool persist);
-
-    ///
-    /// \brief Check if there is a connector available with the given connector type.
-    /// \param evse_id          The evse to check for.
-    /// \param connector_type   The connector type.
-    /// \return True when a connector is available and the evse id exists.
-    ///
-    bool is_connector_available(const uint32_t evse_id, std::optional<ConnectorEnum> connector_type);
 
     ///
     /// \brief Check if the connector exists on the given evse id.

--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -67,7 +67,6 @@
 #include <ocpp/v201/messages/SetNetworkProfile.hpp>
 #include <ocpp/v201/messages/SetVariableMonitoring.hpp>
 #include <ocpp/v201/messages/SetVariables.hpp>
-#include <ocpp/v201/messages/StatusNotification.hpp>
 #include <ocpp/v201/messages/TransactionEvent.hpp>
 #include <ocpp/v201/messages/TriggerMessage.hpp>
 #include <ocpp/v201/messages/UnlockConnector.hpp>

--- a/include/ocpp/v201/evse.hpp
+++ b/include/ocpp/v201/evse.hpp
@@ -142,6 +142,11 @@ public:
     /// effective status \param connector_id The ID of the connector
     virtual void restore_connector_operative_status(int32_t connector_id) = 0;
 
+    /// \brief Get the operational status of a connector within this evse.
+    /// \param connector_id The id of the connector.
+    /// \return The operational status.
+    virtual OperationalStatusEnum get_connector_effective_operational_status(const int32_t connector_id) = 0;
+
     /// \brief Returns the phase type for the EVSE based on its SupplyPhases. It can be AC, DC, or Unknown.
     virtual CurrentPhaseType get_current_phase_type() = 0;
 
@@ -279,6 +284,7 @@ public:
     void set_evse_operative_status(OperationalStatusEnum new_status, bool persist);
     void set_connector_operative_status(int32_t connector_id, OperationalStatusEnum new_status, bool persist);
     void restore_connector_operative_status(int32_t connector_id);
+    OperationalStatusEnum get_connector_effective_operational_status(const int32_t connector_id) override;
 
     CurrentPhaseType get_current_phase_type();
 

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -44,6 +44,19 @@ public:
     ///
     virtual std::optional<int32_t> get_transaction_evseid(const CiString<36>& transaction_id) const = 0;
 
+    /// \brief Helper function to determine if there is any active transaction for the given \p evse
+    /// \param evse if optional is not set, this function will check if there is any transaction active f or the whole
+    /// charging station
+    /// \return
+    virtual bool any_transaction_active(const std::optional<EVSE>& evse) const = 0;
+
+    ///
+    /// \brief Check if the given evse is valid.
+    /// \param evse The evse to check.
+    /// \return True when evse is valid.
+    ///
+    virtual bool is_valid_evse(const EVSE& evse) const = 0;
+
     /// \brief Gets an iterator pointing to the first evse
     virtual EvseIterator begin() = 0;
     /// \brief Gets an iterator pointing past the last evse
@@ -71,6 +84,9 @@ public:
     size_t get_number_of_evses() const override;
 
     std::optional<int32_t> get_transaction_evseid(const CiString<36>& transaction_id) const override;
+
+    bool any_transaction_active(const std::optional<EVSE>& evse) const override;
+    bool is_valid_evse(const EVSE& evse) const override;
 
     EvseIterator begin() override;
     EvseIterator end() override;

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -42,6 +42,11 @@ public:
     /// \brief Check if an evse with \p id exists
     virtual bool does_evse_exist(int32_t id) const = 0;
 
+    /// \brief Checks if all connectors are effectively inoperative.
+    /// If this is the case, calls the all_connectors_unavailable_callback
+    /// This is used e.g. to allow firmware updates once all transactions have finished
+    virtual bool are_all_connectors_effectively_inoperative() const = 0;
+
     /// \brief Get the number of evses
     virtual size_t get_number_of_evses() const = 0;
 
@@ -53,7 +58,7 @@ public:
     virtual std::optional<int32_t> get_transaction_evseid(const CiString<36>& transaction_id) const = 0;
 
     /// \brief Helper function to determine if there is any active transaction for the given \p evse
-    /// \param evse if optional is not set, this function will check if there is any transaction active f or the whole
+    /// \param evse if optional is not set, this function will check if there is any transaction active for the whole
     /// charging station
     /// \return
     virtual bool any_transaction_active(const std::optional<EVSE>& evse) const = 0;
@@ -88,6 +93,8 @@ public:
 
     virtual bool does_connector_exist(const int32_t evse_id, const ConnectorEnum connector_type) const override;
     bool does_evse_exist(const int32_t id) const override;
+
+    bool are_all_connectors_effectively_inoperative() const override;
 
     size_t get_number_of_evses() const override;
 

--- a/include/ocpp/v201/evse_manager.hpp
+++ b/include/ocpp/v201/evse_manager.hpp
@@ -9,6 +9,14 @@
 namespace ocpp {
 namespace v201 {
 
+///
+/// \brief Set all connectors of a given evse to unavailable.
+/// \param evse The evse.
+/// \param persist  True if unavailability should persist. If it is set to false, there will be a check per
+///                 connector if it was already set to true and if that is the case, it will be persisted anyway.
+///
+void set_evse_connectors_unavailable(EvseInterface& evse, bool persist);
+
 /// \brief Class used to access the Evse instances
 class EvseManagerInterface {
 public:

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#pragma once
+
+#include <ocpp/v201/device_model.hpp>
+#include <ocpp/v201/evse_manager.hpp>
+#include <ocpp/v201/message_dispatcher.hpp>
+#include <ocpp/v201/message_handler.hpp>
+
+#include <ocpp/v201/messages/ChangeAvailability.hpp>
+#include <ocpp/v201/messages/Heartbeat.hpp>
+
+namespace ocpp::v201 {
+class AvailabilityInterface : public MessageHandlerInterface {
+public:
+    virtual ~AvailabilityInterface() {
+    }
+
+    virtual void handle_message(const ocpp::EnhancedMessage<MessageType>& message) = 0;
+
+    // Functional Block G: Availability
+    virtual void status_notification_req(const int32_t evse_id, const int32_t connector_id, const ConnectorStatusEnum status,
+                                 const bool initiated_by_trigger_message = false) = 0;
+    virtual void heartbeat_req(const bool initiated_by_trigger_message = false) = 0;
+
+    /// \brief Checks if all connectors are effectively inoperative.
+    /// If this is the case, calls the all_connectors_unavailable_callback
+    /// This is used e.g. to allow firmware updates once all transactions have finished
+    virtual bool are_all_connectors_effectively_inoperative() = 0;
+};
+
+/// \brief Combines ChangeAvailabilityRequest with persist flag for scheduled Availability changes
+struct AvailabilityChange {
+    ChangeAvailabilityRequest request;
+    bool persist;
+};
+
+typedef std::function<void(const ocpp::DateTime& currentTime)> TimeSyncCallback;
+typedef std::function<void()> AllConnectorsUnavailableCallback;
+
+class Availability : public AvailabilityInterface {
+private: // Members
+    MessageDispatcherInterface<MessageType>& message_dispatcher;
+    DeviceModel& device_model;
+    EvseManagerInterface& evse_manager;
+    ComponentStateManagerInterface& component_state_manager;
+
+    std::optional<std::function<void(const ocpp::DateTime& currentTime)>> time_sync_callback;
+    std::optional<std::function<void()>> all_connectors_unavailable_callback;
+
+    std::chrono::time_point<std::chrono::steady_clock> heartbeat_request_time;
+
+    std::map<int32_t, AvailabilityChange> scheduled_change_availability_requests;
+    // TODO mz move heartbeat timer here?
+
+public:
+    Availability(MessageDispatcherInterface<MessageType>& message_dispatcher, DeviceModel& device_model,
+                 EvseManagerInterface& evse_manager, ComponentStateManagerInterface& component_state_manager,
+                 std::optional<TimeSyncCallback> time_sync_callback,
+                 std::optional<AllConnectorsUnavailableCallback> all_connectors_unavailable_callback);
+    void handle_message(const ocpp::EnhancedMessage<MessageType>& message) override;
+
+    // Functional Block G: Availability
+    void status_notification_req(const int32_t evse_id, const int32_t connector_id, const ConnectorStatusEnum status,
+                                 const bool initiated_by_trigger_message = false) override;
+    void heartbeat_req(const bool initiated_by_trigger_message = false) override;
+
+private: // Functions
+    // Functional Block G: Availability
+    void handle_change_availability_req(Call<ChangeAvailabilityRequest> call);
+    void handle_heartbeat_response(CallResult<HeartbeatResponse> call);
+
+    /// \brief Helper function to determine if the requested change results in a state that the Connector(s) is/are
+    /// already in \param request \return
+    bool is_already_in_state(const ChangeAvailabilityRequest& request);
+    void handle_scheduled_change_availability_requests(const int32_t evse_id);
+
+    /// \brief Checks if all connectors are effectively inoperative.
+    /// If this is the case, calls the all_connectors_unavailable_callback
+    /// This is used e.g. to allow firmware updates once all transactions have finished
+    bool are_all_connectors_effectively_inoperative() override;
+
+           /// \brief Immediately execute the given \param request to change the operational state of a component
+           /// If \param persist is set to true, the change will be persisted across a reboot
+    void execute_change_availability_request(ChangeAvailabilityRequest request, bool persist);
+
+    void set_cs_operative_status(OperationalStatusEnum new_status, bool persist) override;
+
+    void set_evse_operative_status(int32_t evse_id, OperationalStatusEnum new_status, bool persist) override;
+
+    void set_connector_operative_status(int32_t evse_id, int32_t connector_id, OperationalStatusEnum new_status,
+                                        bool persist) override;
+};
+} // namespace ocpp::v201

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -12,6 +12,13 @@
 #include <ocpp/v201/messages/Heartbeat.hpp>
 
 namespace ocpp::v201 {
+
+/// \brief Combines ChangeAvailabilityRequest with persist flag for scheduled Availability changes
+struct AvailabilityChange {
+    ChangeAvailabilityRequest request;
+    bool persist;
+};
+
 class AvailabilityInterface : public MessageHandlerInterface {
 public:
     virtual ~AvailabilityInterface() {
@@ -20,20 +27,30 @@ public:
     virtual void handle_message(const ocpp::EnhancedMessage<MessageType>& message) = 0;
 
     // Functional Block G: Availability
-    virtual void status_notification_req(const int32_t evse_id, const int32_t connector_id, const ConnectorStatusEnum status,
-                                 const bool initiated_by_trigger_message = false) = 0;
+    virtual void status_notification_req(const int32_t evse_id, const int32_t connector_id,
+                                         const ConnectorStatusEnum status,
+                                         const bool initiated_by_trigger_message = false) = 0;
     virtual void heartbeat_req(const bool initiated_by_trigger_message = false) = 0;
 
     /// \brief Checks if all connectors are effectively inoperative.
     /// If this is the case, calls the all_connectors_unavailable_callback
     /// This is used e.g. to allow firmware updates once all transactions have finished
     virtual bool are_all_connectors_effectively_inoperative() = 0;
-};
 
-/// \brief Combines ChangeAvailabilityRequest with persist flag for scheduled Availability changes
-struct AvailabilityChange {
-    ChangeAvailabilityRequest request;
-    bool persist;
+    virtual void handle_scheduled_change_availability_requests(const int32_t evse_id) = 0;
+
+    virtual void set_scheduled_change_availability_requests(const int32_t evse_id,
+                                                            AvailabilityChange availability_change) = 0;
+
+    ///
+    /// \brief Set all connectors of a given evse to unavailable.
+    /// \param evse The evse.
+    /// \param persist  True if unavailability should persist. If it is set to false, there will be a check per
+    ///                 connector if it was already set to true and if that is the case, it will be persisted anyway.
+    ///
+    virtual void set_evse_connectors_unavailable(EvseInterface& evse, bool persist) = 0;
+    virtual void set_heartbeat_timer_interval(const std::chrono::seconds& interval) = 0;
+    virtual void stop_heartbeat_timer() = 0;
 };
 
 typedef std::function<void(const ocpp::DateTime& currentTime)> TimeSyncCallback;
@@ -52,19 +69,33 @@ private: // Members
     std::chrono::time_point<std::chrono::steady_clock> heartbeat_request_time;
 
     std::map<int32_t, AvailabilityChange> scheduled_change_availability_requests;
-    // TODO mz move heartbeat timer here?
+    Everest::SteadyTimer heartbeat_timer;
 
 public:
     Availability(MessageDispatcherInterface<MessageType>& message_dispatcher, DeviceModel& device_model,
                  EvseManagerInterface& evse_manager, ComponentStateManagerInterface& component_state_manager,
                  std::optional<TimeSyncCallback> time_sync_callback,
                  std::optional<AllConnectorsUnavailableCallback> all_connectors_unavailable_callback);
+    ~Availability();
     void handle_message(const ocpp::EnhancedMessage<MessageType>& message) override;
 
     // Functional Block G: Availability
     void status_notification_req(const int32_t evse_id, const int32_t connector_id, const ConnectorStatusEnum status,
                                  const bool initiated_by_trigger_message = false) override;
     void heartbeat_req(const bool initiated_by_trigger_message = false) override;
+
+    /// \brief Checks if all connectors are effectively inoperative.
+    /// If this is the case, calls the all_connectors_unavailable_callback
+    /// This is used e.g. to allow firmware updates once all transactions have finished
+    bool are_all_connectors_effectively_inoperative() override;
+
+    void handle_scheduled_change_availability_requests(const int32_t evse_id) override;
+    void set_scheduled_change_availability_requests(const int32_t evse_id,
+                                                    AvailabilityChange availability_change) override;
+
+    void set_evse_connectors_unavailable(EvseInterface& evse, bool persist) override;
+    void set_heartbeat_timer_interval(const std::chrono::seconds& interval) override;
+    void stop_heartbeat_timer() override;
 
 private: // Functions
     // Functional Block G: Availability
@@ -74,22 +105,28 @@ private: // Functions
     /// \brief Helper function to determine if the requested change results in a state that the Connector(s) is/are
     /// already in \param request \return
     bool is_already_in_state(const ChangeAvailabilityRequest& request);
-    void handle_scheduled_change_availability_requests(const int32_t evse_id);
 
-    /// \brief Checks if all connectors are effectively inoperative.
-    /// If this is the case, calls the all_connectors_unavailable_callback
-    /// This is used e.g. to allow firmware updates once all transactions have finished
-    bool are_all_connectors_effectively_inoperative() override;
-
-           /// \brief Immediately execute the given \param request to change the operational state of a component
-           /// If \param persist is set to true, the change will be persisted across a reboot
+    /// \brief Immediately execute the given \param request to change the operational state of a component
+    /// If \param persist is set to true, the change will be persisted across a reboot
     void execute_change_availability_request(ChangeAvailabilityRequest request, bool persist);
 
-    void set_cs_operative_status(OperationalStatusEnum new_status, bool persist) override;
+    /// \brief Switches the operative status of the CS
+    /// \param new_status: The new operative status to switch to
+    /// \param persist: True if the updated state should be persisted in the database
+    void set_cs_operative_status(OperationalStatusEnum new_status, bool persist);
 
-    void set_evse_operative_status(int32_t evse_id, OperationalStatusEnum new_status, bool persist) override;
+    /// \brief Switches the operative status of an EVSE
+    /// \param evse_id: The ID of the EVSE, empty if the CS is addressed
+    /// \param new_status: The new operative status to switch to
+    /// \param persist: True if the updated state should be persisted in the database
+    void set_evse_operative_status(int32_t evse_id, OperationalStatusEnum new_status, bool persist);
 
+    /// \brief Switches the operative status of the CS, an EVSE, or a connector, and recomputes effective statuses
+    /// \param evse_id: The ID of the EVSE, empty if the CS is addressed
+    /// \param connector_id: The ID of the connector, empty if an EVSE or the CS is addressed
+    /// \param new_status: The new operative status to switch to
+    /// \param persist: True if the updated state should be persisted in the database
     void set_connector_operative_status(int32_t evse_id, int32_t connector_id, OperationalStatusEnum new_status,
-                                        bool persist) override;
+                                        bool persist);
 };
 } // namespace ocpp::v201

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -26,10 +26,22 @@ public:
 
     virtual void handle_message(const ocpp::EnhancedMessage<MessageType>& message) = 0;
 
-    // Functional Block G: Availability
+    // Functional Block G: Availability OCPP requests.
+    ///
+    /// \brief Send a StatusNotificationRequest to the CSMS.
+    /// \param evse_id                      Evse id.
+    /// \param connector_id                 Connector id.
+    /// \param status                       Status to send.
+    /// \param initiated_by_trigger_message True if sending of the request was triggered by a trigger message.
+    ///
     virtual void status_notification_req(const int32_t evse_id, const int32_t connector_id,
                                          const ConnectorStatusEnum status,
                                          const bool initiated_by_trigger_message = false) = 0;
+
+    ///
+    /// \brief Send a HeartbeatRequest to the CSMS.
+    /// \param initiated_by_trigger_message True if sending of the request was triggered by a trigger message.
+    ///
     virtual void heartbeat_req(const bool initiated_by_trigger_message = false) = 0;
 
     /// \brief Checks if all connectors are effectively inoperative.
@@ -37,8 +49,18 @@ public:
     /// This is used e.g. to allow firmware updates once all transactions have finished
     virtual bool are_all_connectors_effectively_inoperative() = 0;
 
+    ///
+    /// \brief Handle / send the scheduled change availability requests.
+    /// \param evse_id  The evse id of the change availability request.
+    ///
     virtual void handle_scheduled_change_availability_requests(const int32_t evse_id) = 0;
 
+    ///
+    /// \brief Set scheduled change availability requests, that should be sent later (for example because of a
+    ///        firmware update).
+    /// \param evse_id              The evse id.
+    /// \param availability_change  The availability change request.
+    ///
     virtual void set_scheduled_change_availability_requests(const int32_t evse_id,
                                                             AvailabilityChange availability_change) = 0;
 
@@ -49,7 +71,16 @@ public:
     ///                 connector if it was already set to true and if that is the case, it will be persisted anyway.
     ///
     virtual void set_evse_connectors_unavailable(EvseInterface& evse, bool persist) = 0;
+
+    ///
+    /// \brief Set the heartbeat timer interval.
+    /// \param interval The interval in seconds.
+    ///
     virtual void set_heartbeat_timer_interval(const std::chrono::seconds& interval) = 0;
+
+    ///
+    /// \brief Stop the heartbeat timer.
+    ///
     virtual void stop_heartbeat_timer() = 0;
 };
 
@@ -84,23 +115,30 @@ public:
                                  const bool initiated_by_trigger_message = false) override;
     void heartbeat_req(const bool initiated_by_trigger_message = false) override;
 
-    /// \brief Checks if all connectors are effectively inoperative.
-    /// If this is the case, calls the all_connectors_unavailable_callback
-    /// This is used e.g. to allow firmware updates once all transactions have finished
     bool are_all_connectors_effectively_inoperative() override;
-
     void handle_scheduled_change_availability_requests(const int32_t evse_id) override;
     void set_scheduled_change_availability_requests(const int32_t evse_id,
                                                     AvailabilityChange availability_change) override;
-
     void set_evse_connectors_unavailable(EvseInterface& evse, bool persist) override;
+
     void set_heartbeat_timer_interval(const std::chrono::seconds& interval) override;
     void stop_heartbeat_timer() override;
 
 private: // Functions
     // Functional Block G: Availability
+
+    ///
+    /// \brief Called on 'ChangeAvailability' request from the CSMS.
+    /// \param call The call from the CSMS.
+    ///
     void handle_change_availability_req(Call<ChangeAvailabilityRequest> call);
+
+    ///
+    /// \brief Called on 'HeartbeatResponse' request from the CSMS.
+    /// \param call The call from the CSMS.
+    ///
     void handle_heartbeat_response(CallResult<HeartbeatResponse> call);
+
 
     /// \brief Helper function to determine if the requested change results in a state that the Connector(s) is/are
     /// already in \param request \return

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -65,14 +65,6 @@ public:
                                                             AvailabilityChange availability_change) = 0;
 
     ///
-    /// \brief Set all connectors of a given evse to unavailable.
-    /// \param evse The evse.
-    /// \param persist  True if unavailability should persist. If it is set to false, there will be a check per
-    ///                 connector if it was already set to true and if that is the case, it will be persisted anyway.
-    ///
-    virtual void set_evse_connectors_unavailable(EvseInterface& evse, bool persist) = 0;
-
-    ///
     /// \brief Set the heartbeat timer interval.
     /// \param interval The interval in seconds.
     ///
@@ -119,7 +111,6 @@ public:
     void handle_scheduled_change_availability_requests(const int32_t evse_id) override;
     void set_scheduled_change_availability_requests(const int32_t evse_id,
                                                     AvailabilityChange availability_change) override;
-    void set_evse_connectors_unavailable(EvseInterface& evse, bool persist) override;
 
     void set_heartbeat_timer_interval(const std::chrono::seconds& interval) override;
     void stop_heartbeat_timer() override;

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <ocpp/v201/device_model.hpp>
-#include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/message_dispatcher.hpp>
 #include <ocpp/v201/message_handler.hpp>
 
@@ -12,6 +10,10 @@
 #include <ocpp/v201/messages/Heartbeat.hpp>
 
 namespace ocpp::v201 {
+
+class DeviceModel;
+class EvseManagerInterface;
+class ComponentStateManagerInterface;
 
 /// \brief Combines ChangeAvailabilityRequest with persist flag for scheduled Availability changes
 struct AvailabilityChange {

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -46,11 +46,6 @@ public:
     ///
     virtual void heartbeat_req(const bool initiated_by_trigger_message = false) = 0;
 
-    /// \brief Checks if all connectors are effectively inoperative.
-    /// If this is the case, calls the all_connectors_unavailable_callback
-    /// This is used e.g. to allow firmware updates once all transactions have finished
-    virtual bool are_all_connectors_effectively_inoperative() = 0;
-
     ///
     /// \brief Handle / send the scheduled change availability requests.
     /// \param evse_id  The evse id of the change availability request.
@@ -88,8 +83,8 @@ private: // Members
     EvseManagerInterface& evse_manager;
     ComponentStateManagerInterface& component_state_manager;
 
-    std::optional<std::function<void(const ocpp::DateTime& currentTime)>> time_sync_callback;
-    std::optional<std::function<void()>> all_connectors_unavailable_callback;
+    std::optional<TimeSyncCallback> time_sync_callback;
+    std::optional<AllConnectorsUnavailableCallback> all_connectors_unavailable_callback;
 
     std::chrono::time_point<std::chrono::steady_clock> heartbeat_request_time;
 
@@ -109,7 +104,6 @@ public:
                                  const bool initiated_by_trigger_message = false) override;
     void heartbeat_req(const bool initiated_by_trigger_message = false) override;
 
-    bool are_all_connectors_effectively_inoperative() override;
     void handle_scheduled_change_availability_requests(const int32_t evse_id) override;
     void set_scheduled_change_availability_requests(const int32_t evse_id,
                                                     AvailabilityChange availability_change) override;

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -139,7 +139,6 @@ private: // Functions
     ///
     void handle_heartbeat_response(CallResult<HeartbeatResponse> call);
 
-
     /// \brief Helper function to determine if the requested change results in a state that the Connector(s) is/are
     /// already in \param request \return
     bool is_already_in_state(const ChangeAvailabilityRequest& request);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -95,6 +95,7 @@ if(LIBOCPP_ENABLE_V201)
             ocpp/v201/connectivity_manager.cpp
             ocpp/v201/message_dispatcher.cpp
             ocpp/v201/functional_blocks/authorization.cpp
+            ocpp/v201/functional_blocks/availability.cpp
             ocpp/v201/functional_blocks/security.cpp
             ocpp/v201/functional_blocks/data_transfer.cpp
             ocpp/v201/functional_blocks/reservation.cpp

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -818,10 +818,6 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
                 this->registration_status != RegistrationStatusEnum::Accepted) {
                 return false;
             } else {
-                if (availability == nullptr) {
-                    return false;
-                }
-
                 this->availability->status_notification_req(evse_id, connector_id, status,
                                                             initiated_by_trigger_message);
                 return true;
@@ -1268,7 +1264,7 @@ void ChargePoint::change_all_connectors_to_unavailable_for_firmware_update() {
         }
         // Check succeeded, trigger the callback if needed
         if (this->callbacks.all_connectors_unavailable_callback.has_value() and
-            this->availability->are_all_connectors_effectively_inoperative()) {
+            this->evse_manager->are_all_connectors_effectively_inoperative()) {
             this->callbacks.all_connectors_unavailable_callback.value()();
         }
     } else if (response.status == ChangeAvailabilityStatusEnum::Scheduled) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -374,7 +374,7 @@ void ChargePoint::on_transaction_finished(const int32_t evse_id, const DateTime&
             }
 
             if (is_charging) {
-                this->availability->set_evse_connectors_unavailable(evse_handle, false);
+                set_evse_connectors_unavailable(evse_handle, false);
             } else {
                 send_reset = true;
             }
@@ -1263,7 +1263,7 @@ void ChargePoint::change_all_connectors_to_unavailable_for_firmware_update() {
         // execute change availability if possible
         for (auto& evse : *this->evse_manager) {
             if (!evse.has_active_transaction()) {
-                this->availability->set_evse_connectors_unavailable(evse, false);
+                set_evse_connectors_unavailable(evse, false);
             }
         }
         // Check succeeded, trigger the callback if needed
@@ -1275,7 +1275,7 @@ void ChargePoint::change_all_connectors_to_unavailable_for_firmware_update() {
         // put all EVSEs to unavailable that do not have active transaction
         for (auto& evse : *this->evse_manager) {
             if (!evse.has_active_transaction()) {
-                this->availability->set_evse_connectors_unavailable(evse, false);
+                set_evse_connectors_unavailable(evse, false);
             } else {
                 EVSE e;
                 e.id = evse.get_id();
@@ -2097,7 +2097,7 @@ void ChargePoint::handle_reset_req(Call<ResetRequest> call) {
         } else if (msg.type == ResetEnum::OnIdle and !evse_no_transactions.empty()) {
             for (const int32_t evse_id : evse_no_transactions) {
                 auto& evse = this->evse_manager->get_evse(evse_id);
-                this->availability->set_evse_connectors_unavailable(evse, false);
+                set_evse_connectors_unavailable(evse, false);
             }
         }
     }

--- a/lib/ocpp/v201/evse.cpp
+++ b/lib/ocpp/v201/evse.cpp
@@ -664,6 +664,10 @@ void Evse::restore_connector_operative_status(int32_t connector_id) {
     this->id_connector_map.at(connector_id)->restore_connector_operative_status();
 }
 
+OperationalStatusEnum Evse::get_connector_effective_operational_status(const int32_t connector_id) {
+    return this->component_state_manager->get_connector_effective_operational_status(this->get_id(), connector_id);
+}
+
 OperationalStatusEnum Evse::get_effective_operational_status() {
     return this->component_state_manager->get_evse_effective_operational_status(this->evse_id);
 }

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -75,5 +75,23 @@ std::optional<int32_t> EvseManager::get_transaction_evseid(const CiString<36>& t
     return std::nullopt;
 }
 
+bool EvseManager::any_transaction_active(const std::optional<EVSE>& evse) const {
+    if (!evse.has_value()) {
+        for (auto const& evse : this->evses) {
+            if (evse->has_active_transaction()) {
+                return true;
+            }
+        }
+        return false;
+    }
+    return this->get_evse(evse.value().id).has_active_transaction();
+}
+
+bool EvseManager::is_valid_evse(const EVSE& evse) const {
+    return this->does_evse_exist(evse.id) and
+           (!evse.connectorId.has_value() or
+            this->get_evse(evse.id).get_number_of_connectors() >= evse.connectorId.value());
+}
+
 } // namespace v201
 } // namespace ocpp

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -93,5 +93,15 @@ bool EvseManager::is_valid_evse(const EVSE& evse) const {
             this->get_evse(evse.id).get_number_of_connectors() >= evse.connectorId.value());
 }
 
+// Free functions
+
+void set_evse_connectors_unavailable(EvseInterface& evse, bool persist) {
+    uint32_t number_of_connectors = evse.get_number_of_connectors();
+
+    for (uint32_t i = 1; i <= number_of_connectors; ++i) {
+        evse.set_connector_operative_status(static_cast<int32_t>(i), OperationalStatusEnum::Inoperative, persist);
+    }
+}
+
 } // namespace v201
 } // namespace ocpp

--- a/lib/ocpp/v201/evse_manager.cpp
+++ b/lib/ocpp/v201/evse_manager.cpp
@@ -59,6 +59,19 @@ bool EvseManager::does_evse_exist(const int32_t id) const {
     return id >= 0 && static_cast<uint64_t>(id) <= this->evses.size();
 }
 
+bool EvseManager::are_all_connectors_effectively_inoperative() const {
+    // Check that all connectors on all EVSEs are inoperative
+    for (const auto& evse : this->evses) {
+        for (int connector_id = 1; connector_id <= evse->get_number_of_connectors(); connector_id++) {
+            OperationalStatusEnum connector_status = evse->get_connector_effective_operational_status(connector_id);
+            if (connector_status == OperationalStatusEnum::Operative) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 size_t EvseManager::get_number_of_evses() const {
     return this->evses.size();
 }

--- a/lib/ocpp/v201/functional_blocks/availability.cpp
+++ b/lib/ocpp/v201/functional_blocks/availability.cpp
@@ -97,14 +97,6 @@ void ocpp::v201::Availability::set_scheduled_change_availability_requests(const 
     this->scheduled_change_availability_requests[evse_id] = availability_change;
 }
 
-void ocpp::v201::Availability::set_evse_connectors_unavailable(EvseInterface& evse, bool persist) {
-    uint32_t number_of_connectors = evse.get_number_of_connectors();
-
-    for (uint32_t i = 1; i <= number_of_connectors; ++i) {
-        evse.set_connector_operative_status(static_cast<int32_t>(i), OperationalStatusEnum::Inoperative, persist);
-    }
-}
-
 void ocpp::v201::Availability::set_heartbeat_timer_interval(const std::chrono::seconds& interval) {
     this->heartbeat_timer.interval([this]() { this->heartbeat_req(); }, interval);
 }

--- a/lib/ocpp/v201/functional_blocks/availability.cpp
+++ b/lib/ocpp/v201/functional_blocks/availability.cpp
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include "ocpp/v201/ctrlr_component_variables.hpp"
+#include <ocpp/v201/functional_blocks/availability.hpp>
+
+#include <ocpp/v201/messages/StatusNotification.hpp>
+
+ocpp::v201::Availability::Availability(MessageDispatcherInterface<MessageType>& message_dispatcher,
+                                       DeviceModel& device_model, EvseManagerInterface& evse_manager,
+                                       ComponentStateManagerInterface& component_state_manager,
+                                       std::optional<TimeSyncCallback> time_sync_callback,
+                                       std::optional<AllConnectorsUnavailableCallback> all_connectors_unavailable_callback) :
+    message_dispatcher(message_dispatcher),
+    device_model(device_model),
+    evse_manager(evse_manager),
+    component_state_manager(component_state_manager),
+    time_sync_callback(time_sync_callback),
+    all_connectors_unavailable_callback(all_connectors_unavailable_callback) {
+}
+
+void ocpp::v201::Availability::handle_message(const ocpp::EnhancedMessage<MessageType>& message) {
+    const auto& json_message = message.message;
+    switch (message.messageType) {
+    case MessageType::ChangeAvailability:
+        this->handle_change_availability_req(json_message);
+        break;
+    case MessageType::HeartbeatResponse:
+        this->handle_heartbeat_response(json_message);
+        break;
+    default:
+        throw MessageTypeNotImplementedException(message.messageType);
+    }
+}
+
+void ocpp::v201::Availability::status_notification_req(const int32_t evse_id, const int32_t connector_id,
+                                                       const ConnectorStatusEnum status,
+                                                       const bool initiated_by_trigger_message) {
+    StatusNotificationRequest req;
+    req.connectorId = connector_id;
+    req.evseId = evse_id;
+    req.timestamp = DateTime();
+    req.connectorStatus = status;
+
+    ocpp::Call<StatusNotificationRequest> call(req);
+    this->message_dispatcher.dispatch_call(call, initiated_by_trigger_message);
+}
+
+void ocpp::v201::Availability::heartbeat_req(const bool initiated_by_trigger_message) {
+    HeartbeatRequest req;
+
+    heartbeat_request_time = std::chrono::steady_clock::now();
+    ocpp::Call<HeartbeatRequest> call(req);
+    this->message_dispatcher.dispatch_call(call, initiated_by_trigger_message);
+}
+
+void ocpp::v201::Availability::handle_change_availability_req(Call<ChangeAvailabilityRequest> call) {
+    const auto msg = call.msg;
+    ChangeAvailabilityResponse response;
+    response.status = ChangeAvailabilityStatusEnum::Scheduled;
+
+    // Sanity check: if we're addressing an EVSE or a connector, it must actually exist
+    if (msg.evse.has_value() and !this->evse_manager.is_valid_evse(msg.evse.value())) {
+        EVLOG_warning << "CSMS requested ChangeAvailability for invalid evse id or connector id";
+        response.status = ChangeAvailabilityStatusEnum::Rejected;
+        ocpp::CallResult<ChangeAvailabilityResponse> call_result(response, call.uniqueId);
+        this->message_dispatcher.dispatch_call_result(call_result);
+        return;
+    }
+
+    // Check if we have any transaction running on the EVSE (or any EVSE if we're addressing the whole CS)
+    const auto transaction_active = this->evse_manager.any_transaction_active(msg.evse);
+    // Check if we're already in the requested state
+    const auto is_already_in_state = this->is_already_in_state(msg);
+
+    // evse_id will be 0 if we're addressing the whole CS, and >=1 otherwise
+    auto evse_id = 0;
+    if (msg.evse.has_value()) {
+        evse_id = msg.evse.value().id;
+    }
+
+    if (!transaction_active or is_already_in_state or
+        (evse_id == 0 and msg.operationalStatus == OperationalStatusEnum::Operative)) {
+        // If the chosen EVSE (or CS) has no transactions, we're already in the desired state,
+        // or we're telling the whole CS to power on, we can accept the request - there's nothing stopping us.
+        response.status = ChangeAvailabilityStatusEnum::Accepted;
+        // Remove any scheduled availability requests for the evse_id.
+        // This is relevant in case some of those requests become activated later - the current one overrides them.
+        this->scheduled_change_availability_requests.erase(evse_id);
+    } else {
+        // We can't immediately perform the change, because we have a transaction running.
+        // Schedule the request to run when the transaction finishes.
+        this->scheduled_change_availability_requests[evse_id] = {msg, true};
+    }
+
+    // Respond to the CSMS before performing any changes to avoid StatusNotification.req being sent before
+    // the ChangeAvailabilityResponse.
+    ocpp::CallResult<ChangeAvailabilityResponse> call_result(response, call.uniqueId);
+    this->message_dispatcher.dispatch_call_result(call_result);
+
+    if (!transaction_active) {
+        // No transactions - execute the change now
+        this->execute_change_availability_request(msg, true);
+    } else if (response.status == ChangeAvailabilityStatusEnum::Scheduled) {
+        // We can't execute the change now, but it's scheduled to run after transactions are finished.
+        if (evse_id == 0) {
+            // The whole CS is being addressed - we need to prevent further transactions from starting.
+            // To do that, make all EVSEs without an active transaction Inoperative
+            for (auto const& evse : this->evse_manager) {
+                if (!evse.has_active_transaction()) {
+                    // FIXME: This will linger after the update too! We probably need another mechanism...
+                    this->set_evse_operative_status(evse.get_id(), OperationalStatusEnum::Inoperative, false);
+                }
+            }
+        } else {
+            // A single EVSE is being addressed. We need to prevent further transactions from starting on it.
+            // To do that, make all connectors of the EVSE without an active transaction Inoperative.
+            int number_of_connectors = this->evse_manager.get_evse(evse_id).get_number_of_connectors();
+            for (int connector_id = 1; connector_id <= number_of_connectors; connector_id++) {
+                if (!this->evse_manager.get_evse(evse_id).has_active_transaction(connector_id)) {
+                    // FIXME: This will linger after the update too! We probably need another mechanism...
+                    this->set_connector_operative_status(evse_id, connector_id, OperationalStatusEnum::Inoperative,
+                                                         false);
+                }
+            }
+        }
+    }
+}
+
+void ocpp::v201::Availability::handle_heartbeat_response(CallResult<HeartbeatResponse> call) {
+    if (this->time_sync_callback.has_value() and
+        this->device_model.get_value<std::string>(ControllerComponentVariables::TimeSource).find("Heartbeat") !=
+            std::string::npos) {
+        // the received currentTime was the time the CSMS received the heartbeat request
+        // to get a system time as accurate as possible keep the time-of-flight into account
+        auto timeOfFlight = (std::chrono::steady_clock::now() - this->heartbeat_request_time) / 2;
+        ocpp::DateTime currentTimeCompensated(call.msg.currentTime.to_time_point() + timeOfFlight);
+        this->time_sync_callback.value()(currentTimeCompensated);
+    }
+}
+
+bool ocpp::v201::Availability::is_already_in_state(const ChangeAvailabilityRequest& request) {
+    // TODO: This checks against the individual status setting. What about effective/persisted status?
+    if (!request.evse.has_value()) {
+        // We're addressing the whole charging station
+        return (this->component_state_manager.get_cs_individual_operational_status() == request.operationalStatus);
+    }
+    if (!request.evse.value().connectorId.has_value()) {
+        // An EVSE is addressed
+        return (this->component_state_manager.get_evse_individual_operational_status(request.evse.value().id) ==
+                request.operationalStatus);
+    }
+    // A connector is being addressed
+    return (this->component_state_manager.get_connector_individual_operational_status(
+                request.evse.value().id, request.evse.value().connectorId.value()) == request.operationalStatus);
+}
+
+void ocpp::v201::Availability::handle_scheduled_change_availability_requests(const int32_t evse_id) {
+    if (this->scheduled_change_availability_requests.count(evse_id)) {
+        EVLOG_info << "Found scheduled ChangeAvailability.req for evse_id:" << evse_id;
+        const auto req = this->scheduled_change_availability_requests[evse_id].request;
+        const auto persist = this->scheduled_change_availability_requests[evse_id].persist;
+        if (!this->evse_manager.any_transaction_active(req.evse)) {
+            EVLOG_info << "Changing availability of evse:" << evse_id;
+            this->execute_change_availability_request(req, persist);
+            this->scheduled_change_availability_requests.erase(evse_id);
+            // Check succeeded, trigger the callback if needed
+            if (this->all_connectors_unavailable_callback.has_value() and
+                this->are_all_connectors_effectively_inoperative()) {
+                this->all_connectors_unavailable_callback.value()();
+            }
+        } else {
+            EVLOG_info << "Cannot change availability because transaction is still active";
+        }
+    }
+}
+
+bool ocpp::v201::Availability::are_all_connectors_effectively_inoperative() {
+    // Check that all connectors on all EVSEs are inoperative
+    for (const auto& evse : this->evse_manager) {
+        for (int connector_id = 1; connector_id <= evse.get_number_of_connectors(); connector_id++) {
+            OperationalStatusEnum connector_status =
+                this->component_state_manager.get_connector_effective_operational_status(evse.get_id(), connector_id);
+            if (connector_status == OperationalStatusEnum::Operative) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void ocpp::v201::Availability::execute_change_availability_request(ChangeAvailabilityRequest request, bool persist) {
+    if (request.evse.has_value()) {
+        if (request.evse.value().connectorId.has_value()) {
+            this->set_connector_operative_status(request.evse.value().id, request.evse.value().connectorId.value(),
+                                                 request.operationalStatus, persist);
+        } else {
+            this->set_evse_operative_status(request.evse.value().id, request.operationalStatus, persist);
+        }
+    } else {
+        this->set_cs_operative_status(request.operationalStatus, persist);
+    }
+}
+
+void ocpp::v201::Availability::set_cs_operative_status(OperationalStatusEnum new_status, bool persist) {
+    this->component_state_manager.set_cs_individual_operational_status(new_status, persist);
+}
+
+void ocpp::v201::Availability::set_evse_operative_status(int32_t evse_id, OperationalStatusEnum new_status,
+                                                         bool persist) {
+    this->evse_manager.get_evse(evse_id).set_evse_operative_status(new_status, persist);
+}
+
+void ocpp::v201::Availability::set_connector_operative_status(int32_t evse_id, int32_t connector_id,
+                                                              OperationalStatusEnum new_status, bool persist) {
+    this->evse_manager.get_evse(evse_id).set_connector_operative_status(connector_id, new_status, persist);
+}

--- a/lib/ocpp/v201/functional_blocks/availability.cpp
+++ b/lib/ocpp/v201/functional_blocks/availability.cpp
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
-#include "ocpp/v201/ctrlr_component_variables.hpp"
 #include <ocpp/v201/functional_blocks/availability.hpp>
+
+#include <ocpp/v201/ctrlr_component_variables.hpp>
+#include <ocpp/v201/device_model.hpp>
+#include <ocpp/v201/evse_manager.hpp>
 
 #include <ocpp/v201/messages/StatusNotification.hpp>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,8 @@ add_custom_command(TARGET libocpp_unit_tests POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${DEVICE_MODEL_CURRENT_EXAMPLE_CONFIG_LOCATION_V201} ${DEVICE_MODEL_EXAMPLE_CONFIG_LOCATION_V201}
 )
 
+set(GCOVR_ADDITIONAL_ARGS "--gcov-ignore-parse-errors=negative_hits.warn")
+
 setup_target_for_coverage_gcovr_html(
     NAME ${PROJECT_NAME}_gcovr_coverage
     EXECUTABLE ctest

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -93,6 +93,14 @@ public:
     EvseMock& get_mock(int32_t evse_id) {
         return dynamic_cast<EvseMock&>(*evses.at(evse_id - 1).get());
     }
+
+    bool any_transaction_active(const std::optional<EVSE> &/*evse*/) const override {
+        return false;
+    }
+
+    bool is_valid_evse(const EVSE &evse) const override {
+        return (static_cast<int32_t>(evses.size()) > evse.id);
+    }
 };
 
 } // namespace ocpp::v201

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -94,11 +94,11 @@ public:
         return dynamic_cast<EvseMock&>(*evses.at(evse_id - 1).get());
     }
 
-    bool any_transaction_active(const std::optional<EVSE> &/*evse*/) const override {
+    bool any_transaction_active(const std::optional<EVSE>& /*evse*/) const override {
         return false;
     }
 
-    bool is_valid_evse(const EVSE &evse) const override {
+    bool is_valid_evse(const EVSE& evse) const override {
         return (static_cast<int32_t>(evses.size()) > evse.id);
     }
 };

--- a/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_manager_fake.hpp
@@ -64,6 +64,18 @@ public:
         return id <= this->evses.size();
     }
 
+    bool are_all_connectors_effectively_inoperative() const override {
+        for (const auto& evse : this->evses) {
+            for (int connector_id = 1; connector_id <= evse->get_number_of_connectors(); connector_id++) {
+                OperationalStatusEnum connector_status = evse->get_connector_effective_operational_status(connector_id);
+                if (connector_status == OperationalStatusEnum::Operative) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     size_t get_number_of_evses() const override {
         return this->evses.size();
     }

--- a/tests/lib/ocpp/v201/mocks/evse_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/evse_mock.hpp
@@ -38,6 +38,7 @@ public:
     MOCK_METHOD(void, set_connector_operative_status,
                 (int32_t connector_id, OperationalStatusEnum new_status, bool persist));
     MOCK_METHOD(void, restore_connector_operative_status, (int32_t connector_id));
+    MOCK_METHOD(OperationalStatusEnum, get_connector_effective_operational_status, (const int32_t connector_id));
     MOCK_METHOD(CurrentPhaseType, get_current_phase_type, ());
     MOCK_METHOD(void, set_meter_value_pricing_triggers,
                 (std::optional<double> trigger_metervalue_on_power_kw,


### PR DESCRIPTION
## Describe your changes
Move functional block 'Availability' callbacks and handlers to new class.

I did move a lot of functions that have something to do with availability to this class. But for example, `ChargePoint::change_all_connectors_to_unavailable_for_firmware_update()` is left in the ChargePoint class, because only the firmware update uses this, so it can better be moved to the firmware update functional block. 

## Issue ticket number and link

#946 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [n/a] I have made corresponding changes to the documentation
- [n/a] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

