### PR TITLE
Bump version to 0.26.3 and libtimer dependency to 0.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.26.2
+    VERSION 0.26.3
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,7 +19,7 @@ liblog:
   options: ["BUILD_EXAMPLES OFF"]
 libtimer:
   git: https://github.com/EVerest/libtimer.git
-  git_tag: v0.1.1
+  git_tag: v0.1.2
   options: ["BUILD_EXAMPLES OFF"]
 date:
   git: https://github.com/HowardHinnant/date.git


### PR DESCRIPTION
## Describe your changes
- Bump libtimer dependency to 0.1.2

This is already used when building with everest-core and related to #1005
## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

