### PR TITLE
Fix EVSE struct initialization in handle_unlock_connector

### DIFF
--- a/lib/ocpp/v2/functional_blocks/remote_transaction_control.cpp
+++ b/lib/ocpp/v2/functional_blocks/remote_transaction_control.cpp
@@ -72,7 +72,9 @@ void RemoteTransactionControl::handle_unlock_connector(Call<UnlockConnectorReque
     const UnlockConnectorRequest& msg = call.msg;
     UnlockConnectorResponse unlock_response;
 
-    EVSE evse = {msg.evseId, std::nullopt, msg.connectorId};
+    EVSE evse;
+    evse.id = msg.evseId;
+    evse.connectorId = msg.connectorId;
 
     if (this->context.evse_manager.is_valid_evse(evse)) {
         if (!this->context.evse_manager.get_evse(msg.evseId).has_active_transaction()) {


### PR DESCRIPTION
The aggregate initialization used before accidentally set the connectorId of the evse to nullopt while setting the customData to coennectorId, this should be the other way around

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

