### PR TITLE
feature(ocpp16): Authorize response waits for set user price

### DIFF
--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -175,6 +175,7 @@
         "CustomIdleFeeAfterStop": false,
         "MultiLanguageSupportedLanguages": "en, nl, de, nb_NO",
         "CustomMultiLanguageMessages": true,
-        "Language": "en"
+        "Language": "en",
+        "WaitForSetUserPriceTimeout": 5000
     }
 }

--- a/config/v16/profile_schemas/CostAndPrice.json
+++ b/config/v16/profile_schemas/CostAndPrice.json
@@ -129,6 +129,13 @@
             "type": "string",
             "readOnly": false,
             "minLength": 1
+        },
+        "WaitForSetUserPriceTimeout": {
+            "description": "Timeout in milliseconds that the charge point will wait for a DataTransfer(SetUserPrice) after an Authorize.req if CustomDisplayCostAndPrice is true. If the timeout expires, the authorization response will be returned without a price",
+            "type": "integer",
+            "readOnly": false,
+            "minimum": 0,
+            "maximum": 30000
         }
     }
 }

--- a/doc/common/california_pricing_requirements.md
+++ b/doc/common/california_pricing_requirements.md
@@ -14,7 +14,13 @@ information.
 The User-specific price is used for display purposes only and can be sent as soon as the user identifies itself with an 
 id token. It should not be used to calculate prices.
 Internally, the messages in the DataTransfer json (for 1.6) is converted to a `TariffMessage`, defined in
-`common/types.hpp`. In case of multi language messages, they are all added to the TariffMessage vector.  
+`common/types.hpp`. In case of multi language messages, they are all added to the TariffMessage vector.
+
+In order to be able to use information from `SetUserPrice` before a transaction is started (e.g. for the OCMF TT field), OCPP1.6 implements a mechanism to wait for `DataTransfer.req(SetUserPrice)` from
+the CSMS before the `authorize_id_token` function returns. This is required because the `Authorize.conf` in OCPP1.6 does not contain this information (unlike OCPP2.x). This allows to integrate the information
+from `DataTransfer.req(SetUserPrice)` in the response of the authorization request. The timeout for waiting for this message from the CSMS can be controlled using the `WaitForSetUserPriceTimeout`
+configuration key, which is specified in milliseconds. If no `DataTransfer.req(SetUserPrice)` is received within the specified timeout, the result is returned and a transaction may still start.
+
 If the message is sent when a transaction has already started, the session id will be included in the session cost message and the `IdentifierType` will be set to `SessionId`. If it has not started yet, the id token is sent with
 `IdentifierType` set to `IdToken`.
 

--- a/include/ocpp/v16/charge_point.hpp
+++ b/include/ocpp/v16/charge_point.hpp
@@ -144,8 +144,8 @@ public:
     /// \brief Authorizes the provided \p id_token against the central system, LocalAuthorizationList or
     /// AuthorizationCache depending on the values of the ConfigurationKeys LocalPreAuthorize, LocalAuthorizeOffline,
     /// LocalAuthListEnabled and AuthorizationCacheEnabled
-    /// \returns the IdTagInfo
-    IdTagInfo authorize_id_token(CiString<20> id_token);
+    /// \returns the EnhancedIdTagInfo that contains the result of the authorization and an optional tarriff message
+    EnhancedIdTagInfo authorize_id_token(CiString<20> id_token);
 
     // for plug&charge 1.6 whitepaper
 

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -492,6 +492,10 @@ public:
     void setLanguage(const std::string& language);
     std::optional<KeyValue> getLanguageKeyValue();
 
