### PR TITLE
fix(v2): eventNotificationType made optional NotifyMonitoringReport

### DIFF
--- a/include/ocpp/v2/ocpp_types.hpp
+++ b/include/ocpp/v2/ocpp_types.hpp
@@ -1424,7 +1424,7 @@ struct VariableMonitoring {
     float value;
     MonitorEnum type;
     int32_t severity;
-    EventNotificationEnum eventNotificationType;
+    std::optional<EventNotificationEnum> eventNotificationType;
     std::optional<CustomData> customData;
 };
 /// \brief Conversion from a given VariableMonitoring \p k to a given json object \p j

--- a/lib/ocpp/v2/ocpp_types.cpp
+++ b/lib/ocpp/v2/ocpp_types.cpp
@@ -4218,9 +4218,11 @@ void to_json(json& j, const VariableMonitoring& k) {
         {"value", k.value},
         {"type", conversions::monitor_enum_to_string(k.type)},
         {"severity", k.severity},
-        {"eventNotificationType", conversions::event_notification_enum_to_string(k.eventNotificationType)},
     };
     // the optional parts of the message
+    if (k.eventNotificationType) {
+        j["eventNotificationType"] = conversions::event_notification_enum_to_string(k.eventNotificationType.value());
+    }
     if (k.customData) {
         j["customData"] = k.customData.value();
     }
@@ -4234,9 +4236,11 @@ void from_json(const json& j, VariableMonitoring& k) {
     k.value = j.at("value");
     k.type = conversions::string_to_monitor_enum(j.at("type"));
     k.severity = j.at("severity");
-    k.eventNotificationType = conversions::string_to_event_notification_enum(j.at("eventNotificationType"));
 
     // the optional parts of the message
+    if (j.contains("eventNotificationType")) {
+        k.eventNotificationType.emplace(conversions::string_to_event_notification_enum(j.at("eventNotificationType")));
+    }
     if (j.contains("customData")) {
         k.customData.emplace(j.at("customData"));
     }

--- a/src/code_generator/common/generate_cpp.py
+++ b/src/code_generator/common/generate_cpp.py
@@ -543,6 +543,16 @@ def parse_schemas(version: str, schema_dir: Path = Path('schemas/json/'),
                 generated_class_cpp_fn = Path(messages_source_dir_v21, action + '.cpp')
                 conversions_namespace_prefix = 'ocpp::v2::'
 
+            if action == 'NotifyMonitoringReport':
+                # Exception needed for this specific message since the eventNotificationType
+                # field was marked as required in OCPP 2.1 which breaks schema validation
+                # for OCPP 2.0.1
+                for i, property in enumerate(sorted_types):
+                    if property['name'] == 'VariableMonitoring':
+                        for j, field in enumerate(property['properties']):
+                            if field['name'] == 'eventNotificationType':
+                                sorted_types[i]['properties'][j]['required'] = False
+
             with open(generated_class_hpp_fn, writemode[type_key]) as out:
                 out.write(message_hpp_template.render({
                     'types': sorted_types,


### PR DESCRIPTION
The code generator was amended to have an exception for eventNotificationType in NotifyMonitoringReportRequest. This was marked as new and required in OCPP 2.1, but breaks schema validation in OCPP 2.0.1 so the presense of this value will be checked in code and not as type definition to avoid issues.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

