### PR TITLE
Ensure compliance with OCPP 1.6 3.13.2. Stacking charging profiles

### DIFF
--- a/tests/lib/ocpp/v16/database_tests.cpp
+++ b/tests/lib/ocpp/v16/database_tests.cpp
@@ -365,6 +365,10 @@ TEST_F(DatabaseTest, test_delete_profile) {
 
     profile2.chargingProfileId = 2;
 
+    // two profiles with same purpose and level are not allowed
+    // see OCPP 1.6 3.13.2. Stacking charging profiles
+    profile2.stackLevel++;
+
     this->db_handler->insert_or_update_charging_profile(1, profile1);
     this->db_handler->insert_or_update_charging_profile(2, profile2);
 

--- a/tests/lib/ocpp/v16/database_tests.cpp
+++ b/tests/lib/ocpp/v16/database_tests.cpp
@@ -359,6 +359,34 @@ TEST_F(DatabaseTest, test_update_profile_same_profile_id) {
     ASSERT_EQ(profiles.size(), 1);
 }
 
+TEST_F(DatabaseTest, test_update_profile_same_purpose_and_level_non_zero) {
+    const auto profile1 = get_sample_charging_profile();
+    auto profile2 = get_sample_charging_profile();
+
+    profile2.chargingProfileId++; // different profile ID
+
+    this->db_handler->insert_or_update_charging_profile(1, profile1);
+    this->db_handler->insert_or_update_charging_profile(2, profile2);
+
+    const auto profiles = this->db_handler->get_charging_profiles();
+
+    ASSERT_EQ(profiles.size(), 1);
+}
+
+TEST_F(DatabaseTest, test_update_profile_same_purpose_and_level_connector_zero) {
+    const auto profile1 = get_sample_charging_profile();
+    auto profile2 = get_sample_charging_profile();
+
+    profile2.chargingProfileId++; // different profile ID
+
+    this->db_handler->insert_or_update_charging_profile(0, profile1);
+    this->db_handler->insert_or_update_charging_profile(0, profile2);
+
+    const auto profiles = this->db_handler->get_charging_profiles();
+
+    ASSERT_EQ(profiles.size(), 1);
+}
+
 TEST_F(DatabaseTest, test_delete_profile) {
     const auto profile1 = get_sample_charging_profile();
     auto profile2 = get_sample_charging_profile();


### PR DESCRIPTION
## Describe your changes
fix: OCPP 1.6 remove charging profiles with same level and purpose

When updating a charging profile the following is required:
> To avoid conflicts, the existence of multiple Charging Profiles with
> the same stackLevel and Purposes in a Charge Point is not allowed.
> Whenever a Charge Point receives a Charging Profile with a stackLevel
> and Purpose that already exists in the Charge Point, the Charge Point
> SHALL replace the existing profile.

## steps to reproduce:
1.  clear all profiles
2.  get composite - check clear worked
3.  set profile A (id 101 TxDefault and stack level 30, 20A)
4.  get composite - check set profile A active
5.  set profile B (id 102 TxDefault and stack level 30, 30A)
6.  get composite - check set profile B active
7.  clear profile B
8.  get composite - check no profile set
9.  restart
10. get composite - check no profile set

The bug is at step 10 profile A is active (20A).

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

