### PR TITLE
Replace deprecated boost::asio::io_service with boost::asio::io_context

### DIFF
--- a/include/ocpp/common/charging_station_base.hpp
+++ b/include/ocpp/common/charging_station_base.hpp
@@ -19,9 +19,9 @@ protected:
     std::shared_ptr<EvseSecurity> evse_security;
     std::shared_ptr<MessageLogging> logging;
 
-    boost::shared_ptr<boost::asio::io_service::work> work;
-    boost::asio::io_service io_service;
-    std::thread io_service_thread;
+    boost::shared_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> work;
+    boost::asio::io_context io_context;
+    std::thread io_context_thread;
 
 public:
     /// \brief Constructor for ChargingStationBase

--- a/include/ocpp/v2/evse.hpp
+++ b/include/ocpp/v2/evse.hpp
@@ -156,7 +156,7 @@ public:
     /// \param trigger_metervalue_on_energy_kwh Send metervalues when this kwh is reached.
     /// \param trigger_metervalue_at_time       Send metervalues at a specific time.
     /// \param send_metervalue_function         Function used to send the metervalues.
-    /// \param io_context                       io service for the timers.
+    /// \param io_context                       io context for the timers.
     ///
     virtual void set_meter_value_pricing_triggers(
         std::optional<double> trigger_metervalue_on_power_kw, std::optional<double> trigger_metervalue_on_energy_kwh,

--- a/include/ocpp/v2/evse.hpp
+++ b/include/ocpp/v2/evse.hpp
@@ -156,13 +156,13 @@ public:
     /// \param trigger_metervalue_on_energy_kwh Send metervalues when this kwh is reached.
     /// \param trigger_metervalue_at_time       Send metervalues at a specific time.
     /// \param send_metervalue_function         Function used to send the metervalues.
-    /// \param io_service                       io service for the timers.
+    /// \param io_context                       io service for the timers.
     ///
     virtual void set_meter_value_pricing_triggers(
         std::optional<double> trigger_metervalue_on_power_kw, std::optional<double> trigger_metervalue_on_energy_kwh,
         std::optional<DateTime> trigger_metervalue_at_time,
         std::function<void(const std::vector<MeterValue>& meter_values)> send_metervalue_function,
-        boost::asio::io_service& io_service) = 0;
+        boost::asio::io_context& io_context) = 0;
 };
 
 /// \brief Represents an EVSE. An EVSE can contain multiple Connector objects, but can only supply energy to one of
@@ -186,7 +186,7 @@ private:
     std::unique_ptr<Everest::SystemTimer> trigger_metervalue_at_time_timer;
     std::optional<double> last_triggered_metervalue_power_kw;
     std::function<void(const std::vector<MeterValue>& meter_values)> send_metervalue_function;
-    boost::asio::io_service io_service;
+    boost::asio::io_context io_context;
 
     /// \brief gets the active import energy meter value from meter_value, normalized to Wh.
     std::optional<float> get_active_import_register_meter_value();
@@ -294,13 +294,13 @@ public:
     /// \param trigger_metervalue_on_energy_kwh Trigger when amount of kwh is reached
     /// \param trigger_metervalue_at_time       Trigger for a specific time
     /// \param send_metervalue_function         Function to send metervalues when trigger 'fires'
-    /// \param io_service                       Io service needed for the timer
+    /// \param io_context                       Io service needed for the timer
     ///
     void set_meter_value_pricing_triggers(
         std::optional<double> trigger_metervalue_on_power_kw, std::optional<double> trigger_metervalue_on_energy_kwh,
         std::optional<DateTime> trigger_metervalue_at_time,
         std::function<void(const std::vector<MeterValue>& meter_values)> send_metervalue_function,
-        boost::asio::io_service& io_service);
+        boost::asio::io_context& io_context);
 };
 
 } // namespace v2

