### PR TITLE
[OCPP 1.6] periodically check for expired profiles across all profile types

### DIFF
--- a/include/ocpp/v16/smart_charging.hpp
+++ b/include/ocpp/v16/smart_charging.hpp
@@ -52,8 +52,9 @@ private:
                         std::optional<int> connector_id_opt, const int connector_id, std::optional<int> stack_level_opt,
                         std::optional<ChargingProfilePurposeType> charging_profile_purpose_opt, bool check_id_only);
 
-    void clear_expired_profiles();
+protected:
     int get_number_installed_profiles();
+    void clear_expired_profiles(const date::utc_clock::time_point& now);
 
 public:
     SmartChargingHandler(std::map<int32_t, std::shared_ptr<Connector>>& connectors,

--- a/lib/ocpp/v16/smart_charging.cpp
+++ b/lib/ocpp/v16/smart_charging.cpp
@@ -11,6 +11,38 @@ using namespace std::chrono;
 
 using QueryExecutionException = everest::db::QueryExecutionException;
 
+namespace {
+/**
+ * \brief remove expired profiles from the memory map structure and database
+ * \param[in] now - profiles with a validTo time earlier that this are removed
+ * \param[in] db - a reference to the database handler
+ * \param[in,out] map - the map containing charging profiles
+ */
+template <class PROFILES>
+void clear_expired_profiles(const date::utc_clock::time_point& now, ocpp::v16::DatabaseHandler& db, PROFILES& map) {
+
+    // check all profiles in the map
+    for (auto it = map.cbegin(); it != map.cend();) {
+        bool remove = false;
+
+        // check if the profile has expired
+        if (it->second.validTo) {
+            const auto validTo = it->second.validTo.value().to_time_point();
+            remove = validTo < now;
+        }
+
+        if (remove) {
+            // remove expired profile from the database and map
+            // the order of these matters!
+            db.delete_charging_profile(it->second.chargingProfileId);
+            it = map.erase(it);
+        } else {
+            it++;
+        }
+    }
+}
+} // namespace
+
 namespace ocpp {
 namespace v16 {
 
@@ -49,23 +81,23 @@ SmartChargingHandler::SmartChargingHandler(std::map<int32_t, std::shared_ptr<Con
                                            ChargePointConfiguration& configuration) :
     connectors(connectors), database_handler(database_handler), configuration(configuration) {
     this->clear_profiles_timer = std::make_unique<Everest::SteadyTimer>();
-    this->clear_profiles_timer->interval([this]() { this->clear_expired_profiles(); }, hours(HOURS_PER_DAY));
+    this->clear_profiles_timer->interval([this]() { this->clear_expired_profiles(date::utc_clock::now()); },
+                                         hours(HOURS_PER_DAY));
 }
 
-void SmartChargingHandler::clear_expired_profiles() {
+void SmartChargingHandler::clear_expired_profiles(const date::utc_clock::time_point& now) {
     EVLOG_debug << "Scanning all installed profiles and clearing expired profiles";
 
-    const auto now = date::utc_clock::now();
-    std::lock_guard<std::mutex> lk(this->charge_point_max_profiles_map_mutex);
-    for (auto it = this->stack_level_charge_point_max_profiles_map.cbegin();
-         it != this->stack_level_charge_point_max_profiles_map.cend();) {
-        const auto& validTo = it->second.validTo;
-        if (validTo.has_value() and validTo.value().to_time_point() < now) {
-            this->stack_level_charge_point_max_profiles_map.erase(it++);
-            this->database_handler->delete_charging_profile(it->second.chargingProfileId);
-        } else {
-            ++it;
-        }
+    // obtain locks - note the order needs to be consistent with other uses
+    std::lock_guard<std::mutex> lk_cp(charge_point_max_profiles_map_mutex);
+    std::lock_guard<std::mutex> lk_txd(tx_default_profiles_map_mutex);
+    std::lock_guard<std::mutex> lk_tx(tx_profiles_map_mutex);
+
+    // check all profile types for expired entries
+    ::clear_expired_profiles(now, *database_handler, stack_level_charge_point_max_profiles_map);
+    for (auto& [connector_id, connector] : connectors) {
+        ::clear_expired_profiles(now, *database_handler, connector->stack_level_tx_default_profiles_map);
+        ::clear_expired_profiles(now, *database_handler, connector->stack_level_tx_profiles_map);
     }
 }
 

--- a/tests/lib/ocpp/v16/test_smart_charging_handler.cpp
+++ b/tests/lib/ocpp/v16/test_smart_charging_handler.cpp
@@ -10,6 +10,16 @@ namespace fs = std::filesystem;
 #include <ocpp/v16/smart_charging.hpp>
 #include <optional>
 
+namespace {
+struct SmartChargingHandlerUTest : public ocpp::v16::SmartChargingHandler {
+    using SmartChargingHandler::clear_expired_profiles;
+    using SmartChargingHandler::get_number_installed_profiles;
+    using SmartChargingHandler::SmartChargingHandler;
+    SmartChargingHandlerUTest() = delete;
+};
+
+} // namespace
+
 namespace ocpp {
 namespace v16 {
 
@@ -37,7 +47,8 @@ namespace v16 {
  * - NB07 Invalid ChargingSchedule
  * - NB08 profile.chargingProfileKind == Recurring && !profile.recurrencyKind
  * - NB09 profile.chargingProfileKind == Recurring && !startSchedule
- * - NB10 profile.chargingProfileKind == Recurring && !startSchedule && !allow_charging_profile_without_start_schedule
+ * - NB10 profile.chargingProfileKind == Recurring && !startSchedule &&
+ * !allow_charging_profile_without_start_schedule
  * - NB11 Absolute ChargePointMaxProfile Profile with connector id not 0
  * - NB12 Absolute TxProfile connector_id == 0
  * - NB13 Absolute TxProfile && connector transaction == nullptr && ignore_no_transaction == true
@@ -793,10 +804,10 @@ TEST_F(ChargepointTestFixture, ClearAllProfilesWithFilter__NoProfiles_ProfileId_
 
 /**
  * There is an issue open https://github.com/EVerest/libocpp/issues/432 for the below clear_all_profiles_with_filter
- * The current method call will allow for all parameters to be passed in at a single time and then act on all of them.
- * The issue is that a call should either have a profile id and delete that specific profile or any combination of the
- * other three to delete n number of profiles (to a single one if given all three).
- * The logic is exclusionary but the method does not guard against it which can put the system in an odd state.
+ * The current method call will allow for all parameters to be passed in at a single time and then act on all of
+ * them. The issue is that a call should either have a profile id and delete that specific profile or any
+ * combination of the other three to delete n number of profiles (to a single one if given all three). The logic is
+ * exclusionary but the method does not guard against it which can put the system in an odd state.
  */
 
 // 0, 1 and many connectors
@@ -1281,7 +1292,8 @@ TEST_F(ChargepointTestFixture, AddTxDefaultProfile_ConnectorId_eq_0) {
     const int connector_id = 0;
     handler->add_tx_default_profile(profile, connector_id);
     // While the connector id is 0 when it is added, it is retrieved with a connector id of 1
-    // See AddTxDefaultProfile_ConnectorId_eq_0_Retrieved_at_0__NoProfilesReturned for a demonstration of this behavior
+    // See AddTxDefaultProfile_ConnectorId_eq_0_Retrieved_at_0__NoProfilesReturned for a demonstration of this
+    // behavior
     const int retrieved_connector_id = 1;
     auto valid_profiles = handler->get_valid_profiles(date_start_range, date_end_range, retrieved_connector_id);
     auto retrieved = valid_profiles[0];
@@ -1330,6 +1342,85 @@ TEST_F(ChargepointTestFixture, AddTxDefaultProfile__ConnectorId_gt_0) {
     auto tx_default_profile = valid_profiles[1];
     ASSERT_EQ(ChargingProfilePurposeType::TxDefaultProfile, tx_default_profile.chargingProfilePurpose);
     ASSERT_EQ(ChargingProfileKindType::Absolute, tx_default_profile.chargingProfileKind);
+}
+
+/**
+ * SmartChargingHandler test clearing of expired profiles
+ */
+TEST_F(ChargepointTestFixture, ClearingExpiredProfiles) {
+    // double check that date and time comparisons work
+    ASSERT_GT(date_end_range, date_start_range);
+    ASSERT_LT(date_start_range.to_time_point(), date_end_range.to_time_point());
+
+    // create and configure a real database
+    auto database_connection = std::make_unique<everest::db::sqlite::Connection>("file::memory:?cache=shared");
+    database_connection->open_connection(); // Open connection so memory stays shared
+    database_handler = std::make_unique<DatabaseHandler>(std::move(database_connection),
+                                                         std::filesystem::path(MIGRATION_FILES_LOCATION_V16), 2);
+    database_handler->open_connection();
+    addConnector(0);
+    addConnector(1);
+
+    // use the handler with access to protected methods
+    auto handler = SmartChargingHandlerUTest(connectors, database_handler, *configuration);
+
+    // create some profiles
+    auto profile_cpm = createMaxChargingProfile(createChargeSchedule(ChargingRateUnit::A));
+    auto profile_txd = createChargingProfile(createChargeSchedule(ChargingRateUnit::A));
+    auto profile_tx = createTxChargingProfile(createChargeSchedule(ChargingRateUnit::A));
+
+    // ensure they have different IDs
+    profile_cpm.chargingProfileId = 1;
+    profile_txd.chargingProfileId = 2;
+    profile_tx.chargingProfileId = 3;
+
+    // add the profiles
+    handler.add_charge_point_max_profile(profile_cpm);
+    handler.add_tx_default_profile(profile_txd, 1);
+    handler.add_tx_profile(profile_tx, 1);
+
+    // check that there are three profiles
+    auto valid_profiles = handler.get_valid_profiles(date_start_range, date_end_range, 1);
+    auto db_profiles = database_handler->get_charging_profiles();
+    EXPECT_EQ(handler.get_number_installed_profiles(), 3);
+    EXPECT_EQ(db_profiles.size(), 3);
+    EXPECT_EQ(valid_profiles.size(), 3);
+
+    // test clearing at date_start_range (all profiles start after that)
+    // no profiles should be deleted
+    handler.clear_expired_profiles(date_start_range.to_time_point());
+    valid_profiles = handler.get_valid_profiles(date_start_range, date_end_range, 1);
+    db_profiles = database_handler->get_charging_profiles();
+    EXPECT_EQ(handler.get_number_installed_profiles(), 3);
+    EXPECT_EQ(db_profiles.size(), 3);
+    EXPECT_EQ(valid_profiles.size(), 3);
+
+    // test clearing at before date_end_range
+    // no profiles should be deleted
+    handler.clear_expired_profiles(ocpp::DateTime("2024-02-19T00:00:00").to_time_point());
+    valid_profiles = handler.get_valid_profiles(date_start_range, date_end_range, 1);
+    db_profiles = database_handler->get_charging_profiles();
+    EXPECT_EQ(handler.get_number_installed_profiles(), 3);
+    EXPECT_EQ(db_profiles.size(), 3);
+    EXPECT_EQ(valid_profiles.size(), 3);
+
+    // test clearing at date_end_range
+    // no profiles should be deleted
+    handler.clear_expired_profiles(date_end_range.to_time_point());
+    valid_profiles = handler.get_valid_profiles(date_start_range, date_end_range, 1);
+    db_profiles = database_handler->get_charging_profiles();
+    EXPECT_EQ(handler.get_number_installed_profiles(), 3);
+    EXPECT_EQ(db_profiles.size(), 3);
+    EXPECT_EQ(valid_profiles.size(), 3);
+
+    // test clearing after date_end_range
+    // all profiles should be deleted
+    handler.clear_expired_profiles(ocpp::DateTime("2024-03-19T00:00:01").to_time_point());
+    valid_profiles = handler.get_valid_profiles(date_start_range, date_end_range, 1);
+    db_profiles = database_handler->get_charging_profiles();
+    EXPECT_EQ(handler.get_number_installed_profiles(), 0);
+    EXPECT_EQ(db_profiles.size(), 0);
+    EXPECT_EQ(valid_profiles.size(), 0);
 }
 
 } // namespace v16


### PR DESCRIPTION
## Describe your changes

OCPP 1.6 periodically checks for expired profiles
There is a periodic check where expired charging profiles are removed. 
Originally this was for charge point max profiles only. 

Now tx and tx default profiles are also checked.

Unit test created to ensure correct operation.

Note the original implementation has a subtle bug 
```
            this->stack_level_charge_point_max_profiles_map.erase(it++);
            this->database_handler->delete_charging_profile(it->second.chargingProfileId);
```
`delete_charging_profile()` is called with the profile ID of the next element since the iterator was incremented on the previous line. The recommended form for use of erase is `it = map.erase(it);` since erase() returns the updated iterator.

## Issue ticket number and link
Expired profiles were not being removed from the database except on startup.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

