### PR TITLE
Respond with to ChangeAvailability with Scheduled when in Preparing state 

### DIFF
--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -361,24 +361,28 @@ private:
     ///
     void set_time_offset_timer(const std::string& date_time);
 
-    // //brief Preprocess a ChangeAvailabilityRequest: Determine response;
-    // - if connector is 0, availability change is also propagated for all connectors
-    // - for each connector (except "0"), if transaction is ongoing the change is scheduled,
-    //    otherwise the OCPP connector id is appended to the `accepted_connector_availability_changes` vector
+    /// \brief Preprocess a ChangeAvailabilityRequest: Determine response;
+    /// - if connector is 0, availability change is also propagated for all connectors
+    /// - for each connector (except "0"), if transaction is ongoing the change is scheduled,
+    ///    otherwise the OCPP connector id is appended to the `accepted_connector_availability_changes` vector
     void preprocess_change_availability_request(const ChangeAvailabilityRequest& request,
                                                 ChangeAvailabilityResponse& response,
                                                 std::vector<int32_t>& accepted_connector_availability_changes);
 
-    // \brief TExecutes availability change for the provided connectors:
-    // - if persist == true: store availability in database
-    // - submit state event (for the whole ChargePoint if "0" in set of connectors; otherwise for each connector
-    // individually)
-    // - call according EVSE enable or disable callback, respectively
+    /// \brief Executes availability change for the provided connectors:
+    /// - if persist == true: store availability in database
+    /// - submit state event (for the whole ChargePoint if "0" in set of connectors; otherwise for each connector
+    /// individually)
+    /// - call according EVSE enable or disable callback, respectively
     /// \param changed_connectors list of OCPP connector ids (and 0 for whole chargepoint)
     /// \param availability new availabillity
     /// \param persist if true, persists availability in database
     void execute_connectors_availability_change(const std::vector<int32_t>& changed_connectors,
                                                 const ocpp::v16::AvailabilityType availability, bool persist);
