### PR TITLE
Fixed potential bad function call for set_connection_timeout_callback

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1864,7 +1864,7 @@ void ChargePointImpl::handleChangeConfigurationRequest(ocpp::Call<ChangeConfigur
                         response.status = ConfigurationStatus::Rejected;
                     }
                 } else if (call.msg.key == "ConnectionTimeout") {
-                    this->set_connection_timeout_callback(this->configuration->getConnectionTimeOut());
+                    this->call_set_connection_timeout();
                 } else if (call.msg.key == "TransactionMessageAttempts") {
                     this->message_queue->update_transaction_message_attempts(
                         this->configuration->getTransactionMessageAttempts());


### PR DESCRIPTION

## Describe your changes
Fixed a bug that set_connection_timeout_callback was called without checking for nullptr

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

