### PR TITLE
fix(Ocpp16): Make StopTransactionOnEVSideDisconnect optional

### DIFF
--- a/config/v16/config-docker-tls.json
+++ b/config/v16/config-docker-tls.json
@@ -21,7 +21,6 @@
         "MeterValueSampleInterval": 0,
         "NumberOfConnectors": 1,
         "ResetRetries": 1,
-        "StopTransactionOnEVSideDisconnect": true,
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",

--- a/config/v16/config-docker.json
+++ b/config/v16/config-docker.json
@@ -24,7 +24,6 @@
         "MeterValueSampleInterval": 60,
         "NumberOfConnectors": 1,
         "ResetRetries": 1,
-        "StopTransactionOnEVSideDisconnect": true,
         "StopTransactionOnInvalidId": true,
         "StopTxnAlignedData": "Energy.Active.Import.Register",
         "StopTxnSampledData": "Energy.Active.Import.Register",

--- a/config/v16/profile_schemas/Core.json
+++ b/config/v16/profile_schemas/Core.json
@@ -133,7 +133,7 @@
         },
         "StopTransactionOnEVSideDisconnect": {
             "type": "boolean",
-            "readOnly": false
+            "readOnly": true
         },
         "StopTransactionOnInvalidId": {
             "type": "boolean",

--- a/config/v16/profile_schemas/Core.json
+++ b/config/v16/profile_schemas/Core.json
@@ -16,7 +16,6 @@
         "MeterValueSampleInterval",
         "NumberOfConnectors",
         "ResetRetries",
-        "StopTransactionOnEVSideDisconnect",
         "StopTransactionOnInvalidId",
         "StopTxnAlignedData",
         "StopTxnSampledData",

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -271,10 +271,9 @@ public:
     void setResetRetries(int32_t retries);
     KeyValue getResetRetriesKeyValue();
 
-    // Core Profile
-    bool getStopTransactionOnEVSideDisconnect();
-    void setStopTransactionOnEVSideDisconnect(bool stop_transaction_on_ev_side_disconnect);
-    KeyValue getStopTransactionOnEVSideDisconnectKeyValue();
+    // Core Profile - optional
+    std::optional<bool> getStopTransactionOnEVSideDisconnect();
+    std::optional<KeyValue> getStopTransactionOnEVSideDisconnectKeyValue();
 
     // Core Profile
     bool getStopTransactionOnInvalidId();

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -1560,7 +1560,7 @@ KeyValue ChargePointConfiguration::getResetRetriesKeyValue() {
     return kv;
 }
 
-// Core Profile
+// Core Profile - optional
 std::optional<bool> ChargePointConfiguration::getStopTransactionOnEVSideDisconnect() {
     std::optional<bool> stop_transaction_on_ev_side_disconnect = std::nullopt;
     if (this->config["Core"].contains("StopTransactionOnEVSideDisconnect")) {
@@ -1570,7 +1570,7 @@ std::optional<bool> ChargePointConfiguration::getStopTransactionOnEVSideDisconne
 }
 std::optional<KeyValue> ChargePointConfiguration::getStopTransactionOnEVSideDisconnectKeyValue() {
     std::optional<KeyValue> stop_transaction_on_ev_side_disconnect_kv = std::nullopt;
-    auto stop_transaction_on_ev_side_disconnect = this->getSupportedFeatureProfilesMaxLength();
+    auto stop_transaction_on_ev_side_disconnect = this->getStopTransactionOnEVSideDisconnect();
     if (stop_transaction_on_ev_side_disconnect != std::nullopt) {
         KeyValue kv;
         kv.key = "StopTransactionOnEVSideDisconnect";
@@ -3652,13 +3652,6 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
         } catch (const std::invalid_argument& e) {
             return ConfigurationStatus::Rejected;
         } catch (const std::out_of_range& e) {
-            return ConfigurationStatus::Rejected;
-        }
-    }
-    if (key == "StopTransactionOnEVSideDisconnect") {
-        if (this->getStopTransactionOnEVSideDisconnect() == std::nullopt) {
-            return ConfigurationStatus::NotSupported;
-        } else {
             return ConfigurationStatus::Rejected;
         }
     }

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -3656,8 +3656,8 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
         }
     }
     if (key == "StopTransactionOnEVSideDisconnect") {
-        if (isBool(value.get())) {
-            this->setStopTransactionOnEVSideDisconnect(ocpp::conversions::string_to_bool(value.get()));
+        if (this->getStopTransactionOnEVSideDisconnect() == std::nullopt) {
+            return ConfigurationStatus::NotSupported;
         } else {
             return ConfigurationStatus::Rejected;
         }

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -1561,19 +1561,24 @@ KeyValue ChargePointConfiguration::getResetRetriesKeyValue() {
 }
 
 // Core Profile
-bool ChargePointConfiguration::getStopTransactionOnEVSideDisconnect() {
-    return this->config["Core"]["StopTransactionOnEVSideDisconnect"];
+std::optional<bool> ChargePointConfiguration::getStopTransactionOnEVSideDisconnect() {
+    std::optional<bool> stop_transaction_on_ev_side_disconnect = std::nullopt;
+    if (this->config["Core"].contains("StopTransactionOnEVSideDisconnect")) {
+        stop_transaction_on_ev_side_disconnect.emplace(this->config["Core"]["StopTransactionOnEVSideDisconnect"]);
+    }
+    return stop_transaction_on_ev_side_disconnect;
 }
-void ChargePointConfiguration::setStopTransactionOnEVSideDisconnect(bool stop_transaction_on_ev_side_disconnect) {
-    this->config["Core"]["StopTransactionOnEVSideDisconnect"] = stop_transaction_on_ev_side_disconnect;
-    this->setInUserConfig("Core", "StopTransactionOnEVSideDisconnect", stop_transaction_on_ev_side_disconnect);
-}
-KeyValue ChargePointConfiguration::getStopTransactionOnEVSideDisconnectKeyValue() {
-    KeyValue kv;
-    kv.key = "StopTransactionOnEVSideDisconnect";
-    kv.readonly = false;
-    kv.value.emplace(ocpp::conversions::bool_to_string(this->getStopTransactionOnEVSideDisconnect()));
-    return kv;
+std::optional<KeyValue> ChargePointConfiguration::getStopTransactionOnEVSideDisconnectKeyValue() {
+    std::optional<KeyValue> stop_transaction_on_ev_side_disconnect_kv = std::nullopt;
+    auto stop_transaction_on_ev_side_disconnect = this->getSupportedFeatureProfilesMaxLength();
+    if (stop_transaction_on_ev_side_disconnect != std::nullopt) {
+        KeyValue kv;
+        kv.key = "StopTransactionOnEVSideDisconnect";
+        kv.readonly = true;
+        kv.value.emplace(ocpp::conversions::bool_to_string(stop_transaction_on_ev_side_disconnect.value()));
+        stop_transaction_on_ev_side_disconnect_kv.emplace(kv);
+    }
+    return stop_transaction_on_ev_side_disconnect_kv;
 }
 
 // Core Profile


### PR DESCRIPTION
This configuration key is now made optional due to newer erratas. Additionally, the value is not supported so it is now set to true by default.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ x ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ x ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

Closes #1012