+
+    /// \brief Checks scheduled availability queue and exeuctues availability change if required
+    /// \param connector for which availability change shall be checked and executed
+    void execute_queued_availability_change(const int32_t connector);
 
 public:
     /// \brief The main entrypoint for libOCPP for OCPP 1.6

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1645,19 +1645,23 @@ void ChargePointImpl::preprocess_change_availability_request(
     std::vector<int32_t>& accepted_connector_availability_changes) {
 
     // we can only change the connector availability if there is no active transaction on this
-    // connector. is that case this change must be scheduled and we should report an availability status
-    // of "Scheduled"
+    // connector or the connector is not in Preparing state. If this is the case this change must be scheduled and we
+    // should report an availability status of "Scheduled"
+    auto should_be_scheduled_func = [this](int32_t connector) {
+        return this->transaction_handler->transaction_active(connector) or
+               this->status->get_state(connector) == ChargePointStatus::Preparing;
+    };
 
     // check if connector exists
     if (request.connectorId <= this->configuration->getNumberOfConnectors() && request.connectorId >= 0) {
-        bool transaction_running = false;
+        bool should_be_scheduled = false;
 
         if (request.connectorId == 0) {
             accepted_connector_availability_changes.push_back(0);
             int32_t number_of_connectors = this->configuration->getNumberOfConnectors();
             for (int32_t connector = 1; connector <= number_of_connectors; connector++) {
-                if (this->transaction_handler->transaction_active(connector)) {
-                    transaction_running = true;
+                if (should_be_scheduled_func(connector)) {
+                    should_be_scheduled = true;
                     std::lock_guard<std::mutex> change_availability_lock(change_availability_mutex);
                     this->change_availability_queue[connector] = {request.type, true};
                 } else {
@@ -1665,8 +1669,8 @@ void ChargePointImpl::preprocess_change_availability_request(
                 }
             }
         } else {
-            if (this->transaction_handler->transaction_active(request.connectorId)) {
-                transaction_running = true;
+            if (should_be_scheduled_func(request.connectorId)) {
+                should_be_scheduled = true;
                 std::lock_guard<std::mutex> change_availability_lock(change_availability_mutex);
                 this->change_availability_queue[request.connectorId] = {request.type, true};
             } else {
@@ -1679,7 +1683,7 @@ void ChargePointImpl::preprocess_change_availability_request(
             this->database_handler->insert_or_update_connector_availability(connector, availabilityChange.availability);
         }
 
-        if (transaction_running) {
+        if (should_be_scheduled) {
             response.status = AvailabilityStatus::Scheduled;
         } else {
             response.status = AvailabilityStatus::Accepted;
@@ -1718,6 +1722,25 @@ void ChargePointImpl::execute_connectors_availability_change(const std::vector<i
                 this->disable_evse_callback(connector);
             }
         }
+    }
+}
+
+void ChargePointImpl::execute_queued_availability_change(const int32_t connector) {
+    bool change_queued = false;
+    AvailabilityType connector_availability;
+    bool persist = false;
+    {
+        std::lock_guard<std::mutex> change_availability_lock(change_availability_mutex);
+        change_queued = this->change_availability_queue.count(connector) != 0;
+        connector_availability = this->change_availability_queue[connector].availability;
+        persist = this->change_availability_queue[connector].persist;
+        this->change_availability_queue.erase(connector);
+    }
+
+    if (change_queued) {
+        EVLOG_debug << "Queued availability change of connector " << connector << " to "
+                    << conversions::availability_type_to_string(connector_availability);
+        execute_connectors_availability_change({connector}, connector_availability, persist);
     }
 }
 
@@ -2261,22 +2284,7 @@ void ChargePointImpl::handleStopTransactionResponse(const EnhancedMessage<v16::M
         }
 
         // perform a queued connector availability change
-        bool change_queued = false;
-        AvailabilityType connector_availability;
-        bool persist = false;
-        {
-            std::lock_guard<std::mutex> change_availability_lock(change_availability_mutex);
-            change_queued = this->change_availability_queue.count(connector) != 0;
-            connector_availability = this->change_availability_queue[connector].availability;
-            persist = this->change_availability_queue[connector].persist;
-            this->change_availability_queue.erase(connector);
-        }
-
-        if (change_queued) {
-            EVLOG_debug << "Queued availability change of connector " << connector << " to "
-                        << conversions::availability_type_to_string(connector_availability);
-            execute_connectors_availability_change({connector}, connector_availability, persist);
-        }
+        this->execute_queued_availability_change(connector);
     } else {
         EVLOG_warning << "Received StopTransaction.conf for transaction that is not known to transaction_handler";
     }
@@ -4129,6 +4137,8 @@ void ChargePointImpl::on_session_started(int32_t connector, const std::string& s
 }
 
 void ChargePointImpl::on_session_stopped(const int32_t connector, const std::string& session_id) {
+    this->execute_queued_availability_change(connector);
+
     if (this->status->get_state(connector) != ChargePointStatus::Reserved &&
         this->status->get_state(connector) != ChargePointStatus::Unavailable) {
         this->status->submit_event(connector, FSMEvent::BecomeAvailable, ocpp::DateTime());

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1649,7 +1649,8 @@ void ChargePointImpl::preprocess_change_availability_request(
     // should report an availability status of "Scheduled"
     auto should_be_scheduled_func = [this](int32_t connector) {
         return this->transaction_handler->transaction_active(connector) or
-               this->status->get_state(connector) == ChargePointStatus::Preparing;
+               this->status->get_state(connector) == ChargePointStatus::Preparing or
+               this->status->get_state(connector) == ChargePointStatus::Reserved;
     };
 
     // check if connector exists
@@ -4618,6 +4619,7 @@ void ChargePointImpl::on_reservation_start(int32_t connector) {
 }
 
 void ChargePointImpl::on_reservation_end(int32_t connector) {
+    this->execute_queued_availability_change(connector);
     this->status->submit_event(connector, FSMEvent::ReservationEnd, ocpp::DateTime());
 }
 


### PR DESCRIPTION

## Describe your changes
This change changes the behavior of the ChangeAvailability handler. It will now also respond with Scheduled and schedule the change availability request in case the connector is in the status Preparing.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

