### PR TITLE
Addressed added argument to libevse-security for verify_certificate

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -27,10 +27,10 @@ date:
   options: ["BUILD_TZ_LIB ON", "HAS_REMOTE_API 0", "USE_AUTOLOAD 0", "USE_SYSTEM_TZ_DB ON"]
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.9.3
+  git_tag: v0.9.5
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
-  git_tag: v4.3.3  
+  git_tag: v4.3.3
   options:
     - CMAKE_POLICY_DEFAULT_CMP0077 NEW
     - LWS_ROLE_RAW_FILE OFF

--- a/include/ocpp/common/evse_security.hpp
+++ b/include/ocpp/common/evse_security.hpp
@@ -49,6 +49,15 @@ public:
     virtual CertificateValidationResult verify_certificate(const std::string& certificate_chain,
                                                            const LeafCertificateType& certificate_type) = 0;
 
+    /// \brief Verifies the given \p certificate_chain against the respective CA
+    /// trust anchors (indicated by the given \p certificate_types) for the leaf.
+    /// \param certificate_chain PEM formatted certificate or certificate chain
+    /// \param certificate_types types of the root certificates for which the chain is verified
+    /// \return result of the operation
+    virtual CertificateValidationResult
+    verify_certificate(const std::string& certificate_chain,
+                       const std::vector<LeafCertificateType>& certificate_types) = 0;
+
     /// \brief Retrieves all certificates installed on the filesystem applying the \p certificate_types filter. This
     /// function respects the requirements of OCPP specified for the CSMS initiated message
     /// GetInstalledCertificateIds.req .

--- a/include/ocpp/common/evse_security_impl.hpp
+++ b/include/ocpp/common/evse_security_impl.hpp
@@ -41,6 +41,8 @@ public:
                                                      const CertificateSigningUseEnum& certificate_type) override;
     CertificateValidationResult verify_certificate(const std::string& certificate_chain,
                                                    const LeafCertificateType& certificate_type) override;
+    CertificateValidationResult verify_certificate(const std::string& certificate_chain,
+                                                   const std::vector<LeafCertificateType>& certificate_types) override;
     std::vector<CertificateHashDataChain>
     get_installed_certificates(const std::vector<CertificateType>& certificate_types) override;
     std::vector<OCSPRequestData> get_v2g_ocsp_request_data() override;

--- a/lib/ocpp/common/evse_security_impl.cpp
+++ b/lib/ocpp/common/evse_security_impl.cpp
@@ -47,6 +47,18 @@ CertificateValidationResult EvseSecurityImpl::verify_certificate(const std::stri
         this->evse_security->verify_certificate(certificate_chain, conversions::from_ocpp(certificate_type)));
 }
 
+CertificateValidationResult
+EvseSecurityImpl::verify_certificate(const std::string& certificate_chain,
+                                     const std::vector<LeafCertificateType>& certificate_types) {
+    std::vector<evse_security::LeafCertificateType> _certificate_types;
+
+    for (const auto& certificate_type : certificate_types) {
+        _certificate_types.push_back(conversions::from_ocpp(certificate_type));
+    }
+
+    return conversions::to_ocpp(this->evse_security->verify_certificate(certificate_chain, _certificate_types));
+}
+
 std::vector<CertificateHashDataChain>
 EvseSecurityImpl::get_installed_certificates(const std::vector<CertificateType>& certificate_types) {
     std::vector<CertificateHashDataChain> result;

--- a/tests/lib/ocpp/common/evse_security_mock.hpp
+++ b/tests/lib/ocpp/common/evse_security_mock.hpp
@@ -20,6 +20,8 @@ public:
                 (const std::string&, const CertificateSigningUseEnum&), (override));
     MOCK_METHOD(CertificateValidationResult, verify_certificate, (const std::string&, const LeafCertificateType&),
                 (override));
+    MOCK_METHOD(CertificateValidationResult, verify_certificate,
+                (const std::string&, const std::vector<LeafCertificateType>&), (override));
     MOCK_METHOD(std::vector<CertificateHashDataChain>, get_installed_certificates,
                 (const std::vector<CertificateType>&), (override));
     MOCK_METHOD(std::vector<OCSPRequestData>, get_v2g_ocsp_request_data, (), (override));

