### PR TITLE
Fix handling and reporting of more invalid messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.26.1
+    VERSION 0.26.2
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/common/message_queue.hpp
+++ b/include/ocpp/common/message_queue.hpp
@@ -90,6 +90,10 @@ enum class MessageTransmissionPriority {
     Discard                              // message shall be discarded and not be sent
 };
 
+class MalformedRpcMessage : public std::runtime_error {
+    using std::runtime_error::runtime_error;
+};
+
 /// \brief Helper function to handle messages that shall be send
 inline MessageTransmissionPriority get_message_transmission_priority(bool is_boot_notification_message, bool triggered,
                                                                      bool registration_already_accepted,
@@ -208,6 +212,9 @@ private:
         start_transaction_message_retry_callback;
 
     MessageId getMessageId(const json::array_t& json_message) {
+        if (json_message.size() < 2) {
+            throw MalformedRpcMessage("Message has too few elements, could not get message id.");
+        }
         return MessageId(json_message.at(MESSAGE_ID).get<std::string>());
     }
     MessageTypeId getMessageTypeId(const json::array_t& json_message) {

--- a/lib/ocpp/v2/charge_point.cpp
+++ b/lib/ocpp/v2/charge_point.cpp
@@ -863,6 +863,15 @@ void ChargePoint::message_callback(const std::string& message) {
                                                         CiString<255>(message, StringTooLarge::Truncate), true,
                                                         utils::is_critical(security_event));
         return;
+    } catch (const MalformedRpcMessage& e) {
+        EVLOG_error << "MalformedRpcMessage exception during handling of message: " << e.what();
+        auto call_error = CallError(MessageId("-1"), "RpcFrameworkError", e.what(), json({}));
+        this->message_dispatcher->dispatch_call_error(call_error);
+        const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
+        this->security->security_event_notification_req(CiString<50>(security_event, StringTooLarge::Truncate),
+                                                        CiString<255>(message, StringTooLarge::Truncate), true,
+                                                        utils::is_critical(security_event));
+        return;
     }
 
     enhanced_message.message_size = message.size();

--- a/lib/ocpp/v2/charge_point.cpp
+++ b/lib/ocpp/v2/charge_point.cpp
@@ -946,6 +946,13 @@ void ChargePoint::message_callback(const std::string& message) {
         }
         auto call_error = CallError(enhanced_message.uniqueId, "OccurrenceConstraintViolation", e.what(), json({}));
         this->message_dispatcher->dispatch_call_error(call_error);
+    } catch (const StringConversionException& e) {
+        EVLOG_error << "StringConversionException during handling of message: " << e.what();
+        if (enhanced_message.messageTypeId != MessageTypeId::CALL) {
+            return; // CALLERROR shall only follow on a CALL message
+        }
+        auto call_error = CallError(enhanced_message.uniqueId, "FormationViolation", e.what(), json({}));
+        this->message_dispatcher->dispatch_call_error(call_error);
     } catch (const EnumConversionException& e) {
         EVLOG_error << "EnumConversionException during handling of message: " << e.what();
         if (enhanced_message.messageTypeId != MessageTypeId::CALL) {

--- a/lib/ocpp/v2/charge_point.cpp
+++ b/lib/ocpp/v2/charge_point.cpp
@@ -874,6 +874,17 @@ void ChargePoint::message_callback(const std::string& message) {
         return;
     }
 
+    if (enhanced_message.messageTypeId == MessageTypeId::UNKNOWN) {
+        EVLOG_error << "Cannot handle message with an unknown message type";
+        auto call_error = CallError(MessageId("-1"), "MessageTypeNotSupported", "", json({}));
+        this->message_dispatcher->dispatch_call_error(call_error);
+        const auto& security_event = ocpp::security_events::INVALIDMESSAGES;
+        this->security->security_event_notification_req(CiString<50>(security_event, StringTooLarge::Truncate),
+                                                        CiString<255>(message, StringTooLarge::Truncate), true,
+                                                        utils::is_critical(security_event));
+        return;
+    }
+
     enhanced_message.message_size = message.size();
     auto json_message = enhanced_message.message;
     this->logging->central_system(conversions::messagetype_to_string(enhanced_message.messageType), message);


### PR DESCRIPTION
## Describe your changes
Add missing catch of StringConversionException and report CALLERROR
    
Report CALLERROR when the message ID cannot be extracted from RPC message
This can happen when RPC messages are malformed
    
Respond with MessageTypeNotSupported CALLERROR when message type is unknown

Bump version to 0.26.2

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

