### PR TITLE
build with fetchcontent: add everest-evse_security dependency

### DIFF
--- a/doc/common/build-with-fetchcontent/CMakeLists.txt
+++ b/doc/common/build-with-fetchcontent/CMakeLists.txt
@@ -147,6 +147,22 @@ macro(find_everest_log)
     FetchContent_MakeAvailable(${EXTERNAL_EVEREST_LOG_NAME})
 endmacro()
 
+
+macro(find_everest_evse_security)
+    message(STATUS "Using FetchContent for everest-evse_security library")
+    set(EXTERNAL_EVEREST_SEC_NAME everest-evse_security)
+    set(EXTERNAL_EVEREST_SEC_URL https://github.com/EVerest/libevse-security.git)
+    set(EXTERNAL_EVEREST_SEC_TAG v0.9.2)
+
+    FetchContent_Declare(
+        ${EXTERNAL_EVEREST_SEC_NAME}
+        GIT_REPOSITORY ${EXTERNAL_EVEREST_SEC_URL}
+        GIT_TAG ${EXTERNAL_EVEREST_SEC_TAG}
+    )
+
+    FetchContent_MakeAvailable(${EXTERNAL_EVEREST_SEC_NAME})
+endmacro()
+
 macro(find_package PACKAGE_NAME)
     message(STATUS "FIND PACKAGE ${PACKAGE_NAME}")
 
@@ -166,6 +182,8 @@ macro(find_package PACKAGE_NAME)
         find_everest_timer()
     elseif("${PACKAGE_NAME}" STREQUAL "everest-log")
         find_everest_log()
+    elseif("${PACKAGE_NAME}" STREQUAL "everest-evse_security")
+        find_everest_evse_security()
     else()
         message(STATUS "Using regular findpackage for ${PACKAGE_NAME}")
         _find_package(${ARGV})


### PR DESCRIPTION
Fetch everest-evse_security without using edm

## Describe your changes
Fetch everest-evse_security without edm as it is a dependency for libocpp 
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

