### PR TITLE
Add forward declarations and move includes to cpp files

### DIFF
--- a/include/ocpp/v201/charge_point.hpp
+++ b/include/ocpp/v201/charge_point.hpp
@@ -8,31 +8,11 @@
 #include <set>
 
 #include <ocpp/common/message_dispatcher.hpp>
-#include <ocpp/v201/functional_blocks/authorization.hpp>
-#include <ocpp/v201/functional_blocks/availability.hpp>
-#include <ocpp/v201/functional_blocks/data_transfer.hpp>
-#include <ocpp/v201/functional_blocks/diagnostics.hpp>
-#include <ocpp/v201/functional_blocks/display_message.hpp>
-#include <ocpp/v201/functional_blocks/firmware_update.hpp>
-#include <ocpp/v201/functional_blocks/meter_values.hpp>
-#include <ocpp/v201/functional_blocks/provisioning.hpp>
-#include <ocpp/v201/functional_blocks/remote_transaction_control.hpp>
-#include <ocpp/v201/functional_blocks/reservation.hpp>
-#include <ocpp/v201/functional_blocks/security.hpp>
-#include <ocpp/v201/functional_blocks/smart_charging.hpp>
-#include <ocpp/v201/functional_blocks/tariff_and_cost.hpp>
-#include <ocpp/v201/functional_blocks/transaction.hpp>
 
 #include <ocpp/common/charging_station_base.hpp>
 
 #include <ocpp/v201/average_meter_values.hpp>
 #include <ocpp/v201/charge_point_callbacks.hpp>
-#include <ocpp/v201/ctrlr_component_variables.hpp>
-#include <ocpp/v201/database_handler.hpp>
-#include <ocpp/v201/device_model.hpp>
-#include <ocpp/v201/device_model_storage_interface.hpp>
-#include <ocpp/v201/evse_manager.hpp>
-#include <ocpp/v201/monitoring_updater.hpp>
 #include <ocpp/v201/ocpp_enums.hpp>
 #include <ocpp/v201/ocpp_types.hpp>
 #include <ocpp/v201/ocsp_updater.hpp>
@@ -40,31 +20,34 @@
 #include <ocpp/v201/utils.hpp>
 
 #include <ocpp/v201/messages/Authorize.hpp>
-#include <ocpp/v201/messages/BootNotification.hpp>
-#include <ocpp/v201/messages/ClearVariableMonitoring.hpp>
-#include <ocpp/v201/messages/CustomerInformation.hpp>
 #include <ocpp/v201/messages/DataTransfer.hpp>
 #include <ocpp/v201/messages/Get15118EVCertificate.hpp>