+    std::optional<int32_t> getWaitForSetUserPriceTimeout();
+    void setWaitForSetUserPriceTimeout(const int32_t wait_for_set_user_price_timeout);
+    std::optional<KeyValue> getWaitForSetUserPriceTimeoutKeyValue();
+
     // custom
     std::optional<KeyValue> getCustomKeyValue(CiString<50> key);
     ConfigurationStatus setCustomKey(CiString<50> key, CiString<500> value, bool force);

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -458,6 +458,8 @@ public:
     std::optional<KeyValue> getPriceNumberOfDecimalsForCostValuesKeyValue();
 
     std::optional<std::string> getDefaultPriceText(const std::string& language);
+    TariffMessage getTariffMessageWithDefaultPriceText();
+    TariffMessage getTariffMessageWithDefaultPriceTextOffline();
     ConfigurationStatus setDefaultPriceText(const CiString<50>& key, const CiString<500>& value);
     KeyValue getDefaultPriceTextKeyValue(const std::string& language);
     std::optional<std::vector<KeyValue>> getAllDefaultPriceTextKeyValues();

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -139,6 +139,10 @@ private:
     std::mutex stop_transaction_mutex;
     std::condition_variable stop_transaction_cv;
 
+    std::mutex user_price_map_mutex;
+    std::map<std::string, std::condition_variable> user_price_cvs;
+    std::map<std::string, TariffMessage> tariff_messages_by_id_token;
+
     std::thread reset_thread;
 
     int log_status_request_id;
@@ -475,8 +479,8 @@ public:
     /// AuthorizationCache depending on the values of the ConfigurationKeys LocalPreAuthorize, LocalAuthorizeOffline,
     /// LocalAuthListEnabled and AuthorizationCacheEnabled. If \p authorize_only_locally is true, no Authorize.req will
     /// be sent to the CSMS but only LocalAuthorizationList and LocalAuthorizationCache will be used for the validation
-    /// \returns the IdTagInfo
-    IdTagInfo authorize_id_token(CiString<20> id_token, const bool authorize_only_locally = false);
+    /// \returns the EnhancedIdTagInfo that contains the result of the authorization and an optional tarriff message
+    EnhancedIdTagInfo authorize_id_token(CiString<20> id_token, const bool authorize_only_locally = false);
 
     // for plug&charge 1.6 whitepaper
 

--- a/include/ocpp/v16/ocpp_types.hpp
+++ b/include/ocpp/v16/ocpp_types.hpp
@@ -12,7 +12,6 @@
 
 #include <ocpp/common/types.hpp>
 #include <ocpp/v16/ocpp_enums.hpp>
-#include <ocpp/v16/types.hpp>
 
 namespace ocpp {
 namespace v16 {

--- a/include/ocpp/v16/types.hpp
+++ b/include/ocpp/v16/types.hpp
@@ -12,6 +12,7 @@
 
 #include <ocpp/common/types.hpp>
 #include <ocpp/v16/ocpp_enums.hpp>
+#include <ocpp/v16/ocpp_types.hpp>
 
 using json = nlohmann::json;
 
@@ -230,6 +231,12 @@ void to_json(json& j, const EnhancedChargingSchedule& k);
 
 /// \brief Conversion from a given json object \p j to a given EnhancedChargingSchedule \p k
 void from_json(const json& j, EnhancedChargingSchedule& k);
+
+/// \brief Extends the IdTagInfo with an optional TariffMessage for california pricing
+struct EnhancedIdTagInfo {
+    IdTagInfo id_tag_info;
+    std::optional<TariffMessage> tariff_message;
+};
 
 } // namespace v16
 } // namespace ocpp

--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -51,7 +51,7 @@ void ChargePoint::call_set_connection_timeout() {
     this->charge_point->call_set_connection_timeout();
 }
 
