### PR TITLE
Bounds checks for Plug&Charge configuration keys

### DIFF
--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -49,7 +49,7 @@
         "VerifyCsmsCommonName": true,
         "VerifyCsmsAllowWildcards": true,
         "OcspRequestInterval": 604800,
-        "SeccLeafSubjectCommonName": "cp001",
+        "SeccLeafSubjectCommonName": "DEPNX100001",
         "SeccLeafSubjectCountry": "DE",
         "SeccLeafSubjectOrganization": "Pionix",
         "ConnectorEvseIds": "DE*PNX*100001,DE*PNX*100002",

--- a/config/v16/profile_schemas/Internal.json
+++ b/config/v16/profile_schemas/Internal.json
@@ -284,17 +284,23 @@
         "SeccLeafSubjectCommonName": {
             "$comment": "Common Name(s) of the SECC (EVSE) leaf certificate(s). The CN must be a SECCID. The field can contain optional multiple SECCIDs if necessary.",
             "type": "string",
-            "readOnly": false
+            "readOnly": false,
+            "minLength": 7,
+            "maxLength": 64
         },
         "SeccLeafSubjectCountry": {
             "$comment": "County of the SECC (EVSE) leaf certificate. Indicates in which country the CPO operates.",
             "type": "string",
-            "readOnly": false
+            "readOnly": false,
+            "minLength": 2,
+            "maxLength": 2
         },
         "SeccLeafSubjectOrganization": {
             "$comment": "Organization of the SECC (EVSE) leaf certificate. Indicates which CPO operates this EVSE. Example: Hubject GmbH",
             "type": "string",
-            "readOnly": false
+            "readOnly": false,
+            "minLength": 0,
+            "maxLength": 64
         },
         "ConnectorEvseIds": {
             "$comment": "Comma separated EVSEIDs for OCPP connectors starting with connector 1 in one string.",

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -979,7 +979,7 @@ bool ChargePointConfiguration::validate_measurands(const json& config) {
 }
 
 bool validate_connector_evse_ids(const std::string& value) {
-    if (value.length() > 1000) {
+    if (value.length() > CONNECTOR_EVSE_IDS_MAX_LENGTH) {
         return false;
     }
 

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -16,6 +16,13 @@
 namespace ocpp {
 namespace v16 {
 
+const size_t CONNECTOR_EVSE_IDS_MAX_LENGTH = 1000;
+const size_t SECC_LEAF_SUBJECT_ORGANIZATION_MAX_LENGTH = 64;
+const size_t SECC_LEAF_SUBJECT_COUNTRY_LENGTH = 2;
+const size_t SECC_LEAF_SUBJECT_COMMON_NAME_MIN_LENGTH = 7;
+const size_t SECC_LEAF_SUBJECT_COMMON_NAME_MAX_LENGTH = 64;
+const size_t AUTHORIZATION_KEY_MIN_LENGTH = 8;
+
 ChargePointConfiguration::ChargePointConfiguration(const std::string& config, const fs::path& ocpp_main_path,
                                                    const fs::path& user_config_path) {
 
@@ -972,6 +979,10 @@ bool ChargePointConfiguration::validate_measurands(const json& config) {
 }
 
 bool validate_connector_evse_ids(const std::string& value) {
+    if (value.length() > 1000) {
+        return false;
+    }
+
     // this fullfills parts of HUB-24-003 of Requirements EVSE Check PnC with ISO15118-2 v4
     const auto evse_ids = split_string(value, ',');
     for (const auto& evse_id : evse_ids) {
@@ -3425,7 +3436,7 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
     }
     if (key == "AuthorizationKey") {
         std::string authorization_key = value.get();
-        if (authorization_key.length() >= 8) {
+        if (authorization_key.length() >= AUTHORIZATION_KEY_MIN_LENGTH) {
             this->setAuthorizationKey(value.get());
             return ConfigurationStatus::Accepted;
         } else {
@@ -3838,6 +3849,11 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
     // Hubject PnC Extension keys
     if (key == "SeccLeafSubjectCommonName") {
         if (this->getSeccLeafSubjectCommonName().has_value()) {
+            if (value.get().length() < SECC_LEAF_SUBJECT_COMMON_NAME_MIN_LENGTH or
+                value.get().length() > SECC_LEAF_SUBJECT_COMMON_NAME_MAX_LENGTH) {
+                EVLOG_warning << "Attempt to set SeccLeafSubjectCommonName with invalid number of characters";
+                return ConfigurationStatus::Rejected;
+            }
             this->setSeccLeafSubjectCommonName(value.get());
         } else {
             return ConfigurationStatus::NotSupported;
@@ -3845,6 +3861,10 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
     }
     if (key == "SeccLeafSubjectCountry") {
         if (this->getSeccLeafSubjectCountry().has_value()) {
+            if (value.get().length() != SECC_LEAF_SUBJECT_COUNTRY_LENGTH) {
+                EVLOG_warning << "Attempt to set SeccLeafSubjectCountry with invalid number of characters";
+                return ConfigurationStatus::Rejected;
+            }
             this->setSeccLeafSubjectCountry(value.get());
         } else {
             return ConfigurationStatus::NotSupported;
@@ -3852,6 +3872,10 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
     }
     if (key == "SeccLeafSubjectOrganization") {
         if (this->getSeccLeafSubjectOrganization().has_value()) {
+            if (value.get().length() > SECC_LEAF_SUBJECT_ORGANIZATION_MAX_LENGTH) {
+                EVLOG_warning << "Attempt to set SeccLeafSubjectOrganization with invalid number of characters";
+                return ConfigurationStatus::Rejected;
+            }
             this->setSeccLeafSubjectOrganization(value.get());
         } else {
             return ConfigurationStatus::NotSupported;


### PR DESCRIPTION
## Describe your changes
Implemented Hubjects EVSE requirements of OCPP1.6 configuration keys.

Test cases for this are implemented here:
https://github.com/EVerest/everest-core/pull/1124

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

