### PR TITLE
fix(v2Database): Use proper last used date for cache expiry

### DIFF
--- a/lib/ocpp/v2/database_handler.cpp
+++ b/lib/ocpp/v2/database_handler.cpp
@@ -193,7 +193,8 @@ void DatabaseHandler::authorization_cache_delete_expired_entries(
     DateTime now;
     delete_stmt->bind_int64("@before_date", to_unix_milliseconds(now));
     if (auth_cache_lifetime.has_value()) {
-        delete_stmt->bind_int64("@before_last_used", to_unix_milliseconds(DateTime(now)));
+        delete_stmt->bind_int64("@before_last_used",
+                                to_unix_milliseconds(DateTime(now.to_time_point() - auth_cache_lifetime.value())));
     } else {
         delete_stmt->bind_null("@before_last_used");
     }


### PR DESCRIPTION
We would always remove a token after inserting since we considered it expired due to using the wrong date.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