-IdTagInfo ChargePoint::authorize_id_token(CiString<20> id_token) {
+EnhancedIdTagInfo ChargePoint::authorize_id_token(CiString<20> id_token) {
     return this->charge_point->authorize_id_token(id_token);
 }
 

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2619,6 +2619,46 @@ std::optional<std::string> ChargePointConfiguration::getDefaultPriceText(const s
     return std::nullopt;
 }
 
+TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceText() {
+    TariffMessage tariff_message;
+    if (this->config.contains("CostAndPrice") and this->config.at("CostAndPrice").contains("DefaultPriceText")) {
+        json& default_tariff = this->config["CostAndPrice"]["DefaultPriceText"];
+
+        if (!default_tariff.contains("priceTexts")) {
+            return tariff_message;
+        }
+
+        for (auto& tariff_message_item : default_tariff.at("priceTexts").items()) {
+            DisplayMessageContent content;
+            content.language = tariff_message_item.value().at("language");
+            content.message = tariff_message_item.value().at("priceText");
+            tariff_message.message.push_back(content);
+        }
+    }
+    return tariff_message;
+}
+
+TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceTextOffline() {
+    TariffMessage tariff_message;
+    if (this->config.contains("CostAndPrice") and this->config.at("CostAndPrice").contains("DefaultPriceText")) {
+        json& default_tariff = this->config["CostAndPrice"]["DefaultPriceText"];
+
+        if (!default_tariff.contains("priceTexts")) {
+            return tariff_message;
+        }
+
+        for (auto& tariff_message_item : default_tariff.at("priceTexts").items()) {
+            DisplayMessageContent content;
+            content.language = tariff_message_item.value().at("language");
+            if (tariff_message_item.value().contains("priceTextOffline")) {
+                content.message = tariff_message_item.value().at("priceTextOffline");
+                tariff_message.message.push_back(content);
+            }
+        }
+    }
+    return tariff_message;
+}
+
 ConfigurationStatus ChargePointConfiguration::setDefaultPriceText(const CiString<50>& key, const CiString<500>& value) {
     std::string language;
     const std::vector<std::string> default_prices = split_string(key.get(), ',');

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2628,11 +2628,16 @@ TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceText() {
             return tariff_message;
         }
 
-        for (auto& tariff_message_item : default_tariff.at("priceTexts").items()) {
+        for (auto& item : default_tariff.at("priceTexts").items()) {
+            const auto tariff_message_item = item.value();
             DisplayMessageContent content;
-            content.language = tariff_message_item.value().at("language");
-            content.message = tariff_message_item.value().at("priceText");
-            tariff_message.message.push_back(content);
+            if (tariff_message_item.contains("language")) {
+                content.language = tariff_message_item.at("language");
+            }
+            if (tariff_message_item.contains("priceText")) {
+                content.message = tariff_message_item.at("priceText");
+                tariff_message.message.push_back(content);
+            }
         }
     }
     return tariff_message;
@@ -2647,11 +2652,14 @@ TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceTextOffl
             return tariff_message;
         }
 
-        for (auto& tariff_message_item : default_tariff.at("priceTexts").items()) {
+        for (auto& item : default_tariff.at("priceTexts").items()) {
             DisplayMessageContent content;
-            content.language = tariff_message_item.value().at("language");
-            if (tariff_message_item.value().contains("priceTextOffline")) {
-                content.message = tariff_message_item.value().at("priceTextOffline");
+            const auto tariff_message_item = item.value();
+            if (tariff_message_item.contains("language")) {
+                content.language = tariff_message_item.at("language");
+            }
+            if (tariff_message_item.contains("priceTextOffline")) {
+                content.message = tariff_message_item.at("priceTextOffline");
                 tariff_message.message.push_back(content);
             }
         }

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2630,12 +2630,10 @@ TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceText() {
 
         for (auto& item : default_tariff.at("priceTexts").items()) {
             const auto tariff_message_item = item.value();
-            DisplayMessageContent content;
-            if (tariff_message_item.contains("language")) {
-                content.language = tariff_message_item.at("language");
-            }
-            if (tariff_message_item.contains("priceText")) {
+            if (tariff_message_item.contains("priceText") and tariff_message_item.contains("language")) {
+                DisplayMessageContent content;
                 content.message = tariff_message_item.at("priceText");
+                content.language = tariff_message_item.at("language");
                 tariff_message.message.push_back(content);
             }
         }
@@ -2653,13 +2651,11 @@ TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceTextOffl
         }
 
         for (auto& item : default_tariff.at("priceTexts").items()) {
-            DisplayMessageContent content;
             const auto tariff_message_item = item.value();
-            if (tariff_message_item.contains("language")) {
-                content.language = tariff_message_item.at("language");
-            }
-            if (tariff_message_item.contains("priceTextOffline")) {
+            if (tariff_message_item.contains("priceTextOffline") and tariff_message_item.contains("language")) {
+                DisplayMessageContent content;
                 content.message = tariff_message_item.at("priceTextOffline");
+                content.language = tariff_message_item.at("language");
                 tariff_message.message.push_back(content);
             }
         }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -34,6 +34,7 @@ const auto WEBSOCKET_INIT_DELAY = std::chrono::seconds(2);
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
 const auto DEFAULT_BOOT_NOTIFICATION_INTERVAL_S = 60; // fallback interval if BootNotification returns interval of 0.
 const auto DEFAULT_PRICE_NUMBER_OF_DECIMALS = 3;
+const auto DEFAULT_WAIT_FOR_SET_USER_PRICE_TIMEOUT_MS = 0;
 
 ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& share_path,
                                  const fs::path& user_config_path, const fs::path& database_path,
@@ -3224,6 +3225,14 @@ DataTransferResponse ChargePointImpl::handle_set_user_price(const std::optional<
         }
     }
 
+    {
+        std::lock_guard<std::mutex> lock(this->user_price_map_mutex);
+
+        if (this->user_price_cvs.find(id_token.value()) != this->user_price_cvs.end()) {
+            this->tariff_messages_by_id_token[id_token.value()] = tariff_message;
+            this->user_price_cvs[id_token.value()].notify_all();
+        }
+    }
     response = this->tariff_message_callback(tariff_message);
     return response;
 }
@@ -3392,7 +3401,9 @@ void ChargePointImpl::status_notification(const int32_t connector, const ChargeP
 
 // public API for Core profile
 
-IdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const bool authorize_only_locally) {
+EnhancedIdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const bool authorize_only_locally) {
+    EnhancedIdTagInfo enhanced_id_tag_info;
+
     // only do authorize req when authorization locally not enabled or fails
     // proritize auth list over auth cache for same idTags
 
@@ -3409,62 +3420,90 @@ IdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const bool aut
                 const auto auth_list_entry_opt = this->database_handler->get_local_authorization_list_entry(idTag);
                 if (auth_list_entry_opt.has_value()) {
                     EVLOG_info << "Found id_tag " << idTag.get() << " in AuthorizationList";
-                    return auth_list_entry_opt.value();
+                    enhanced_id_tag_info.id_tag_info = auth_list_entry_opt.value();
+                    return enhanced_id_tag_info;
                 }
-            } catch (const QueryExecutionException& e) {
-                EVLOG_warning << "Could not request local authorization list entry: " << e.what();
             } catch (const std::exception& e) {
-                EVLOG_warning << "Unknown Error while requesting local authorization list entry: " << e.what();
+                EVLOG_warning << "Error while requesting local authorization list entry: " << e.what();
             }
         }
+
         if (this->configuration->getAuthorizationCacheEnabled()) {
             if (this->validate_against_cache_entries(idTag)) {
                 EVLOG_info << "Found valid id_tag " << idTag.get() << " in AuthorizationCache";
-                return this->database_handler->get_authorization_cache_entry(idTag).value();
+                enhanced_id_tag_info.id_tag_info = this->database_handler->get_authorization_cache_entry(idTag).value();
+                return enhanced_id_tag_info;
             }
         }
     }
 
     if (authorize_only_locally) {
-        return {AuthorizationStatus::Invalid};
+        enhanced_id_tag_info.id_tag_info = {AuthorizationStatus::Invalid};
+        return enhanced_id_tag_info;
     }
+
+    std::unique_lock<std::mutex> lock(this->user_price_map_mutex);
+    this->tariff_messages_by_id_token.erase(idTag.get()); // reset any prior data
 
     AuthorizeRequest req;
     req.idTag = idTag;
-
     ocpp::Call<AuthorizeRequest> call(req);
 
     auto authorize_future = this->message_dispatcher->dispatch_call_async(call);
 
     if (authorize_future.wait_for(DEFAULT_WAIT_FOR_FUTURE_TIMEOUT) == std::future_status::timeout) {
         EVLOG_warning << "Waiting for Authorize.conf future timed out!";
-        return {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
+        enhanced_id_tag_info.id_tag_info = {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
+        return enhanced_id_tag_info;
     }
 
     auto enhanced_message = authorize_future.get();
 
-    IdTagInfo id_tag_info;
     if (enhanced_message.messageType == MessageType::AuthorizeResponse) {
         try {
             ocpp::CallResult<AuthorizeResponse> call_result = enhanced_message.message;
             this->database_handler->insert_or_update_authorization_cache_entry(idTag, call_result.msg.idTagInfo);
-            return call_result.msg.idTagInfo;
-        } catch (const QueryExecutionException& e) {
-            EVLOG_warning << "Could not insert or update authorization cache entry";
-            return {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
-        } catch (const json::exception& e) {
-            EVLOG_warning << "CSMS returned a malformed response to the AuthorizeRequest, assuming id tag is invalid.";
-            return {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
+            enhanced_id_tag_info.id_tag_info = call_result.msg.idTagInfo;
+
+            if (this->configuration->getCustomDisplayCostAndPriceEnabled() &&
+                call_result.msg.idTagInfo.status == AuthorizationStatus::Accepted) {
+                EVLOG_info << "California pricing is active, waiting for set user price.";
+
+                this->user_price_cvs[idTag.get()].wait_for(
+                    lock,
+                    std::chrono::milliseconds(this->configuration->getWaitForSetUserPriceTimeout().value_or(
+                        DEFAULT_WAIT_FOR_SET_USER_PRICE_TIMEOUT_MS)),
+                    [&] {
+                        return this->tariff_messages_by_id_token.find(idTag.get()) !=
+                               this->tariff_messages_by_id_token.end();
+                    });
+
+                auto tariff_it = this->tariff_messages_by_id_token.find(idTag.get());
+                if (tariff_it != this->tariff_messages_by_id_token.end()) {
+                    EVLOG_info << "Tariff message received for idToken " << idTag.get();
+                    enhanced_id_tag_info.tariff_message = tariff_it->second;
+                    this->tariff_messages_by_id_token.erase(tariff_it);
+                } else {
+                    EVLOG_warning << "Tariff message was not received within timeout for idToken " << idTag.get();
+                }
+                this->user_price_cvs.erase(idTag.get());
+            }
+
+            return enhanced_id_tag_info;
+        } catch (const std::exception& e) {
+            EVLOG_warning << "Error processing AuthorizeResponse: " << e.what();
+            enhanced_id_tag_info.id_tag_info = {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
+            return enhanced_id_tag_info;
         }
     } else if (enhanced_message.offline) {
-        if (this->configuration->getAllowOfflineTxForUnknownId() != std::nullopt &&
-            this->configuration->getAllowOfflineTxForUnknownId().value()) {
-            id_tag_info = {AuthorizationStatus::Accepted, std::nullopt, std::nullopt};
-            return id_tag_info;
+        if (this->configuration->getAllowOfflineTxForUnknownId().value_or(false)) {
+            enhanced_id_tag_info.id_tag_info = {AuthorizationStatus::Accepted, std::nullopt, std::nullopt};
+            return enhanced_id_tag_info;
         }
     }
-    id_tag_info = {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
-    return id_tag_info;
+
+    enhanced_id_tag_info.id_tag_info = {AuthorizationStatus::Invalid, std::nullopt, std::nullopt};
+    return enhanced_id_tag_info;
 }
 
 std::map<int32_t, ChargingSchedule> ChargePointImpl::get_all_composite_charging_schedules(const int32_t duration_s,
@@ -3685,7 +3724,7 @@ ocpp::v2::AuthorizeResponse ChargePointImpl::data_transfer_pnc_authorize(
         return authorize_response;
     } else {
         const auto local_authorize_result = this->authorize_id_token(emaid, true);
-        if (local_authorize_result.status == AuthorizationStatus::Accepted) {
+        if (local_authorize_result.id_tag_info.status == AuthorizationStatus::Accepted) {
             authorize_response.idTokenInfo.status = ocpp::v2::AuthorizationStatusEnum::Accepted;
         } else {
             authorize_response.idTokenInfo.status = ocpp::v2::AuthorizationStatusEnum::Invalid;

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3423,8 +3423,10 @@ EnhancedIdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const 
                     enhanced_id_tag_info.id_tag_info = auth_list_entry_opt.value();
                     return enhanced_id_tag_info;
                 }
+            } catch (const QueryExecutionException& e) {
+                EVLOG_warning << "Could not request local authorization list entry: " << e.what();
             } catch (const std::exception& e) {
-                EVLOG_warning << "Error while requesting local authorization list entry: " << e.what();
+                EVLOG_warning << "Unknown Error while requesting local authorization list entry: " << e.what();
             }
         }
 

--- a/src/charge_point.cpp
+++ b/src/charge_point.cpp
@@ -280,7 +280,7 @@ int main(int argc, char* argv[]) {
                     uuid = boost::lexical_cast<std::string>(boost::uuids::random_generator()());
                     charge_point->on_session_started(1, uuid, ocpp::SessionStartedReason::EVConnected, std::nullopt);
                     const auto result = charge_point->authorize_id_token(ocpp::CiString<20>(std::string("DEADBEEF")));
-                    if (result.status == ocpp::v16::AuthorizationStatus::Accepted) {
+                    if (result.id_token_info.status == ocpp::v16::AuthorizationStatus::Accepted) {
                         charge_point->on_transaction_started(1, uuid, "DEADBEEF", 0, std::nullopt, ocpp::DateTime(),
                                                              std::nullopt);
                         charge_point->on_resume_charging(1);

--- a/src/charge_point.cpp
+++ b/src/charge_point.cpp
@@ -280,7 +280,7 @@ int main(int argc, char* argv[]) {
                     uuid = boost::lexical_cast<std::string>(boost::uuids::random_generator()());
                     charge_point->on_session_started(1, uuid, ocpp::SessionStartedReason::EVConnected, std::nullopt);
                     const auto result = charge_point->authorize_id_token(ocpp::CiString<20>(std::string("DEADBEEF")));
-                    if (result.id_token_info.status == ocpp::v16::AuthorizationStatus::Accepted) {
+                    if (result.id_tag_info.status == ocpp::v16::AuthorizationStatus::Accepted) {
                         charge_point->on_transaction_started(1, uuid, "DEADBEEF", 0, std::nullopt, ocpp::DateTime(),
                                                              std::nullopt);
                         charge_point->on_resume_charging(1);


### PR DESCRIPTION
## Describe your changes
If california pricing is active, authorize_id_token will wait for a DataTransfer(SetUserPrice) before returning the result
* Added tariff message handling with per-idToken condition variables
* Added per-idToken map for tariff message
* Added configuration key for `WaitForSetUserPrice` to OCPP1.6 which specifies for how long the authorization request should wait for `DataTransfer.req(SetUserPrice)`.

## Issue ticket number and link
Companion PR in everest-core : https://github.com/EVerest/everest-core/pull/1186

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

