### PR TITLE
refactor(ocpp16): Remove the call to stop during a reset

### DIFF
--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -83,7 +83,7 @@
         "MeterValuesSampledData": "Energy.Active.Import.Register",
         "MeterValuesSampledDataMaxLength": 1024,
         "MeterValueSampleInterval": 300,
-        "MinimumStatusDuration": 2,
+        "MinimumStatusDuration": 1,
         "NumberOfConnectors": 2,
         "ResetRetries": 1,
         "StopTransactionOnEVSideDisconnect": true,

--- a/doc/v16/getting_started.md
+++ b/doc/v16/getting_started.md
@@ -197,7 +197,7 @@ Some general notes: the "connector" parameter of some of the callbacks refers to
 
 - register_reset_callback
 
-  used to perform a reset of the requested type
+  used to perform a reset of the requested type, it is up to the user to properly stop the charge point when this callback is used
 
 - register_connection_state_changed_callback
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -2229,14 +2229,15 @@ void ChargePointImpl::handleResetRequest(ocpp::Call<ResetRequest> call) {
                 lk, std::chrono::seconds(this->configuration->getWaitForStopTransactionsOnResetTimeout()), [this] {
                     for (int32_t connector = 1; connector <= this->configuration->getNumberOfConnectors();
                          connector++) {
-                        if (this->transaction_handler->transaction_active(connector)) {
+                        if (this->transaction_handler->transaction_active(connector) or
+                            this->status->get_state(connector) == ChargePointStatus::Charging) {
                             return false;
                         }
                     }
                     return true;
                 });
             // this is executed after all transactions have been stopped
-            this->stop();
+            // it is expected that the user properly shuts down the software, including calling stop()
             this->reset_callback(reset_type);
         });
         if (call.msg.type == ResetType::Soft) {


### PR DESCRIPTION
It is expected that the user call stop during the reset callback so that all of the software can be properly and cleanly stopped.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

