### PR TITLE
fix(v16): Adding / removing connector id 0 default profiles

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2386,6 +2386,8 @@ void ChargePointImpl::handleSetChargingProfileRequest(ocpp::Call<SetChargingProf
         // existing charging profile, otherwise it SHALL be added.
         this->smart_charging_handler->clear_all_profiles_with_filter(profile.chargingProfileId, std::nullopt,
                                                                      std::nullopt, std::nullopt, true);
+        this->smart_charging_handler->clear_all_profiles_with_filter(std::nullopt, connector_id, profile.stackLevel,
+                                                                     profile.chargingProfilePurpose, false);
         if (profile.chargingProfilePurpose == ChargingProfilePurposeType::ChargePointMaxProfile) {
             this->smart_charging_handler->add_charge_point_max_profile(profile);
         } else if (profile.chargingProfilePurpose == ChargingProfilePurposeType::TxDefaultProfile) {

--- a/lib/ocpp/v16/smart_charging.cpp
+++ b/lib/ocpp/v16/smart_charging.cpp
@@ -275,19 +275,15 @@ void SmartChargingHandler::add_tx_default_profile(const ChargingProfile& profile
     if (connector_id == 0) {
         for (size_t id = 1; id <= this->connectors.size() - 1; id++) {
             this->connectors.at(id)->stack_level_tx_default_profiles_map[profile.stackLevel] = profile;
-            try {
-                this->database_handler->insert_or_update_charging_profile(connector_id, profile);
-            } catch (const QueryExecutionException& e) {
-                EVLOG_warning << "Could not store TxDefaultProfile in the database: " << e.what();
-            }
         }
     } else {
         this->connectors.at(connector_id)->stack_level_tx_default_profiles_map[profile.stackLevel] = profile;
-        try {
-            this->database_handler->insert_or_update_charging_profile(connector_id, profile);
-        } catch (const QueryExecutionException& e) {
-            EVLOG_warning << "Could not store TxDefaultProfile in the database: " << e.what();
-        }
+    }
+    try {
+        this->database_handler->insert_or_update_charging_profile(connector_id, profile);
+    } catch (const QueryExecutionException& e) {
+        EVLOG_warning << "Could not store TxDefaultProfile for connector id " << connector_id
+                      << " in the database: " << e.what();
     }
 }
 


### PR DESCRIPTION
There were discrepancies between the in memory and the database's versions of the list of profiles. This has been fixed by only adding to the DB once for connector id 0 and before adding we remove any combination of connector id and stack level and purpose that is the same.

## Describe your changes

In the handle set charging profile, I updated the functionality to mirror what is written in comment aka delete by id, then delete by combination of stack level + purpose + connector id. Then I simplified the calls to the database handler in the add_tx_default_profile.

## Issue ticket number and link

fixes #978 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