-#include <ocpp/v201/messages/GetBaseReport.hpp>
-#include <ocpp/v201/messages/GetLog.hpp>
-#include <ocpp/v201/messages/GetMonitoringReport.hpp>
-#include <ocpp/v201/messages/GetReport.hpp>
-#include <ocpp/v201/messages/GetVariables.hpp>
-#include <ocpp/v201/messages/NotifyCustomerInformation.hpp>
-#include <ocpp/v201/messages/NotifyEvent.hpp>
-#include <ocpp/v201/messages/NotifyMonitoringReport.hpp>
-#include <ocpp/v201/messages/NotifyReport.hpp>
-#include <ocpp/v201/messages/Reset.hpp>
-#include <ocpp/v201/messages/SetMonitoringBase.hpp>
-#include <ocpp/v201/messages/SetMonitoringLevel.hpp>
-#include <ocpp/v201/messages/SetNetworkProfile.hpp>
-#include <ocpp/v201/messages/SetVariableMonitoring.hpp>
-#include <ocpp/v201/messages/SetVariables.hpp>
+#include <ocpp/v201/messages/GetCompositeSchedule.hpp>
 
 #include "component_state_manager.hpp"
 
 namespace ocpp {
 namespace v201 {
+
+class AuthorizationInterface;
+class AvailabilityInterface;
+class DataTransferInterface;
+class DiagnosticsInterface;
+class DisplayMessageInterface;
+class FirmwareUpdateInterface;
+class MeterValuesInterface;
+class ProvisioningInterface;
+class RemoteTransactionControlInterface;
+class ReservationInterface;
+class SecurityInterface;
+class SmartChargingInterface;
+class TariffAndCostInterface;
+class TransactionInterface;
+
+class DatabaseHandler;
+class DeviceModel;
+class DeviceModelStorageInterface;
+class EvseManager;
 
 class UnexpectedMessageTypeFromCSMS : public std::runtime_error {
     using std::runtime_error::runtime_error;
@@ -358,11 +341,11 @@ private:
     std::unique_ptr<DisplayMessageInterface> display_message;
     std::unique_ptr<FirmwareUpdateInterface> firmware_update;
     std::unique_ptr<MeterValuesInterface> meter_values;
-    std::unique_ptr<SmartCharging> smart_charging;
+    std::unique_ptr<SmartChargingInterface> smart_charging;
     std::unique_ptr<TariffAndCostInterface> tariff_and_cost;
     std::unique_ptr<TransactionInterface> transaction;
     std::unique_ptr<ProvisioningInterface> provisioning;
-    std::unique_ptr<RemoteTransactionControl> remote_transaction_control;
+    std::unique_ptr<RemoteTransactionControlInterface> remote_transaction_control;
 
     // utility
     std::shared_ptr<MessageQueue<v201::MessageType>> message_queue;

--- a/include/ocpp/v201/functional_blocks/authorization.hpp
+++ b/include/ocpp/v201/functional_blocks/authorization.hpp
@@ -3,16 +3,17 @@
 
 #pragma once
 
-#include <ocpp/v201/messages/Authorize.hpp>
-#include <ocpp/v201/messages/ClearCache.hpp>
-#include <ocpp/v201/messages/GetLocalListVersion.hpp>
-#include <ocpp/v201/messages/SendLocalList.hpp>
-
 #include <ocpp/v201/database_handler.hpp>
 #include <ocpp/v201/message_dispatcher.hpp>
 #include <ocpp/v201/message_handler.hpp>
 
 namespace ocpp::v201 {
+struct AuthorizationCacheEntry;
+struct AuthorizeResponse;
+struct ClearCacheRequest;
+struct SendLocalListRequest;
+struct GetLocalListVersionRequest;
+
 class AuthorizationInterface : public MessageHandlerInterface {
 public:
     virtual ~AuthorizationInterface() {
@@ -45,7 +46,7 @@ private: // Members
     MessageDispatcherInterface<MessageType>& message_dispatcher;
     DeviceModel& device_model;
     ConnectivityManagerInterface& connectivity_manager;
-    ocpp::v201::DatabaseHandlerInterface& database_handler;
+    DatabaseHandlerInterface& database_handler;
     EvseSecurity& evse_security;
 
     // threads and synchronization

--- a/include/ocpp/v201/functional_blocks/availability.hpp
+++ b/include/ocpp/v201/functional_blocks/availability.hpp
@@ -7,13 +7,13 @@
 #include <ocpp/v201/message_handler.hpp>
 
 #include <ocpp/v201/messages/ChangeAvailability.hpp>
-#include <ocpp/v201/messages/Heartbeat.hpp>
 
 namespace ocpp::v201 {
-
 class DeviceModel;
 class EvseManagerInterface;
 class ComponentStateManagerInterface;
+
+struct HeartbeatResponse;
 
 /// \brief Combines ChangeAvailabilityRequest with persist flag for scheduled Availability changes
 struct AvailabilityChange {

--- a/include/ocpp/v201/functional_blocks/data_transfer.hpp
+++ b/include/ocpp/v201/functional_blocks/data_transfer.hpp
@@ -5,10 +5,11 @@
 
 #include <ocpp/v201/message_dispatcher.hpp>
 #include <ocpp/v201/message_handler.hpp>
-#include <ocpp/v201/messages/DataTransfer.hpp>
 
 namespace ocpp {
 namespace v201 {
+struct DataTransferRequest;
+struct DataTransferResponse;
 
 class DataTransferInterface : public MessageHandlerInterface {
 

--- a/include/ocpp/v201/functional_blocks/display_message.hpp
+++ b/include/ocpp/v201/functional_blocks/display_message.hpp
@@ -3,14 +3,16 @@
 
 #pragma once
 
-#include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/message_dispatcher.hpp>
 #include <ocpp/v201/message_handler.hpp>
-#include <ocpp/v201/messages/ClearDisplayMessage.hpp>
-#include <ocpp/v201/messages/GetDisplayMessages.hpp>
+
 #include <ocpp/v201/messages/SetDisplayMessage.hpp>
 
 namespace ocpp::v201 {
+class EvseManagerInterface;
+struct GetDisplayMessagesRequest;
+struct ClearDisplayMessageResponse;
+struct ClearDisplayMessageRequest;
 
 ///
 /// \brief Convert message content from OCPP spec to DisplayMessageContent.

--- a/include/ocpp/v201/functional_blocks/firmware_update.hpp
+++ b/include/ocpp/v201/functional_blocks/firmware_update.hpp
@@ -5,10 +5,8 @@
 
 #include <ocpp/common/message_dispatcher.hpp>
 #include <ocpp/v201/message_handler.hpp>
-#include <ocpp/v201/messages/UpdateFirmware.hpp>
 
 namespace ocpp {
-
 // Forward declarations.
 class EvseSecurity;
 
@@ -20,14 +18,16 @@ class EvseManagerInterface;
 class AvailabilityInterface;
 class SecurityInterface;
 
+struct UpdateFirmwareRequest;
+struct UpdateFirmwareResponse;
+
 // Typedef
 typedef std::function<UpdateFirmwareResponse(const UpdateFirmwareRequest& request)> UpdateFirmwareRequestCallback;
 typedef std::function<void()> AllConnectorsUnavailableCallback;
 
 class FirmwareUpdateInterface : public MessageHandlerInterface {
 public:
-    virtual ~FirmwareUpdateInterface() {
-    }
+    virtual ~FirmwareUpdateInterface() = default;
 
     virtual void on_firmware_update_status_notification(int32_t request_id,
                                                         const FirmwareStatusEnum& firmware_update_status) = 0;

--- a/include/ocpp/v201/functional_blocks/reservation.hpp
+++ b/include/ocpp/v201/functional_blocks/reservation.hpp
@@ -3,16 +3,15 @@
 
 #include <ocpp/v201/message_dispatcher.hpp>
 #include <ocpp/v201/message_handler.hpp>
-#include <ocpp/v201/messages/CancelReservation.hpp>
-#include <ocpp/v201/messages/ReservationStatusUpdate.hpp>
-#include <ocpp/v201/messages/ReserveNow.hpp>
 
 #pragma once
 
 namespace ocpp::v201 {
-
 class EvseInterface;
 class EvseManagerInterface;
+
+struct ReserveNowRequest;
+struct CancelReservationRequest;
 
 typedef std::function<ReserveNowStatusEnum(const ReserveNowRequest& request)> ReserveNowCallback;
 typedef std::function<bool(const int32_t reservationId)> CancelReservationCallback;

--- a/include/ocpp/v201/functional_blocks/security.hpp
+++ b/include/ocpp/v201/functional_blocks/security.hpp
@@ -9,14 +9,16 @@
 #include <ocpp/v201/message_handler.hpp>
 #include <ocpp/v201/ocsp_updater.hpp>
 
-#include <ocpp/v201/messages/CertificateSigned.hpp>
-#include <ocpp/v201/messages/DeleteCertificate.hpp>
-#include <ocpp/v201/messages/Get15118EVCertificate.hpp>
-#include <ocpp/v201/messages/GetInstalledCertificateIds.hpp>
-#include <ocpp/v201/messages/InstallCertificate.hpp>
-#include <ocpp/v201/messages/SignCertificate.hpp>
-
 namespace ocpp::v201 {
+struct CertificateSignedRequest;
+struct CertificateSignedResponse;
+struct GetInstalledCertificateIdsRequest;
+struct Get15118EVCertificateRequest;
+struct Get15118EVCertificateResponse;
+struct InstallCertificateRequest;
+struct DeleteCertificateRequest;
+struct SignCertificateResponse;
+
 typedef std::function<void(const CiString<50>& event_type, const std::optional<CiString<255>>& tech_info)>
     SecurityEventCallback;
 

--- a/include/ocpp/v201/functional_blocks/smart_charging.hpp
+++ b/include/ocpp/v201/functional_blocks/smart_charging.hpp
@@ -9,19 +9,21 @@
 #include <ocpp/v201/evse.hpp>
 #include <ocpp/v201/message_dispatcher.hpp>
 
-#include <ocpp/v201/messages/ClearChargingProfile.hpp>
-#include <ocpp/v201/messages/GetChargingProfiles.hpp>
-#include <ocpp/v201/messages/GetCompositeSchedule.hpp>
-#include <ocpp/v201/messages/ReportChargingProfiles.hpp>
-#include <ocpp/v201/messages/SetChargingProfile.hpp>
-
 namespace ocpp::v201 {
-
 class DeviceModel;
 class EvseManagerInterface;
 class ConnectivityManagerInterface;
 class SmartChargingHandlerInterface;
 class EvseInterface;
+
+struct GetChargingProfilesRequest;
+struct SetChargingProfileRequest;
+struct SetChargingProfileResponse;
+struct GetCompositeScheduleResponse;
+struct GetCompositeScheduleRequest;
+struct ClearChargingProfileResponse;
+struct ClearChargingProfileRequest;
+struct ReportChargingProfilesRequest;
 
 enum class ProfileValidationResultEnum {
     Valid,

--- a/include/ocpp/v201/functional_blocks/tariff_and_cost.hpp
+++ b/include/ocpp/v201/functional_blocks/tariff_and_cost.hpp
@@ -8,12 +8,12 @@
 #include <ocpp/common/message_dispatcher.hpp>
 #include <ocpp/v201/functional_blocks/display_message.hpp>
 
-#include <ocpp/v201/messages/CostUpdated.hpp>
-
 namespace ocpp::v201 {
 class DeviceModel;
 class EvseManagerInterface;
 class MeterValuesInterface;
+
+struct CostUpdatedRequest;
 
 typedef std::function<void(const RunningCost& running_cost, const uint32_t number_of_decimals,
                            std::optional<std::string> currency_code)>

--- a/lib/ocpp/v201/charge_point.cpp
+++ b/lib/ocpp/v201/charge_point.cpp
@@ -1,15 +1,35 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include <ocpp/v201/charge_point.hpp>
+
 #include <ocpp/common/constants.hpp>
 #include <ocpp/common/types.hpp>
-#include <ocpp/v201/charge_point.hpp>
 #include <ocpp/v201/ctrlr_component_variables.hpp>
+#include <ocpp/v201/database_handler.hpp>
+#include <ocpp/v201/device_model.hpp>
+#include <ocpp/v201/device_model_storage_interface.hpp>
 #include <ocpp/v201/device_model_storage_sqlite.hpp>
+#include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/message_dispatcher.hpp>
-#include <ocpp/v201/messages/LogStatusNotification.hpp>
 #include <ocpp/v201/notify_report_requests_splitter.hpp>
 
+#include <ocpp/v201/functional_blocks/authorization.hpp>
+#include <ocpp/v201/functional_blocks/availability.hpp>
+#include <ocpp/v201/functional_blocks/data_transfer.hpp>
+#include <ocpp/v201/functional_blocks/diagnostics.hpp>
+#include <ocpp/v201/functional_blocks/display_message.hpp>
+#include <ocpp/v201/functional_blocks/firmware_update.hpp>
+#include <ocpp/v201/functional_blocks/meter_values.hpp>
+#include <ocpp/v201/functional_blocks/provisioning.hpp>
+#include <ocpp/v201/functional_blocks/remote_transaction_control.hpp>
+#include <ocpp/v201/functional_blocks/reservation.hpp>
+#include <ocpp/v201/functional_blocks/security.hpp>
+#include <ocpp/v201/functional_blocks/smart_charging.hpp>
+#include <ocpp/v201/functional_blocks/tariff_and_cost.hpp>
+#include <ocpp/v201/functional_blocks/transaction.hpp>
+
+#include <ocpp/v201/messages/LogStatusNotification.hpp>
 #include <ocpp/v201/messages/RequestStopTransaction.hpp>
 #include <ocpp/v201/messages/TriggerMessage.hpp>
 

--- a/lib/ocpp/v201/functional_blocks/authorization.cpp
+++ b/lib/ocpp/v201/functional_blocks/authorization.cpp
@@ -3,8 +3,14 @@
 
 #include <ocpp/common/constants.hpp>
 #include <ocpp/v201/ctrlr_component_variables.hpp>
+#include <ocpp/v201/database_handler.hpp>
 #include <ocpp/v201/functional_blocks/authorization.hpp>
 #include <ocpp/v201/utils.hpp>
+
+#include <ocpp/v201/messages/Authorize.hpp>
+#include <ocpp/v201/messages/ClearCache.hpp>
+#include <ocpp/v201/messages/GetLocalListVersion.hpp>
+#include <ocpp/v201/messages/SendLocalList.hpp>
 
 ///
 /// \brief Check if vector of authorization data has a duplicate id token.

--- a/lib/ocpp/v201/functional_blocks/availability.cpp
+++ b/lib/ocpp/v201/functional_blocks/availability.cpp
@@ -7,6 +7,7 @@
 #include <ocpp/v201/device_model.hpp>
 #include <ocpp/v201/evse_manager.hpp>
 
+#include <ocpp/v201/messages/Heartbeat.hpp>
 #include <ocpp/v201/messages/StatusNotification.hpp>
 
 namespace ocpp::v201 {

--- a/lib/ocpp/v201/functional_blocks/data_transfer.cpp
+++ b/lib/ocpp/v201/functional_blocks/data_transfer.cpp
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
-#include <ocpp/common/constants.hpp>
 #include <ocpp/v201/functional_blocks/data_transfer.hpp>
+
+#include <ocpp/common/constants.hpp>
+#include <ocpp/v201/messages/DataTransfer.hpp>
 
 namespace ocpp {
 namespace v201 {
 
 void DataTransfer::handle_message(const EnhancedMessage<MessageType>& message) {
-
     if (message.messageType != MessageType::DataTransfer) {
         throw MessageTypeNotImplementedException(message.messageType);
     }

--- a/lib/ocpp/v201/functional_blocks/display_message.cpp
+++ b/lib/ocpp/v201/functional_blocks/display_message.cpp
@@ -2,7 +2,11 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 
 #include <ocpp/v201/ctrlr_component_variables.hpp>
+#include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/functional_blocks/display_message.hpp>
+
+#include <ocpp/v201/messages/ClearDisplayMessage.hpp>
+#include <ocpp/v201/messages/GetDisplayMessages.hpp>
 #include <ocpp/v201/messages/NotifyDisplayMessages.hpp>
 
 namespace ocpp::v201 {

--- a/lib/ocpp/v201/functional_blocks/firmware_update.cpp
+++ b/lib/ocpp/v201/functional_blocks/firmware_update.cpp
@@ -8,6 +8,7 @@
 #include <ocpp/v201/functional_blocks/availability.hpp>
 #include <ocpp/v201/functional_blocks/security.hpp>
 #include <ocpp/v201/messages/FirmwareStatusNotification.hpp>
+#include <ocpp/v201/messages/UpdateFirmware.hpp>
 
 #include <ocpp/v201/ctrlr_component_variables.hpp>
 #include <ocpp/v201/device_model.hpp>

--- a/lib/ocpp/v201/functional_blocks/remote_transaction_control.cpp
+++ b/lib/ocpp/v201/functional_blocks/remote_transaction_control.cpp
@@ -20,6 +20,7 @@
 #include <ocpp/v201/messages/LogStatusNotification.hpp>
 #include <ocpp/v201/messages/RequestStartTransaction.hpp>
 #include <ocpp/v201/messages/RequestStopTransaction.hpp>
+#include <ocpp/v201/messages/SetChargingProfile.hpp>
 #include <ocpp/v201/messages/TriggerMessage.hpp>
 #include <ocpp/v201/messages/UnlockConnector.hpp>
 

--- a/lib/ocpp/v201/functional_blocks/reservation.cpp
+++ b/lib/ocpp/v201/functional_blocks/reservation.cpp
@@ -7,6 +7,10 @@
 #include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/functional_blocks/reservation.hpp>
 
+#include <ocpp/v201/messages/CancelReservation.hpp>
+#include <ocpp/v201/messages/ReservationStatusUpdate.hpp>
+#include <ocpp/v201/messages/ReserveNow.hpp>
+
 namespace ocpp::v201 {
 Reservation::Reservation(MessageDispatcherInterface<MessageType>& message_dispatcher, DeviceModel& device_model,
                          EvseManagerInterface& evse_manager, ReserveNowCallback reserve_now_callback,

--- a/lib/ocpp/v201/functional_blocks/security.cpp
+++ b/lib/ocpp/v201/functional_blocks/security.cpp
@@ -8,6 +8,13 @@
 #include <ocpp/v201/messages/SecurityEventNotification.hpp>
 #include <ocpp/v201/utils.hpp>
 
+#include <ocpp/v201/messages/CertificateSigned.hpp>
+#include <ocpp/v201/messages/DeleteCertificate.hpp>
+#include <ocpp/v201/messages/Get15118EVCertificate.hpp>
+#include <ocpp/v201/messages/GetInstalledCertificateIds.hpp>
+#include <ocpp/v201/messages/InstallCertificate.hpp>
+#include <ocpp/v201/messages/SignCertificate.hpp>
+
 constexpr int32_t minimum_cert_signing_wait_time_seconds = 250;
 
 namespace ocpp::v201 {

--- a/lib/ocpp/v201/functional_blocks/smart_charging.cpp
+++ b/lib/ocpp/v201/functional_blocks/smart_charging.cpp
@@ -13,6 +13,12 @@
 
 #include <ocpp/common/constants.hpp>
 
+#include <ocpp/v201/messages/ClearChargingProfile.hpp>
+#include <ocpp/v201/messages/GetChargingProfiles.hpp>
+#include <ocpp/v201/messages/GetCompositeSchedule.hpp>
+#include <ocpp/v201/messages/ReportChargingProfiles.hpp>
+#include <ocpp/v201/messages/SetChargingProfile.hpp>
+
 const int32_t STATION_WIDE_ID = 0;
 
 namespace ocpp::v201 {

--- a/lib/ocpp/v201/functional_blocks/tariff_and_cost.cpp
+++ b/lib/ocpp/v201/functional_blocks/tariff_and_cost.cpp
@@ -8,6 +8,8 @@
 #include <ocpp/v201/evse_manager.hpp>
 #include <ocpp/v201/functional_blocks/meter_values.hpp>
 
+#include <ocpp/v201/messages/CostUpdated.hpp>
+
 const auto DEFAULT_PRICE_NUMBER_OF_DECIMALS = 3;
 
 namespace ocpp::v201 {

--- a/tests/lib/ocpp/v201/functional_blocks/test_authorization.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_authorization.cpp
@@ -14,6 +14,11 @@
 #include "message_dispatcher_mock.hpp"
 #include "mocks/database_handler_mock.hpp"
 
+#include <ocpp/v201/messages/Authorize.hpp>
+#include <ocpp/v201/messages/ClearCache.hpp>
+#include <ocpp/v201/messages/GetLocalListVersion.hpp>
+#include <ocpp/v201/messages/SendLocalList.hpp>
+
 using namespace ocpp::v201;
 using ::testing::_;
 using ::testing::InSequence;

--- a/tests/lib/ocpp/v201/functional_blocks/test_data_transfer.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_data_transfer.cpp
@@ -5,9 +5,9 @@
 #include <gtest/gtest.h>
 
 #include <message_dispatcher_mock.hpp>
-
 #include <ocpp/common/constants.hpp>
 #include <ocpp/v201/functional_blocks/data_transfer.hpp>
+#include <ocpp/v201/messages/DataTransfer.hpp>
 
 using namespace ocpp::v201;
 using ::testing::_;

--- a/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_reservation.cpp
@@ -12,6 +12,10 @@
 #include <ocpp/v201/ctrlr_component_variables.hpp>
 #include <ocpp/v201/device_model_storage_sqlite.hpp>
 #include <ocpp/v201/init_device_model_db.hpp>
+
+#include <ocpp/v201/messages/CancelReservation.hpp>
+#include <ocpp/v201/messages/ReservationStatusUpdate.hpp>
+#include <ocpp/v201/messages/ReserveNow.hpp>
 #include <ocpp/v201/messages/Reset.hpp>
 
 const static std::string MIGRATION_FILES_PATH = "./resources/v201/device_model_migration_files";

--- a/tests/lib/ocpp/v201/functional_blocks/test_security.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_security.cpp
@@ -9,8 +9,10 @@
 #define private public // Make everything in security.hpp public so we can trigger the timer.
 #include <ocpp/v201/functional_blocks/security.hpp>
 #undef private
+#include <ocpp/v201/messages/CertificateSigned.hpp>
 #include <ocpp/v201/messages/Reset.hpp>
 #include <ocpp/v201/messages/SecurityEventNotification.hpp>
+#include <ocpp/v201/messages/SignCertificate.hpp>
 
 #include "connectivity_manager_mock.hpp"
 #include "device_model_test_helper.hpp"

--- a/tests/lib/ocpp/v201/functional_blocks/test_smart_charging.cpp
+++ b/tests/lib/ocpp/v201/functional_blocks/test_smart_charging.cpp
@@ -10,7 +10,6 @@
 #include "ocpp/v201/ctrlr_component_variables.hpp"
 #include "ocpp/v201/device_model.hpp"
 #include "ocpp/v201/functional_blocks/smart_charging.hpp"
-#include "ocpp/v201/init_device_model_db.hpp"
 #include "ocpp/v201/ocpp_types.hpp"
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -36,6 +35,11 @@
 #include "smart_charging_test_utils.hpp"
 #include <sstream>
 #include <vector>
+
+#include <ocpp/v201/messages/ClearChargingProfile.hpp>
+#include <ocpp/v201/messages/GetChargingProfiles.hpp>
+#include <ocpp/v201/messages/GetCompositeSchedule.hpp>
+#include <ocpp/v201/messages/SetChargingProfile.hpp>
 
 using ::testing::_;
 using ::testing::ByMove;

--- a/tests/lib/ocpp/v201/mocks/smart_charging_mock.hpp
+++ b/tests/lib/ocpp/v201/mocks/smart_charging_mock.hpp
@@ -6,6 +6,7 @@
 #include "gmock/gmock.h"
 
 #include <ocpp/v201/functional_blocks/smart_charging.hpp>
+#include <ocpp/v201/messages/SetChargingProfile.hpp>
 
 namespace ocpp::v201 {
 class SmartChargingMock : public SmartChargingInterface {


### PR DESCRIPTION
## Describe your changes

A lot of includes in the functional blocks could be changed to forward declarations and the headers moved to the cpp file. Also, remove some unused headers (messages) that are now part of the functional blocks.

## Issue ticket number and link

#974 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [n/a] I have made corresponding changes to the documentation
- [n/a] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

