### PR TITLE
fix(v16): Removed security event on firmware installed notification

### DIFF
--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -124,7 +124,7 @@
         "CertificateStoreMaxLength": 1000,
         "CpoName": "Pionix",
         "SecurityProfile": 1,
-        "DisableSecurityEventNotifications": true
+        "DisableSecurityEventNotifications": false
     },
     "PnC": {
         "ISO15118PnCEnabled": true,

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -4468,12 +4468,9 @@ void ChargePointImpl::on_firmware_update_status_notification(int32_t request_id,
         EVLOG_debug << "Could not convert incoming FirmwareStatusNotification to OCPP type";
     }
 
-    if (firmware_update_status == FirmwareStatusNotification::Installed) {
-        this->securityEventNotification(ocpp::security_events::FIRMWARE_UPDATED,
-                                        std::optional<CiString<255>>("Firmware update was installed"), true);
-    } else if (firmware_update_status == FirmwareStatusNotification::InstallationFailed or
-               firmware_update_status == FirmwareStatusNotification::Installed or
-               firmware_update_status == FirmwareStatusNotification::InstallVerificationFailed) {
+    if (firmware_update_status == FirmwareStatusNotification::InstallationFailed or
+        firmware_update_status == FirmwareStatusNotification::Installed or
+        firmware_update_status == FirmwareStatusNotification::InstallVerificationFailed) {
         // Restore connector status, since we did not save to db the status, we can just get the old status back using
         // it
         auto connector_availability = this->database_handler->get_connector_availability();


### PR DESCRIPTION
## Describe your changes

We are removing the security event notification that is being sent when we receive a firmware status notification with reason FirmwareInstalled as it is redundant with the requirement asking to reboot the station with the new firmware and asks for a security event with reaon firmware updated. In other words, it is up to the user of the stack to properly update the boot reason to be compliant with the secure firmware update / security event  notification requirements. The user must set the boot reason to firmware updated after a boot due to a firmware update.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

