### PR TITLE
Catch exception when assiging String<> type with too long string

### DIFF
--- a/include/ocpp/common/cistring.hpp
+++ b/include/ocpp/common/cistring.hpp
@@ -17,10 +17,10 @@ template <size_t L> class CiString : public String<L> {
 
 public:
     /// \brief Creates a string from the given \p data
-    CiString(const std::string& data) : String<L>(data) {
+    CiString(const std::string& data, StringToLarge to_large = StringToLarge::Throw) : String<L>(data, to_large) {
     }
 
-    CiString(const char* data) : String<L>(data) {
+    CiString(const char* data, StringToLarge to_large = StringToLarge::Throw) : String<L>(data, to_large) {
     }
 
     CiString(const CiString<L>& data) : String<L>(data.get()) {
@@ -35,8 +35,8 @@ public:
     CiString& operator=(CiString&&) = default;
 
     /// \brief CaseInsensitive string implementation only allows printable ASCII characters
-    bool is_valid(const std::string& data) {
-        for (const char& character : data) {
+    bool is_valid(std::string_view data) {
+        for (char character : data) {
             // printable ASCII starts at code 0x20 (space) and ends with code 0x7e (tilde) and 0xa (\n)
             if ((character < 0x20 || character > 0x7e) && character != 0xa) {
                 throw std::runtime_error("CiString can only contain printable ASCII characters");

--- a/include/ocpp/common/cistring.hpp
+++ b/include/ocpp/common/cistring.hpp
@@ -17,10 +17,10 @@ template <size_t L> class CiString : public String<L> {
 
 public:
     /// \brief Creates a string from the given \p data
-    CiString(const std::string& data, StringToLarge to_large = StringToLarge::Throw) : String<L>(data, to_large) {
+    CiString(const std::string& data, StringTooLarge to_large = StringTooLarge::Throw) : String<L>(data, to_large) {
     }
 
-    CiString(const char* data, StringToLarge to_large = StringToLarge::Throw) : String<L>(data, to_large) {
+    CiString(const char* data, StringTooLarge to_large = StringTooLarge::Throw) : String<L>(data, to_large) {
     }
 
     CiString(const CiString<L>& data) : String<L>(data.get()) {

--- a/include/ocpp/common/string.hpp
+++ b/include/ocpp/common/string.hpp
@@ -15,7 +15,7 @@ class StringConversionException : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
-enum class StringToLarge {
+enum class StringTooLarge {
     Throw,
     Truncate
 };
@@ -28,11 +28,11 @@ private:
 
 public:
     /// \brief Creates a string from the given \p data
-    String(const std::string& data, StringToLarge to_large = StringToLarge::Throw) {
+    explicit String(const std::string& data, StringTooLarge to_large = StringTooLarge::Throw) {
         this->set(data, to_large);
     }
 
-    String(const char* data, StringToLarge to_large = StringToLarge::Throw) {
+    explicit String(const char* data, StringTooLarge to_large = StringTooLarge::Throw) {
         this->set(data, to_large);
     }
 
@@ -46,10 +46,10 @@ public:
     }
 
     /// \brief Sets the content of the string to the given \p data
-    void set(const std::string& data, StringToLarge to_large = StringToLarge::Throw) {
+    void set(const std::string& data, StringTooLarge to_large = StringTooLarge::Throw) {
         std::string_view view = data;
         if (view.length() > this->length) {
-            if (to_large == StringToLarge::Throw) {
+            if (to_large == StringTooLarge::Throw) {
                 throw StringConversionException("String length (" + std::to_string(view.length()) +
                                                 ") exceeds permitted length (" + std::to_string(this->length) + ")");
             }

--- a/include/ocpp/common/string.hpp
+++ b/include/ocpp/common/string.hpp
@@ -15,25 +15,29 @@ class StringConversionException : public std::runtime_error {
     using std::runtime_error::runtime_error;
 };
 
+enum class StringToLarge {
+    Throw,
+    Truncate
+};
+
 /// \brief Contains a String impementation with a maximum length
 template <size_t L> class String {
 private:
     std::string data;
-    size_t length;
+    static constexpr size_t length = L;
 
 public:
     /// \brief Creates a string from the given \p data
-    String(const std::string& data) : length(L) {
-        this->set(data);
+    String(const std::string& data, StringToLarge to_large = StringToLarge::Throw) {
+        this->set(data, to_large);
     }
 
-    String(const char* data) : length(L) {
-        this->set(data);
+    String(const char* data, StringToLarge to_large = StringToLarge::Throw) {
+        this->set(data, to_large);
     }
 
     /// \brief Creates a string
-    String() : length(L) {
-    }
+    String() = default;
 
     /// \brief Provides a std::string representation of the string
     /// \returns a std::string
@@ -42,21 +46,26 @@ public:
     }
 
     /// \brief Sets the content of the string to the given \p data
-    void set(const std::string& data) {
-        if (data.length() <= this->length) {
-            if (this->is_valid(data)) {
-                this->data = data;
-            } else {
-                throw StringConversionException("String has invalid format");
+    void set(const std::string& data, StringToLarge to_large = StringToLarge::Throw) {
+        std::string_view view = data;
+        if (view.length() > this->length) {
+            if (to_large == StringToLarge::Throw) {
+                throw StringConversionException("String length (" + std::to_string(view.length()) +
+                                                ") exceeds permitted length (" + std::to_string(this->length) + ")");
             }
+            // Truncate
+            view = view.substr(0, length);
+        }
+
+        if (this->is_valid(view)) {
+            this->data = view;
         } else {
-            throw StringConversionException("String length (" + std::to_string(data.length()) +
-                                            ") exceeds permitted length (" + std::to_string(this->length) + ")");
+            throw StringConversionException("String has invalid format");
         }
     }
 
     /// \brief Override this to check for a specific format
-    bool is_valid(const std::string& data) {
+    bool is_valid(std::string_view data) {
         (void)data; // not needed here
         return true;
     }

--- a/include/ocpp/common/string.hpp
+++ b/include/ocpp/common/string.hpp
@@ -11,6 +11,10 @@
 
 namespace ocpp {
 
+class StringConversionException : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 /// \brief Contains a String impementation with a maximum length
 template <size_t L> class String {
 private:
@@ -43,11 +47,11 @@ public:
             if (this->is_valid(data)) {
                 this->data = data;
             } else {
-                throw std::runtime_error("String has invalid format");
+                throw StringConversionException("String has invalid format");
             }
         } else {
-            throw std::runtime_error("String length (" + std::to_string(data.length()) +
-                                     ") exceeds permitted length (" + std::to_string(this->length) + ")");
+            throw StringConversionException("String length (" + std::to_string(data.length()) +
+                                            ") exceeds permitted length (" + std::to_string(this->length) + ")");
         }
     }
 

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -832,7 +832,8 @@ void ChargePoint::message_callback(const std::string& message) {
         this->message_dispatcher->dispatch_call_error(
             CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
-        this->security->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
+        this->security->security_event_notification_req(CiString<50>(security_event, StringToLarge::Truncate),
+                                                        CiString<255>(message, StringToLarge::Truncate), true,
                                                         utils::is_critical(security_event));
         return;
     } catch (const StringConversionException& e) {
@@ -841,7 +842,8 @@ void ChargePoint::message_callback(const std::string& message) {
         this->message_dispatcher->dispatch_call_error(
             CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
-        this->security->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
+        this->security->security_event_notification_req(CiString<50>(security_event, StringToLarge::Truncate),
+                                                        CiString<255>(message, StringToLarge::Truncate), true,
                                                         utils::is_critical(security_event));
         return;
     } catch (const EnumConversionException& e) {
@@ -849,7 +851,8 @@ void ChargePoint::message_callback(const std::string& message) {
         auto call_error = CallError(MessageId("-1"), "FormationViolation", e.what(), json({}));
         this->message_dispatcher->dispatch_call_error(call_error);
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
-        this->security->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
+        this->security->security_event_notification_req(CiString<50>(security_event, StringToLarge::Truncate),
+                                                        CiString<255>(message, StringToLarge::Truncate), true,
                                                         utils::is_critical(security_event));
         return;
     }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -842,7 +842,7 @@ void ChargePoint::message_callback(const std::string& message) {
             CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
         this->security->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
-                                              utils::is_critical(security_event));
+                                                        utils::is_critical(security_event));
         return;
     } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -832,8 +832,8 @@ void ChargePoint::message_callback(const std::string& message) {
         this->message_dispatcher->dispatch_call_error(
             CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
-        this->security->security_event_notification_req(CiString<50>(security_event, StringToLarge::Truncate),
-                                                        CiString<255>(message, StringToLarge::Truncate), true,
+        this->security->security_event_notification_req(CiString<50>(security_event, StringTooLarge::Truncate),
+                                                        CiString<255>(message, StringTooLarge::Truncate), true,
                                                         utils::is_critical(security_event));
         return;
     } catch (const StringConversionException& e) {
@@ -842,8 +842,8 @@ void ChargePoint::message_callback(const std::string& message) {
         this->message_dispatcher->dispatch_call_error(
             CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
-        this->security->security_event_notification_req(CiString<50>(security_event, StringToLarge::Truncate),
-                                                        CiString<255>(message, StringToLarge::Truncate), true,
+        this->security->security_event_notification_req(CiString<50>(security_event, StringTooLarge::Truncate),
+                                                        CiString<255>(message, StringTooLarge::Truncate), true,
                                                         utils::is_critical(security_event));
         return;
     } catch (const EnumConversionException& e) {
@@ -851,8 +851,8 @@ void ChargePoint::message_callback(const std::string& message) {
         auto call_error = CallError(MessageId("-1"), "FormationViolation", e.what(), json({}));
         this->message_dispatcher->dispatch_call_error(call_error);
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
-        this->security->security_event_notification_req(CiString<50>(security_event, StringToLarge::Truncate),
-                                                        CiString<255>(message, StringToLarge::Truncate), true,
+        this->security->security_event_notification_req(CiString<50>(security_event, StringTooLarge::Truncate),
+                                                        CiString<255>(message, StringTooLarge::Truncate), true,
                                                         utils::is_critical(security_event));
         return;
     }

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -841,7 +841,7 @@ void ChargePoint::message_callback(const std::string& message) {
         this->message_dispatcher->dispatch_call_error(
             CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
         const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
-        this->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
+        this->security->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
                                               utils::is_critical(security_event));
         return;
     } catch (const EnumConversionException& e) {

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -835,6 +835,15 @@ void ChargePoint::message_callback(const std::string& message) {
         this->security->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
                                                         utils::is_critical(security_event));
         return;
+    } catch (const StringConversionException& e) {
+        this->logging->central_system("Unknown", message);
+        EVLOG_error << "JSON exception during reception of message: " << e.what();
+        this->message_dispatcher->dispatch_call_error(
+            CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({})));
+        const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
+        this->security_event_notification_req(CiString<50>(security_event), CiString<255>(message), true,
+                                              utils::is_critical(security_event));
+        return;
     } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         auto call_error = CallError(MessageId("-1"), "FormationViolation", e.what(), json({}));


### PR DESCRIPTION
## Describe your changes

Fixes a crash when the MessageId string received is longer than 36 characters. Instead of crashing we now send an RpcFrameworkError.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

