### PR TITLE
StopTransactionIfUnlockNotSupported configuration key

### DIFF
--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -355,6 +355,12 @@
             "type": "boolean",
             "readOnly": true,
             "default": false
+        },
+        "StopTransactionIfUnlockNotSupported": {
+            "$comment": "If true, a transaction is stopped on an Unlock.req even if unlocking is not supported",
+            "type": "boolean",
+            "readOnly": false,
+            "default": false
         }
     },
     "additionalProperties": false

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -124,6 +124,10 @@ public:
     bool getEnableTLSKeylog();
     std::string getTLSKeylogFile();
 
+    bool getStopTransactionIfUnlockNotSupported();
+    void setStopTransactionIfUnlockNotSupported(bool stop_transaction_if_unlock_not_supported);
+    KeyValue getStopTransactionIfUnlockNotSupportedKeyValue();
+
     int32_t getRetryBackoffRandomRange();
     void setRetryBackoffRandomRange(int32_t retry_backoff_random_range);
     KeyValue getRetryBackoffRandomRangeKeyValue();

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -825,6 +825,23 @@ std::string ChargePointConfiguration::getTLSKeylogFile() {
     return this->config["Internal"]["TLSKeylogFile"];
 }
 
+bool ChargePointConfiguration::getStopTransactionIfUnlockNotSupported() {
+    return this->config["Internal"]["StopTransactionIfUnlockNotSupported"];
+}
+
+void ChargePointConfiguration::setStopTransactionIfUnlockNotSupported(bool stop_transaction_if_unlock_not_supported) {
+    this->config["Internal"]["StopTransactionIfUnlockNotSupported"] = stop_transaction_if_unlock_not_supported;
+    this->setInUserConfig("Internal", "StopTransactionIfUnlockNotSupported", stop_transaction_if_unlock_not_supported);
+}
+
+KeyValue ChargePointConfiguration::getStopTransactionIfUnlockNotSupportedKeyValue() {
+    KeyValue kv;
+    kv.key = "StopTransactionIfUnlockNotSupported";
+    kv.readonly = false;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getStopTransactionIfUnlockNotSupported()));
+    return kv;
+}
+
 KeyValue ChargePointConfiguration::getWebsocketPingPayloadKeyValue() {
     KeyValue kv;
     kv.key = "WebsocketPingPayload";
@@ -3121,6 +3138,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     if (key == "MessageQueueSizeThreshold") {
         return this->getMessageQueueSizeThresholdKeyValue();
     }
+    if (key == "StopTransactionIfUnlockNotSupported") {
+        return this->getStopTransactionIfUnlockNotSupportedKeyValue();
+    }
 
     // Core Profile
     if (key == "AllowOfflineTxForUnknownId") {
@@ -3720,6 +3740,13 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
         } catch (const std::invalid_argument& e) {
             return ConfigurationStatus::Rejected;
         } catch (const std::out_of_range& e) {
+            return ConfigurationStatus::Rejected;
+        }
+    }
+    if (key == "StopTransactionIfUnlockNotSupported") {
+        if (isBool(value.get())) {
+            this->setStopTransactionIfUnlockNotSupported(ocpp::conversions::string_to_bool(value.get()));
+        } else {
             return ConfigurationStatus::Rejected;
         }
     }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2316,6 +2316,11 @@ void ChargePointImpl::handleUnlockConnectorRequest(ocpp::Call<UnlockConnectorReq
 
     ocpp::CallResult<UnlockConnectorResponse> call_result(response, call.uniqueId);
     this->message_dispatcher->dispatch_call_result(call_result);
+
+    if (response.status == UnlockStatus::NotSupported and this->transaction_handler->transaction_active(connector) and
+        this->configuration->getStopTransactionIfUnlockNotSupported()) {
+        this->stop_transaction_callback(connector, Reason::UnlockCommand);
+    }
 }
 
 void ChargePointImpl::handleHeartbeatResponse(CallResult<HeartbeatResponse> call_result) {


### PR DESCRIPTION

## Describe your changes
The OCPP1.6 specification leaves it open if a transaction shall still be stopped if the response to UnlockConnector is `NotSupported`. To allow both options, this PR adds a configuration key `StopTransactionIfUnlockNotSupported`. If its configured to true, a transaction is stopped even if the response to the UnlockConnector is NotSupported. 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

