### PR TITLE
UnlockConnector refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.24.0
+    VERSION 0.24.1
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -428,13 +428,14 @@ public:
     /// \param callback
     void register_cancel_reservation_callback(const std::function<bool(int32_t reservation_id)>& callback);
 
-    /// \brief registers a \p callback function that can be used to unlock the connector. The unlock_connector_callback
-    /// is called:
+    /// \brief registers a \p callback function that can be used to unlock the connector. In case a transaction is
+    // active at the specified connector, the \p callback shall stop the it before unlocking the connector. The
+    // unlock_connector_callback is called:
     /// - when receiving a UnlockConnector.req and
     /// - when a transaction has on_transaction_stopped is called and the configuration key
     /// UnlockConnectorOnEVSideDisconnect is true
     /// \param callback
-    void register_unlock_connector_callback(const std::function<bool(int32_t connector)>& callback);
+    void register_unlock_connector_callback(const std::function<UnlockStatus(int32_t connector)>& callback);
 
     /// \brief registers a \p callback function that can be used to trigger an upload of diagnostics. This callback
     /// should trigger a process of a diagnostics upload using the given parameters of the request. This process should

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -429,7 +429,7 @@ public:
     void register_cancel_reservation_callback(const std::function<bool(int32_t reservation_id)>& callback);
 
     /// \brief registers a \p callback function that can be used to unlock the connector. In case a transaction is
-    // active at the specified connector, the \p callback shall stop the it before unlocking the connector. The
+    // active at the specified connector, the \p callback shall stop the transaction before unlocking the connector. The
     // unlock_connector_callback is called:
     /// - when receiving a UnlockConnector.req and
     /// - when a transaction has on_transaction_stopped is called and the configuration key

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -156,7 +156,7 @@ private:
     std::function<void(const std::string& id_token, std::vector<int32_t> referenced_connectors, bool prevalidated)>
         provide_token_callback;
     std::function<bool(int32_t connector, Reason reason)> stop_transaction_callback;
-    std::function<bool(int32_t connector)> unlock_connector_callback;
+    std::function<UnlockStatus(int32_t connector)> unlock_connector_callback;
     std::function<bool(int32_t connector, int32_t max_current)> set_max_current_callback;
     std::function<bool(const ResetType& reset_type)> is_reset_allowed_callback;
     std::function<void(const ResetType& reset_type)> reset_callback;
@@ -732,13 +732,14 @@ public:
     /// \param callback
     void register_cancel_reservation_callback(const std::function<bool(int32_t reservation_id)>& callback);
 
-    /// \brief registers a \p callback function that can be used to unlock the connector. The unlock_connector_callback
-    /// is called:
+    /// \brief registers a \p callback function that can be used to unlock the connector. In case a transaction is
+    // active at the specified connector, the \p callback shall stop the it before unlocking the connector. The
+    // unlock_connector_callback is called:
     /// - when receiving a UnlockConnector.req and
     /// - when a transaction has on_transaction_stopped is called and the configuration key
     /// UnlockConnectorOnEVSideDisconnect is true
     /// \param callback
-    void register_unlock_connector_callback(const std::function<bool(int32_t connector)>& callback);
+    void register_unlock_connector_callback(const std::function<UnlockStatus(int32_t connector)>& callback);
 
     /// \brief registers a \p callback function that can be used to trigger an upload of diagnostics. This callback
     /// should trigger a process of a diagnostics upload using the given parameters of the request. This process should

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -733,7 +733,7 @@ public:
     void register_cancel_reservation_callback(const std::function<bool(int32_t reservation_id)>& callback);
 
     /// \brief registers a \p callback function that can be used to unlock the connector. In case a transaction is
-    // active at the specified connector, the \p callback shall stop the it before unlocking the connector. The
+    // active at the specified connector, the \p callback shall stop the transaction before unlocking the connector. The
     // unlock_connector_callback is called:
     /// - when receiving a UnlockConnector.req and
     /// - when a transaction has on_transaction_stopped is called and the configuration key

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -230,7 +230,7 @@ void ChargePoint::register_cancel_reservation_callback(const std::function<bool(
     this->charge_point->register_cancel_reservation_callback(callback);
 }
 
-void ChargePoint::register_unlock_connector_callback(const std::function<bool(int32_t connector)>& callback) {
+void ChargePoint::register_unlock_connector_callback(const std::function<UnlockStatus(int32_t connector)>& callback) {
     this->charge_point->register_unlock_connector_callback(callback);
 }
 

--- a/src/charge_point.cpp
+++ b/src/charge_point.cpp
@@ -195,7 +195,7 @@ int main(int argc, char* argv[]) {
     charge_point->register_unlock_connector_callback([](int32_t connector) {
         std::cout << "Callback: "
                   << "Unlock connector#" << connector;
-        return true;
+        return ocpp::v16::UnlockStatus::Unlocked;
     });
 
     charge_point->register_upload_diagnostics_callback([](const ocpp::v16::GetDiagnosticsRequest& request) {


### PR DESCRIPTION
## Describe your changes
Refactored unlock_connector_callback for OCPP1.6:
* Callback must now return UnlockStatus instead of bool, because bool could not transmit enough information
* Within the UnlockConnector handler, stop_transaction_callback . This callback shall be responsible for this

## Issue ticket number and link
Companion PR in everest-core: https://github.com/EVerest/everest-core/pull/1078

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

