### PR TITLE
Refactored OCPP1.6 error cleared handling

### DIFF
--- a/lib/ocpp/v16/charge_point_state_machine.cpp
+++ b/lib/ocpp/v16/charge_point_state_machine.cpp
@@ -227,6 +227,11 @@ bool ChargePointFSM::handle_error(const ErrorInfo& error_info) {
 }
 
 bool ChargePointFSM::handle_error_cleared(const std::string uuid) {
+    // dont do anything if the error is unknown
+    if (this->active_errors.find(uuid) == this->active_errors.end()) {
+        return false;
+    }
+
     this->active_errors.erase(uuid);
 
     // dont report StatusNotification if still "Faulted"
@@ -234,14 +239,26 @@ bool ChargePointFSM::handle_error_cleared(const std::string uuid) {
         return false;
     }
 
-    // dont report StatusNotification if errors are still active
+    // defaults if no errors are active anymore
+    ChargePointErrorCode error_code = ChargePointErrorCode::NoError;
+    std::optional<CiString<50>> info;
+    std::optional<CiString<255>> vendor_id;
+    std::optional<CiString<50>> vendor_error_code;
+
+    // report the latest error if there are still errors active
     if (this->active_errors.size() > 0) {
-        return false;
+        const auto latest_error_opt = this->get_latest_error();
+        if (latest_error_opt.has_value()) {
+            const auto latest_error = latest_error_opt.value();
+            error_code = latest_error.error_code;
+            info = latest_error.info;
+            vendor_id = latest_error.vendor_id;
+            vendor_error_code = latest_error.vendor_error_code;
+        }
     }
 
-    // no fault present and no error active, so we can send a StatusNotification.req and return to previous state
-    status_notification_callback(this->state, ChargePointErrorCode::NoError, DateTime(), std::nullopt, std::nullopt,
-                                 std::nullopt);
+    // Send a StatusNotification.req
+    status_notification_callback(this->state, error_code, DateTime(), info, vendor_id, vendor_error_code);
 
     return true;
 }


### PR DESCRIPTION

## Describe your changes
Refactored OCPP1.6 state machine error cleared handling. If an error is cleared and the charging station is not faulted anymore, it will report the last active (informational) error or return back to its previous state. Before this change, all error had to be cleared in order to move away from Faulted

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

