### PR TITLE
Contract validation using V2G root

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3534,8 +3534,8 @@ ocpp::v2::AuthorizeResponse ChargePointImpl::data_transfer_pnc_authorize(
         forward_to_csms = true;
     } else if (certificate.has_value()) {
         // First try to validate the contract certificate locally
-        CertificateValidationResult local_verify_result =
-            this->evse_security->verify_certificate(certificate.value(), ocpp::LeafCertificateType::MO);
+        CertificateValidationResult local_verify_result = this->evse_security->verify_certificate(
+            certificate.value(), {ocpp::LeafCertificateType::MO, ocpp::LeafCertificateType::V2G});
         EVLOG_info << "Local contract validation result: " << local_verify_result;
         const auto central_contract_validation_allowed =
             this->configuration->getCentralContractValidationAllowed().value_or(false);

--- a/lib/ocpp/v2/functional_blocks/authorization.cpp
+++ b/lib/ocpp/v2/functional_blocks/authorization.cpp
@@ -180,7 +180,7 @@ ocpp::v2::Authorization::validate_token(const IdToken id_token, const std::optio
         } else if (certificate.has_value()) {
             // First try to validate the contract certificate locally
             CertificateValidationResult local_verify_result = this->context.evse_security.verify_certificate(
-                certificate.value().get(), ocpp::LeafCertificateType::MO);
+                certificate.value().get(), {ocpp::LeafCertificateType::MO, ocpp::LeafCertificateType::V2G});
             EVLOG_info << "Local contract validation result: " << local_verify_result;
 
             bool central_contract_validation_allowed =

--- a/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
+++ b/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
@@ -705,7 +705,8 @@ TEST_F(AuthorizationTest,
     // And offline contract validation is not allowed.
     this->set_allow_contract_validation_offline(this->device_model, true);
     this->set_local_authorize_offline(this->device_model, false);
-    ON_CALL(this->evse_security, verify_certificate(_, ocpp::LeafCertificateType::MO))
+    std::vector<ocpp::LeafCertificateType> types({ocpp::LeafCertificateType::MO, ocpp::LeafCertificateType::V2G});
+    ON_CALL(this->evse_security, verify_certificate(_, types))
         .WillByDefault(Return(ocpp::CertificateValidationResult::Expired));
 
     IdToken id_token;


### PR DESCRIPTION
## Describe your changes
Until now, the local contract validation was only using the MO root certificate as a trust anchor. This PR adds the usage of the V2G root, since contracts can also be issued by the V2G root.

Note: Merge after https://github.com/EVerest/libocpp/pull/1033

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

