### PR TITLE
Reserved -> Occupied transition in OCPP2.0.1

### DIFF
--- a/lib/ocpp/v2/charge_point.cpp
+++ b/lib/ocpp/v2/charge_point.cpp
@@ -193,6 +193,11 @@ void ChargePoint::on_transaction_started(
     const TriggerReasonEnum trigger_reason, const MeterValue& meter_start, const std::optional<IdToken>& id_token,
     const std::optional<IdToken>& group_id_token, const std::optional<int32_t>& reservation_id,
     const std::optional<int32_t>& remote_start_id, const ChargingStateEnum charging_state) {
+
+    // This allows us to move from "Reserved" to "Occupied". We dont need to check if a reservation was placed since if
+    // a transaction starts, it is always consumed and just sets the reserved flag to false and triggers a
+    // StatusNotifcation. It does not trigger a StatusNotification when already in "Occupied"
+    this->reservation->on_reservation_cleared(evse_id, connector_id);
     this->transaction->on_transaction_started(evse_id, connector_id, session_id, timestamp, trigger_reason, meter_start,
                                               id_token, group_id_token, reservation_id, remote_start_id,
                                               charging_state);


### PR DESCRIPTION

## Describe your changes
Calling reservation cleared when a transaction starts. Allows the state machine to move from Reserved to Occupied when transactions start. Changes are required because of this change in everest-core: 
https://github.com/EVerest/everest-core/pull/1108

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