--- a/include/ocpp/v2/functional_blocks/tariff_and_cost.hpp
+++ b/include/ocpp/v2/functional_blocks/tariff_and_cost.hpp
@@ -37,7 +37,7 @@ public:
     TariffAndCost(const FunctionalBlockContext& functional_block_context, MeterValuesInterface& meter_values,
                   std::optional<SetDisplayMessageCallback>& set_display_message_callback,
                   std::optional<SetRunningCostCallback>& set_running_cost_callback,
-                  boost::asio::io_service& io_service);
+                  boost::asio::io_context& io_context);
     void handle_message(const ocpp::EnhancedMessage<MessageType>& message) override;
 
     void handle_cost_and_tariff(const TransactionEventResponse& response,
@@ -49,7 +49,7 @@ private: // Members
     MeterValuesInterface& meter_values;
     std::optional<SetDisplayMessageCallback> set_display_message_callback;
     std::optional<SetRunningCostCallback> set_running_cost_callback;
-    boost::asio::io_service& io_service;
+    boost::asio::io_context& io_context;
 
 private: // Functions
     // Functional Block I: TariffAndCost

--- a/lib/ocpp/common/charging_station_base.cpp
+++ b/lib/ocpp/common/charging_station_base.cpp
@@ -17,7 +17,8 @@ ChargingStationBase::ChargingStationBase(const std::shared_ptr<EvseSecurity> evs
         }
         this->evse_security = std::make_shared<EvseSecurityImpl>(security_configuration.value());
     }
-    this->work = boost::make_shared<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(boost::asio::make_work_guard(this->io_context));
+    this->work = boost::make_shared<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
+        boost::asio::make_work_guard(this->io_context));
     this->io_context_thread = std::thread([this]() { this->io_context.run(); });
 }
 

--- a/lib/ocpp/common/charging_station_base.cpp
+++ b/lib/ocpp/common/charging_station_base.cpp
@@ -17,14 +17,14 @@ ChargingStationBase::ChargingStationBase(const std::shared_ptr<EvseSecurity> evs
         }
         this->evse_security = std::make_shared<EvseSecurityImpl>(security_configuration.value());
     }
-    this->work = boost::make_shared<boost::asio::io_service::work>(this->io_service);
-    this->io_service_thread = std::thread([this]() { this->io_service.run(); });
+    this->work = boost::make_shared<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(boost::asio::make_work_guard(this->io_context));
+    this->io_context_thread = std::thread([this]() { this->io_context.run(); });
 }
 
 ChargingStationBase::~ChargingStationBase() {
-    work->get_io_context().stop();
-    io_service.stop();
-    io_service_thread.join();
+    work->get_executor().context().stop();
+    io_context.stop();
+    io_context_thread.join();
 }
 
 } // namespace ocpp

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -50,7 +50,7 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
     message_log_path(message_log_path.string()), // .string() for compatibility with boost::filesystem
     switch_security_profile_callback(nullptr) {
     this->configuration = std::make_shared<ocpp::v16::ChargePointConfiguration>(config, share_path, user_config_path);
-    this->heartbeat_timer = std::make_unique<Everest::SteadyTimer>(&this->io_service, [this]() { this->heartbeat(); });
+    this->heartbeat_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() { this->heartbeat(); });
     this->heartbeat_interval = this->configuration->getHeartbeatInterval();
     auto database_connection =
         std::make_unique<common::DatabaseConnection>(database_path / (this->configuration->getChargePointId() + ".db"));
@@ -92,16 +92,16 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
     }
 
     this->boot_notification_timer =
-        std::make_unique<Everest::SteadyTimer>(&this->io_service, [this]() { this->boot_notification(); });
+        std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() { this->boot_notification(); });
 
     for (int32_t connector = 0; connector < this->configuration->getNumberOfConnectors() + 1; connector++) {
-        this->status_notification_timers.push_back(std::make_unique<Everest::SteadyTimer>(&this->io_service));
+        this->status_notification_timers.push_back(std::make_unique<Everest::SteadyTimer>(&this->io_context));
     }
 
     this->clock_aligned_meter_values_timer =
