### PR TITLE
Add OCPP2.1 to templates and rename status document

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -6,10 +6,11 @@ body:
     id: affected-ocpp-version
     attributes:
       label: OCPP Version
-      description: Which OCPP is affected? Mark both if applicable.
+      description: Which OCPP is affected? Mark multiple if applicable.
       options:
         - OCPP1.6
         - OCPP2.0.1
+        - OCPP2.1
       multiple: true
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -6,10 +6,11 @@ body:
     id: affected-ocpp-version
     attributes:
       label: OCPP Version
-      description: For which OCPP do you suggest this feature? Mark both if applicable.
+      description: For which OCPP do you suggest this feature? Mark multiple if applicable.
       options:
         - OCPP1.6
         - OCPP2.0.1
+        - OCPP2.1
       multiple: true
     validations:
       required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,6 @@
 ## Checklist before requesting a review
 - [ ] I have performed a self-review of my code
 - [ ] I have made corresponding changes to the documentation
-- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
+- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
 - [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The following table shows the known CSMS with which this library was tested.
 | O. DisplayMessage                    | ✅ yes  |
 | P. DataTransfer                      | ✅ yes  |
 
-The development of OCPP2.0.1 is in progress. Check the [detailed current implementation status.](doc/v2/ocpp_201_status.md).
+The development of OCPP2.0.1 is in progress. Check the [detailed current implementation status.](doc/v2/ocpp_2x_status.md).
 
 | Whitepapers & Application Notes                                                                                                                              | Supported              |
 | ----------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |

--- a/doc/v2/ocpp_201_smart_charging_in_depth.md
+++ b/doc/v2/ocpp_201_smart_charging_in_depth.md
@@ -6,7 +6,7 @@ The use cases within the Smart Charging functional block are subdivided into the
 2. External Charging Limit-based Smart Charging (K11–K14)
 3. ISO 15118-based Smart Charging (K15–K17)
 
-Support for General and External Charging Limit-based Smart Charging is largely complete, with ISO 15118-based Smart Charging under active development. For an up-to-date overview of exactly which features are currently supported as well as design decisions that have been made to address optional or ambiguous functional requirements, please refer to the [OCPP 2.0.1 Status document](ocpp_201_status.md).
+Support for General and External Charging Limit-based Smart Charging is largely complete, with ISO 15118-based Smart Charging under active development. For an up-to-date overview of exactly which features are currently supported as well as design decisions that have been made to address optional or ambiguous functional requirements, please refer to the [OCPP 2.0.1 Status document](ocpp_2x_status.md).
 
 ## K01 SetChargingProfile
 

--- a/doc/v2/ocpp_2x_status.md
+++ b/doc/v2/ocpp_2x_status.md
@@ -1,6 +1,6 @@
-# OCPP2.0.1 Functional Requirements Status
+# OCPP2.0.1 / OCPP2.1 Functional Requirements Status
 
-This document contains the status of which OCPP 2.0.1 numbered functional requirements (FRs) have been implemented in `libocpp`. This does not cover if the functionality is also implemented in `everest-core`.
+This document contains the status of which OCPP 2.0.1 and OCPP2.1 numbered functional requirements (FRs) have been implemented in `libocpp`. This does not cover if the functionality is also implemented in `everest-core`.
 
 ## Legend
 


### PR DESCRIPTION

## Describe your changes
* Added OCPP2.1 option to templates
* Renamed status document to ocpp_2x_status.md to be able to add OCPP2.1 requirements to it

Note: OCPP2.1 have not yet been added to the status document.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

