### PR TITLE
Moved StatusNotification.req(Finishing) behind StopTransaction.req

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -4227,8 +4227,12 @@ void ChargePointImpl::on_transaction_stopped(const int32_t connector, const std:
     const auto stop_energy_wh = std::make_shared<StampedEnergyWh>(timestamp, energy_wh_import);
     transaction->add_stop_energy_wh(stop_energy_wh);
 
-    this->status->submit_event(connector, FSMEvent::TransactionStoppedAndUserActionRequired, ocpp::DateTime());
     this->stop_transaction(connector, reason, id_tag_end);
+
+    if (reason != Reason::EVDisconnected) {
+        this->status->submit_event(connector, FSMEvent::TransactionStoppedAndUserActionRequired, ocpp::DateTime());
+    }
+
     this->transaction_handler->remove_active_transaction(connector);
     this->connectors.at(connector)->transaction = nullptr;
 


### PR DESCRIPTION

## Describe your changes
Moved StatusNotification.req(Finishing) behind StopTransaction.req message. Moving to StatusNotification.req(Available) in case transaction ends because of EVDisconnect . 

The OCPP1.6 specification requires:
transition table (p 39) → Transition C6:
”C6 Transaction is stopped by user or a Remote Stop Transaction message and further user action is required (e.g. remove cable, leave parking
bay)” 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

