### PR TITLE
fix(OCPP1.6): V2G CSR generation

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3767,7 +3767,8 @@ void ChargePointImpl::data_transfer_pnc_sign_certificate() {
     const auto result = this->evse_security->generate_certificate_signing_request(
         ocpp::CertificateSigningUseEnum::V2GCertificate,
         this->configuration->getSeccLeafSubjectCountry().value_or("DE"),
-        this->configuration->getSeccLeafSubjectOrganization().value_or(this->configuration->getCpoName().value()),
+        this->configuration->getSeccLeafSubjectOrganization().value_or(
+            this->configuration->getCpoName().value_or("DEFAULT")),
         this->configuration->getSeccLeafSubjectCommonName().value_or(this->configuration->getChargeBoxSerialNumber()),
         this->configuration->getUseTPMSeccLeafCertificate());
 


### PR DESCRIPTION

## Describe your changes
Fixed issue in V2G CSR generation, where getCpoName().value() always evaluated and could cause a bad optional access

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

