### PR TITLE
Catch and aggregate missing required variables in DeviceModel

### DIFF
--- a/config/v2/component_config/standardized/OCPPCommCtrlr.json
+++ b/config/v2/component_config/standardized/OCPPCommCtrlr.json
@@ -125,41 +125,7 @@
       "default": "5",
       "type": "integer"
     },
-    "NetworkConfigurationPriority": {
-      "variable_name": "NetworkConfigurationPriority",
-      "characteristics": {
-        "valuesList": "1,2",
-        "supportsMonitoring": true,
-        "dataType": "SequenceList"
-      },
-      "attributes": [
-        {
-          "type": "Actual",
-          "mutability": "ReadWrite",
-          "value": 1
-        }
-      ],
-      "description": "A comma separated ordered list of the priority of the possible Network Connection Profiles.",
-      "default": "1",
-      "type": "string"
-    },
-    "NetworkProfileConnectionAttempts": {
-      "variable_name": "NetworkProfileConnectionAttempts",
-      "characteristics": {
-        "supportsMonitoring": true,
-        "dataType": "integer"
-      },
-      "attributes": [
-        {
-          "type": "Actual",
-          "mutability": "ReadWrite",
-          "value": 3
-        }
-      ],
-      "description": "Specifies the number of connection attempts the Charging Station executes before switching to a different profile.",
-      "default": "3",
-      "type": "integer"
-    },
+
     "OfflineThreshold": {
       "variable_name": "OfflineThreshold",
       "characteristics": {
@@ -349,8 +315,6 @@
     "MessageAttemptInterval",
     "MessageAttempts",
     "MessageTimeout",
-    "NetworkConfigurationPriority",
-    "NetworkProfileConnectionAttempts",
     "OfflineThreshold",
     "ResetRetries",
     "RetryBackOffRandomRange",


### PR DESCRIPTION
## Describe your changes

This patch updates the DeviceModel::check_required_variables() function to collect and log all missing required variables before throwing an exception, instead of failing on the first one. This helps developers identify all missing entries in a single run. 

Added logging at the start of the function to verify execution. Function is compiled and included in the build. 

## Issue ticket number and link

#1008 – https://github.com/EVerest/libocpp/issues/1008

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements
