### PR TITLE
Implemented missing handle_message in display message functional block

### DIFF
--- a/lib/ocpp/v201/functional_blocks/display_message.cpp
+++ b/lib/ocpp/v201/functional_blocks/display_message.cpp
@@ -21,6 +21,20 @@ DisplayMessageBlock::DisplayMessageBlock(MessageDispatcherInterface<MessageType>
 }
 
 void DisplayMessageBlock::handle_message(const ocpp::EnhancedMessage<MessageType>& message) {
+    const auto& json_message = message.message;
+    switch (message.messageType) {
+    case MessageType::GetDisplayMessages:
+        this->handle_get_display_message(json_message);
+        break;
+    case MessageType::SetDisplayMessage:
+        this->handle_set_display_message(json_message);
+        break;
+    case MessageType::ClearDisplayMessage:
+        this->handle_clear_display_message(json_message);
+        break;
+    default:
+        throw MessageTypeNotImplementedException(message.messageType);
+    }
 }
 
 void DisplayMessageBlock::handle_get_display_message(const Call<GetDisplayMessagesRequest> call) {


### PR DESCRIPTION
## Describe your changes
This PR adds the missing implementation of the `handle_message` function inside the DisplayMessage functional block.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

