### PR TITLE
Add helpers to set charge point common data

### DIFF
--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -81,6 +81,11 @@ public:
     /// @}  // End constructors 1.6 group
     /// @}  // End chargepoint constructors topic
 
+    /// \brief Allow to update the ChargePoint information which will be sent in BootNotification.req
+    void update_chargepoint_information(const std::string& chargepoint_vendor, const std::string& chargepoint_model,
+                                        const std::string& chargepoint_serialnumber,
+                                        const std::optional<std::string>& firmware_version);
+
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint and initializes a
     /// BootNotification.req
     /// \param connector_status_map initial state of connectors including connector 0 with reduced set of states

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -43,7 +43,9 @@ private:
 public:
     ChargePointConfiguration(const std::string& config, const fs::path& ocpp_main_path,
                              const fs::path& user_config_path);
-
+    void setChargepointInformation(const std::string& chargePointVendor, const std::string& chargePointModel,
+                                   const std::string& chargePointSerialNumber,
+                                   const std::optional<std::string>& FirmwareVersion);
     // Internal config options
     std::string getChargePointId();
     KeyValue getChargePointIdKeyValue();

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -412,6 +412,11 @@ public:
     ~ChargePointImpl() {
     }
 
+    /// \brief Allow to update the ChargePoint information which will be sent in BootNotification.req
+    void update_chargepoint_information(const std::string& chargepoint_vendor, const std::string& chargepoint_model,
+                                        const std::string& chargepoint_serialnumber,
+                                        const std::optional<std::string>& firmware_version);
+
     /// \brief Starts the ChargePoint, initializes and connects to the Websocket endpoint and initializes a
     /// BootNotification.req
     /// \param connector_status_map initial state of connectors including connector 0 with reduced set of states

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -21,6 +21,14 @@ ChargePoint::ChargePoint(const std::string& config, const fs::path& share_path, 
 
 ChargePoint::~ChargePoint() = default;
 
+void ChargePoint::update_chargepoint_information(const std::string& chargepoint_vendor,
+                                                 const std::string& chargepoint_model,
+                                                 const std::string& chargepoint_serialnumber,
+                                                 const std::optional<std::string>& firmware_version) {
+    this->charge_point->update_chargepoint_information(chargepoint_vendor, chargepoint_model, chargepoint_serialnumber,
+                                                       firmware_version);
+}
+
 bool ChargePoint::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason,
                         const std::set<std::string>& resuming_session_ids) {
     return this->charge_point->start(connector_status_map, bootreason, resuming_session_ids);

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -262,6 +262,18 @@ void ChargePointConfiguration::init_supported_measurands() {
     }
 }
 
+void ChargePointConfiguration::setChargepointInformation(const std::string& chargePointVendor,
+                                                         const std::string& chargePointModel,
+                                                         const std::string& chargePointSerialNumber,
+                                                         const std::optional<std::string>& firmwareVersion) {
+    this->config["Internal"]["ChargePointVendor"] = chargePointVendor;
+    this->config["Internal"]["ChargePointModel"] = chargePointModel;
+    this->config["Internal"]["ChargePointSerialNumber"] = chargePointSerialNumber;
+    if (firmwareVersion.has_value()) {
+        this->config["Internal"]["FirmwareVersion"] = firmwareVersion.value();
+    }
+}
+
 // Internal config options
 std::string ChargePointConfiguration::getChargePointId() {
     return this->config["Internal"]["ChargePointId"];

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1083,6 +1083,14 @@ void ChargePointImpl::reset_pricing_triggers(const int32_t connector_number) {
     }
 }
 
+void ChargePointImpl::update_chargepoint_information(const std::string& chargepoint_vendor,
+                                                     const std::string& chargepoint_model,
+                                                     const std::string& chargepoint_serialnumber,
+                                                     const std::optional<std::string>& firmware_version) {
+    this->configuration->setChargepointInformation(chargepoint_vendor, chargepoint_model, chargepoint_serialnumber,
+                                                   firmware_version);
+}
+
 bool ChargePointImpl::start(const std::map<int, ChargePointStatus>& connector_status_map, BootReasonEnum bootreason,
                             const std::set<std::string>& resuming_session_ids) {
     this->message_queue->start();


### PR DESCRIPTION
## Describe your changes

The idea is to overwrite this data later, for example if other data sources are available than those available at the time of initialization. This PR adds the required helper methods for the OCPP 1.6 implementation.

Note: since I currently only have a OCPP 1.6 test environment at hand and my knowledge about OCPP 2.x is still limited, help with OCPP 2.x part would be welcome.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