--- a/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
+++ b/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
@@ -30,6 +30,8 @@ using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::Throw;
 
+const ocpp::LeafCertificateType DEFAULT_LEAF_CERT_TYPE = ocpp::LeafCertificateType::MO;
+
 class AuthorizationTest : public ::testing::Test {
 public:
 protected: // Members
@@ -633,7 +635,7 @@ TEST_F(AuthorizationTest, validate_token_emaid_offline_no_certificate_contract_v
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(false));
     // And offline contract validation is not allowed.
     this->set_allow_contract_validation_offline(this->device_model, false);
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
 
     IdToken id_token;
@@ -654,7 +656,7 @@ TEST_F(
     // And offline contract validation is not allowed.
     this->set_allow_contract_validation_offline(this->device_model, true);
     this->set_local_authorize_offline(this->device_model, false);
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
 
     IdToken id_token;
@@ -677,7 +679,7 @@ TEST_F(
     this->set_allow_contract_validation_offline(this->device_model, true);
     this->set_local_authorize_offline(this->device_model, true);
     this->set_local_auth_list_ctrlr_enabled(this->device_model, true);
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
 
     IdTokenInfo id_token_info_result;
@@ -703,7 +705,7 @@ TEST_F(AuthorizationTest,
     // And offline contract validation is not allowed.
     this->set_allow_contract_validation_offline(this->device_model, true);
     this->set_local_authorize_offline(this->device_model, false);
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, ocpp::LeafCertificateType::MO))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Expired));
 
     IdToken id_token;
@@ -726,7 +728,7 @@ TEST_F(AuthorizationTest,
     // Local authorize offline is not allowed.
     this->set_local_authorize_offline(this->device_model, false);
     // The certificate has an invalid signature.
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::InvalidSignature));
 
     IdToken id_token;
@@ -755,7 +757,7 @@ TEST_F(AuthorizationTest, validate_token_emaid_no_ocsp_websocket_connected) {
     // The websocket is connected.
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(true));
     // Certificate is valid according to 'verify_certificate'.
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
     std::vector<ocpp::OCSPRequestData> ocsp_request_data;
     ocpp::OCSPRequestData d;
@@ -785,7 +787,7 @@ TEST_F(AuthorizationTest,
     // Do not allow central contract validation.
     this->set_allow_central_contract_validation(this->device_model, false);
     // Certificate is valid according to 'verify_certificate'.
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
     std::vector<ocpp::OCSPRequestData> ocsp_request_data;
     EXPECT_CALL(this->evse_security, get_mo_ocsp_request_data(_)).WillOnce(Return(ocsp_request_data));
@@ -804,7 +806,7 @@ TEST_F(AuthorizationTest,
     // Do not allow central contract validation.
     this->set_allow_central_contract_validation(this->device_model, true);
     // Certificate is valid according to 'verify_certificate'.
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
     std::vector<ocpp::OCSPRequestData> ocsp_request_data;
     EXPECT_CALL(this->evse_security, get_mo_ocsp_request_data(_)).WillOnce(Return(ocsp_request_data));
@@ -825,7 +827,7 @@ TEST_F(AuthorizationTest,
     // The websocket is connected.
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(true));
     // Certificate is valid according to 'verify_certificate'.
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::IssuerNotFound));
     // Do not allow central contract validation.
     set_allow_central_contract_validation(this->device_model, false);
@@ -842,7 +844,7 @@ TEST_F(AuthorizationTest,
     // The websocket is connected.
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(true));
     // Certificate is valid according to 'verify_certificate'.
-    ON_CALL(this->evse_security, verify_certificate(_, _))
+    ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
         .WillByDefault(Return(ocpp::CertificateValidationResult::IssuerNotFound));
     // Allow central contract validation.
     set_allow_central_contract_validation(this->device_model, true);


### PR DESCRIPTION
## Describe your changes
Addressed changed API in libevse-security, which added a new function.

## Issue ticket number and link
PR in libevse-security: https://github.com/EVerest/libevse-security/pull/105

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

