### PR TITLE
Only change state to available if the current state is 'Reserved'

### DIFF
--- a/include/ocpp/v16/charge_point_state_machine.hpp
+++ b/include/ocpp/v16/charge_point_state_machine.hpp
@@ -25,6 +25,7 @@ enum class FSMEvent {
     ReserveConnector,
     TransactionStoppedAndUserActionRequired,
     ChangeAvailabilityToUnavailable,
+    ReservationEnd,
     // FaultDetected - note: this event is handled via a separate function
     I1_ReturnToAvailable,
     I2_ReturnToPreparing,

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1693,10 +1693,6 @@ void ChargePointImpl::preprocess_change_availability_request(
 void ChargePointImpl::execute_connectors_availability_change(const std::vector<int32_t>& changed_connectors,
                                                              const ocpp::v16::AvailabilityType availability,
                                                              bool persist) {
-
-    // if evse availability changes, status event is only emitted for evse
-    bool evse_changed = std::find(changed_connectors.begin(), changed_connectors.end(), 0) != changed_connectors.end();
-
     for (const auto& connector : changed_connectors) {
         if (persist) {
             try {
@@ -1707,7 +1703,7 @@ void ChargePointImpl::execute_connectors_availability_change(const std::vector<i
             }
         }
         if (availability == AvailabilityType::Operative) {
-            if (connector == 0 or !evse_changed) {
+            if (connector == 0) {
                 this->status->submit_event(connector, FSMEvent::BecomeAvailable, ocpp::DateTime());
             }
 
@@ -1715,7 +1711,7 @@ void ChargePointImpl::execute_connectors_availability_change(const std::vector<i
                 this->enable_evse_callback(connector);
             }
         } else {
-            if (connector == 0 or !evse_changed) {
+            if (connector == 0) {
                 this->status->submit_event(connector, FSMEvent::ChangeAvailabilityToUnavailable, ocpp::DateTime());
             }
             if (this->disable_evse_callback != nullptr) {
@@ -2986,6 +2982,8 @@ void ChargePointImpl::handleReserveNowRequest(ocpp::Call<ReserveNowRequest> call
 
     if (this->status->get_state(call.msg.connectorId) == ChargePointStatus::Faulted) {
         response.status = ReservationStatus::Faulted;
+    } else if (this->status->get_state(call.msg.connectorId) == ChargePointStatus::Preparing) {
+        response.status = ReservationStatus::Occupied;
     } else if (this->reserve_now_callback != nullptr &&
                this->configuration->getSupportedFeatureProfiles().find("Reservation") != std::string::npos) {
         if (call.msg.connectorId != 0 || this->configuration->getReserveConnectorZeroSupported().value_or(false)) {
@@ -4615,9 +4613,7 @@ void ChargePointImpl::on_reservation_start(int32_t connector) {
 }
 
 void ChargePointImpl::on_reservation_end(int32_t connector) {
-    if (this->status->get_state(connector) == ChargePointStatus::Reserved) {
-        this->status->submit_event(connector, FSMEvent::BecomeAvailable, ocpp::DateTime());
-    }
+    this->status->submit_event(connector, FSMEvent::ReservationEnd, ocpp::DateTime());
 }
 
 void ChargePointImpl::on_enabled(int32_t connector) {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -4615,7 +4615,9 @@ void ChargePointImpl::on_reservation_start(int32_t connector) {
 }
 
 void ChargePointImpl::on_reservation_end(int32_t connector) {
-    this->status->submit_event(connector, FSMEvent::BecomeAvailable, ocpp::DateTime());
+    if (this->status->get_state(connector) == ChargePointStatus::Reserved) {
+        this->status->submit_event(connector, FSMEvent::BecomeAvailable, ocpp::DateTime());
+    }
 }
 
 void ChargePointImpl::on_enabled(int32_t connector) {

--- a/lib/ocpp/v16/charge_point_state_machine.cpp
+++ b/lib/ocpp/v16/charge_point_state_machine.cpp
@@ -60,11 +60,10 @@ static const FSMDefinition FSM_DEF = {
          {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
      }},
     {FSMState::Reserved,
-     {
-         {FSMEvent::BecomeAvailable, FSMState::Available},
-         {FSMEvent::UsageInitiated, FSMState::Preparing},
-         {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
-     }},
+     {{FSMEvent::BecomeAvailable, FSMState::Available},
+      {FSMEvent::UsageInitiated, FSMState::Preparing},
+      {FSMEvent::ChangeAvailabilityToUnavailable, FSMState::Unavailable},
+      {FSMEvent::ReservationEnd, FSMState::Available}}},
     {FSMState::Unavailable,
      {
          {FSMEvent::BecomeAvailable, FSMState::Available},


### PR DESCRIPTION
## Describe your changes

OCPP 1.6: When a connector is reserved and it is set to 'Inoperative', it should go to 'Unavailable' and the reservation should be cancelled. 
So when we set to 'Inoperative', status notification 'Unavailable' is sent. It seems the reservation is cancelled indeed, therefore 'ReservationEnd' is called, which causes the state to change to 'Available', but directly after to 'Unavailable' again. So that is three state changes where there should be only one.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [n/a] I have made corresponding changes to the documentation
- [n/a] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

