### PR TITLE
Start websocket ping timer when websocket connects

### DIFF
--- a/config/v16/config-docker.json
+++ b/config/v16/config-docker.json
@@ -32,7 +32,7 @@
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true,
-        "WebsocketPingInterval": 0
+        "WebsocketPingInterval": 10
     },
     "FirmwareManagement": {
         "SupportedFileTransferProtocols": "FTP"

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1504,6 +1504,8 @@ void WebsocketLibwebsockets::on_conn_connected(ConnectionData* conn_data) {
     this->m_is_connected = true;
     this->reconnecting = false;
 
+    this->set_websocket_ping_interval(this->connection_options.ping_interval_s);
+
     // Stop any dangling reconnect
     {
         std::lock_guard<std::mutex> lk(this->reconnect_mutex);


### PR DESCRIPTION

## Describe your changes
* Fixed issue that websocket ping timer was not started when websocket is connected.
* Set default ping interval to 10s

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1: I have updated the [OCPP 2.0.1 status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_201_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

