### PR TITLE
Fixed bug to set CentralContractValidationAllowed

### DIFF
--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -3489,7 +3489,7 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
         if (this->getCentralContractValidationAllowed() == std::nullopt) {
             return ConfigurationStatus::NotSupported;
         } else {
-            this->setContractValidationOffline(ocpp::conversions::string_to_bool(value.get()));
+            this->setCentralContractValidationAllowed(ocpp::conversions::string_to_bool(value.get()));
         }
     }
     if (key == "CertSigningWaitMinimum") {


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