-        std::make_unique<ClockAlignedTimer>(&this->io_service, [this]() { this->clock_aligned_meter_values_sample(); });
+        std::make_unique<ClockAlignedTimer>(&this->io_context, [this]() { this->clock_aligned_meter_values_sample(); });
 
-    this->client_certificate_timer = std::make_unique<Everest::SteadyTimer>(&this->io_service, [this]() {
+    this->client_certificate_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() {
         EVLOG_info << "Checking if CSMS client certificate has expired";
         int expiry_days_count = this->evse_security->get_leaf_expiry_days_count(
             ocpp::CertificateSigningUseEnum::ChargingStationCertificate);
@@ -115,7 +115,7 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
         this->client_certificate_timer->interval(CLIENT_CERTIFICATE_TIMER_INTERVAL);
     });
 
-    this->v2g_certificate_timer = std::make_unique<Everest::SteadyTimer>(&this->io_service, [this]() {
+    this->v2g_certificate_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() {
         EVLOG_info << "Checking if V2GCertificate has expired";
         int expiry_days_count =
             this->evse_security->get_leaf_expiry_days_count(ocpp::CertificateSigningUseEnum::V2GCertificate);
@@ -199,7 +199,7 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
             [this](ocpp::Call<ocpp::v16::DataTransferRequest> call) {
                 this->handle_data_transfer_install_certificate(call);
             };
-        this->ocsp_request_timer = std::make_unique<Everest::SteadyTimer>(&this->io_service, [this]() {
+        this->ocsp_request_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() {
             this->update_ocsp_cache();
             this->ocsp_request_timer->interval(OCSP_REQUEST_TIMER_INTERVAL);
         });
@@ -3287,7 +3287,7 @@ void ChargePointImpl::set_connector_trigger_metervalue_timer(const DateTime& dat
     int32_t connector_id = connector->id;
 
     connector->trigger_metervalue_at_time_timer =
-        std::make_unique<Everest::SystemTimer>(&this->io_service, [this, connector_id]() {
+        std::make_unique<Everest::SystemTimer>(&this->io_context, [this, connector_id]() {
             const std::optional<MeterValue>& meter_value = get_latest_meter_value(
                 connector_id, {{Measurand::Energy_Active_Import_Register, std::nullopt}}, ReadingContext::Other);
             if (!meter_value.has_value()) {
@@ -3311,7 +3311,7 @@ void ChargePointImpl::set_time_offset_timer(const std::string& date_time) {
         return;
     }
 
-    this->change_time_offset_timer = std::make_unique<Everest::SystemTimer>(&this->io_service, [this]() {
+    this->change_time_offset_timer = std::make_unique<Everest::SystemTimer>(&this->io_context, [this]() {
         const std::optional<std::string> next_offset = this->configuration->getTimeOffsetNextTransition();
         if (next_offset.has_value()) {
             this->configuration->setDisplayTimeOffset(next_offset.value());
@@ -4157,7 +4157,7 @@ void ChargePointImpl::on_transaction_started(const int32_t& connector, const std
         this->status->submit_event(connector, FSMEvent::UsageInitiated, ocpp::DateTime());
     }
 
-    auto meter_values_sample_timer = std::make_unique<Everest::SteadyTimer>(&this->io_service, [this, connector]() {
+    auto meter_values_sample_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this, connector]() {
         const auto meter_value = this->get_latest_meter_value(
             connector, this->configuration->getMeterValuesSampledDataVector(), ReadingContext::Sample_Periodic);
         if (meter_value.has_value()) {

--- a/lib/ocpp/v2/charge_point.cpp
+++ b/lib/ocpp/v2/charge_point.cpp
@@ -547,7 +547,7 @@ void ChargePoint::initialize(const std::map<int32_t, int32_t>& evse_connector_st
 
     this->tariff_and_cost = std::make_unique<TariffAndCost>(
         *functional_block_context, *this->meter_values, this->callbacks.set_display_message_callback,
-        this->callbacks.set_running_cost_callback, this->io_service);
+        this->callbacks.set_running_cost_callback, this->io_context);
 
     this->firmware_update = std::make_unique<FirmwareUpdate>(
         *this->functional_block_context, *this->availability, *this->security,

--- a/lib/ocpp/v2/evse.cpp
+++ b/lib/ocpp/v2/evse.cpp
@@ -513,7 +513,7 @@ void Evse::set_meter_value_pricing_triggers(
     std::optional<double> trigger_metervalue_on_power_kw, std::optional<double> trigger_metervalue_on_energy_kwh,
     std::optional<DateTime> trigger_metervalue_at_time,
     std::function<void(const std::vector<MeterValue>& meter_values)> send_metervalue_function,
-    boost::asio::io_service& io_service) {
+    boost::asio::io_context& io_context) {
 
     EVLOG_debug << "Set metervalue pricing triggers: "
                 << (trigger_metervalue_at_time.has_value()
@@ -543,7 +543,7 @@ void Evse::set_meter_value_pricing_triggers(
     }
 
     // Start a timer for the trigger 'atTime'.
-    this->trigger_metervalue_at_time_timer = std::make_unique<Everest::SystemTimer>(&io_service, [this]() {
+    this->trigger_metervalue_at_time_timer = std::make_unique<Everest::SystemTimer>(&io_context, [this]() {
         EVLOG_error << "Sending metervalue in timer";
 
         const MeterValue meter_value = utils::get_meter_value_with_measurands_applied(

--- a/lib/ocpp/v2/functional_blocks/tariff_and_cost.cpp
+++ b/lib/ocpp/v2/functional_blocks/tariff_and_cost.cpp
@@ -17,12 +17,12 @@ namespace ocpp::v2 {
 TariffAndCost::TariffAndCost(const FunctionalBlockContext& functional_block_context, MeterValuesInterface& meter_values,
                              std::optional<SetDisplayMessageCallback>& set_display_message_callback,
                              std::optional<SetRunningCostCallback>& set_running_cost_callback,
-                             boost::asio::io_service& io_service) :
+                             boost::asio::io_context& io_context) :
     context(functional_block_context),
     meter_values(meter_values),
     set_display_message_callback(set_display_message_callback),
     set_running_cost_callback(set_running_cost_callback),
-    io_service(io_service) {
+    io_context(io_context) {
 }
 
 void TariffAndCost::handle_message(const ocpp::EnhancedMessage<MessageType>& message) {
@@ -250,7 +250,7 @@ void TariffAndCost::handle_costupdated_req(const Call<CostUpdatedRequest> call) 
         [this, evse_id](const std::vector<MeterValue>& meter_values) {
             this->meter_values.meter_values_req(evse_id, meter_values, false);
         },
-        this->io_service);
+        this->io_context);
 }
 
 bool TariffAndCost::is_multilanguage_enabled() const {

--- a/tests/lib/ocpp/v2/mocks/evse_mock.hpp
+++ b/tests/lib/ocpp/v2/mocks/evse_mock.hpp
@@ -45,6 +45,6 @@ public:
                  std::optional<double> trigger_metervalue_on_energy_kwh,
                  std::optional<DateTime> trigger_metervalue_at_time,
                  std::function<void(const std::vector<MeterValue>& meter_values)> send_metervalue_function,
-                 boost::asio::io_service& io_service));
+                 boost::asio::io_context& io_context));
 };
 } // namespace ocpp::v2


### PR DESCRIPTION
## Describe your changes

`boost::asio::io_service` and `boost::asio::io_service::work` is removed in boost version `1.78`.
Replace with `boost::asio::io_context` and `executor_work_guard<boost::asio::io_context::executor_type>`
Requires boost version >= `1.66`

## Issue ticket number and link

Closes https://github.com/EVerest/everest-core/issues/1072

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

