### PR TITLE
Refactor: Device model db initialization and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.27.1
+    VERSION 0.28.0
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/include/ocpp/v2/charge_point.hpp
+++ b/include/ocpp/v2/charge_point.hpp
@@ -493,7 +493,6 @@ public:
     /// key represents the id of the EVSE and the value represents the number of connectors for this EVSE. The ids of
     /// the EVSEs have to increment starting with 1.
     /// \param device_model_storage_address address to device model storage (e.g. location of SQLite database)
-    /// \param initialize_device_model  Set to true to initialize the device model database
     /// \param device_model_migration_path  Path to the device model database migration files
     /// \param device_model_config_path    Path to the device model config
     /// \param ocpp_main_path Path where utility files for OCPP are read and written to
@@ -503,11 +502,11 @@ public:
     /// security_configuration must be set
     /// \param callbacks Callbacks that will be registered for ChargePoint
     ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
-                const std::string& device_model_storage_address, const bool initialize_device_model,
-                const std::string& device_model_migration_path, const std::string& device_model_config_path,
-                const std::string& ocpp_main_path, const std::string& core_database_path,
-                const std::string& sql_init_path, const std::string& message_log_path,
-                const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks);
+                const std::string& device_model_storage_address, const std::string& device_model_migration_path,
+                const std::string& device_model_config_path, const std::string& ocpp_main_path,
+                const std::string& core_database_path, const std::string& sql_init_path,
+                const std::string& message_log_path, const std::shared_ptr<EvseSecurity> evse_security,
+                const Callbacks& callbacks);
 
     /// @}  // End chargepoint 2.0.1 member group
 

--- a/include/ocpp/v2/device_model_storage_sqlite.hpp
+++ b/include/ocpp/v2/device_model_storage_sqlite.hpp
@@ -23,6 +23,8 @@ private:
 
     int get_variable_id(const Component& component_id, const Variable& variable_id);
 
+    void initialize_connection(const fs::path& db_path);
+
 public:
     /// \brief Opens SQLite connection at given \p db_path
     ///
@@ -31,11 +33,22 @@ public:
     /// \param db_path              Path to database
     /// \param migration_files_path Path to the migration files to initialize the database (only needs to be set if
     ///                             `init_db` is true)
-    /// \param config_path          Path to the device model config (only needs to be set if `init_db` is true)
-    /// \param init_db              True to initialize the database
+    /// \param config_path          Path to the device model config used to initialize the database
     ///
-    explicit DeviceModelStorageSqlite(const fs::path& db_path, const std::filesystem::path& migration_files_path = "",
-                                      const std::filesystem::path& config_path = "", const bool init_db = false);
+    explicit DeviceModelStorageSqlite(const fs::path& db_path, const std::filesystem::path& migration_files_path,
+                                      const std::filesystem::path& config_path);
+
+    /// \brief Opens SQLite connection at given \p db_path
+    ///
+    /// \param db_path              Path to database
+    /// \param migration_files_path Path to the migration files to initialize the database
+    ///
+    DeviceModelStorageSqlite(const fs::path& db_path, const fs::path& migration_files_path);
+
+    /// \brief Opens SQLite connection at given \p db_path
+    ///
+    /// \param db_path Path to database
+    DeviceModelStorageSqlite(const fs::path& db_path);
 
     ~DeviceModelStorageSqlite() = default;
 

--- a/include/ocpp/v2/functional_blocks/meter_values.hpp
+++ b/include/ocpp/v2/functional_blocks/meter_values.hpp
@@ -45,9 +45,5 @@ private: // Members
 
     ClockAlignedTimer aligned_meter_values_timer;
     AverageMeterValues aligned_data_evse0; // represents evseId = 0 meter value
-
-private: // Functions
-    // Internal helper functions
-    void update_dm_evse_power(const int32_t evse_id, const MeterValue& meter_value);
 };
 } // namespace ocpp::v2

--- a/include/ocpp/v2/init_device_model_db.hpp
+++ b/include/ocpp/v2/init_device_model_db.hpp
@@ -124,6 +124,14 @@ private:
     std::string reason;
 };
 
+///
+/// \brief Read all component config files from the given directory and create a map holding the structure.
+/// \param directory    The parent directory containing the standardized and custom component config files.
+/// \return A map with the device model components, variables, characteristics and attributes.
+///
+std::map<ComponentKey, std::vector<DeviceModelVariable>>
+get_all_component_configs(const std::filesystem::path& directory);
+
 class InitDeviceModelDb : public common::DatabaseHandlerCommon {
 private: // Members
     /// \brief Database path of the device model database.
@@ -146,7 +154,7 @@ public:
 
     ///
     /// \brief Initialize the database schema and component config.
-    /// \param config_path          Path to the component config.
+    /// \param component_configs    A map with all components, variables, characteristics and attributes.
     /// \param delete_db_if_exists  Set to true to delete the database if it already exists.
     ///
     /// \throws InitDeviceModelDbError  - When database could not be initialized or
@@ -158,7 +166,8 @@ public:
     /// \throws std::filesystem::filesystem_error   If the component config path does not exist
     ///
     ///
-    void initialize_database(const std::filesystem::path& config_path, const bool delete_db_if_exists);
+    void initialize_database(const std::map<ComponentKey, std::vector<DeviceModelVariable>> component_configs,
+                             const bool delete_db_if_exists);
 
 private: // Functions
     ///
@@ -181,14 +190,6 @@ private: // Functions
     std::vector<std::filesystem::path> get_component_config_from_directory(const std::filesystem::path& directory);
 
     ///
-    /// \brief Read all component config files from the given directory and create a map holding the structure.
-    /// \param directory    The parent directory containing the standardized and custom component config files.
-    /// \return A map with the device model components, variables, characteristics and attributes.
-    ///
-    std::map<ComponentKey, std::vector<DeviceModelVariable>>
-    get_all_component_configs(const std::filesystem::path& directory);
-
-    ///
     /// \brief Insert components, including variables, characteristics and attributes, to the database.
     /// \param components               The map with all components, variables, characteristics and attributes.
     /// \param existing_components      Vector with components that already exist in the database.
@@ -205,21 +206,6 @@ private: // Functions
     ///
     void insert_component(const ComponentKey& component_key,
                           const std::vector<DeviceModelVariable>& component_variables);
-
-    ///
-    /// \brief Read component config from given files.
-    /// \param components_config_path   The paths to the component config files.
-    /// \return A map holding the components with its variables, characteristics and attributes.
-    ///
-    std::map<ComponentKey, std::vector<DeviceModelVariable>>
-    read_component_config(const std::vector<std::filesystem::path>& components_config_path);
-
-    ///
-    /// \brief Get all component properties (variables) from the given (component) json.
-    /// \param component_properties The json component properties
-    /// \return A vector with all Variables belonging to this component.
-    ///
-    std::vector<DeviceModelVariable> get_all_component_properties(const json& component_properties);
 
     ///
     /// \brief Insert variable characteristics

--- a/lib/ocpp/v2/charge_point.cpp
+++ b/lib/ocpp/v2/charge_point.cpp
@@ -91,14 +91,14 @@ ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_struct
 }
 
 ChargePoint::ChargePoint(const std::map<int32_t, int32_t>& evse_connector_structure,
-                         const std::string& device_model_storage_address, const bool initialize_device_model,
+                         const std::string& device_model_storage_address,
                          const std::string& device_model_migration_path, const std::string& device_model_config_path,
                          const std::string& ocpp_main_path, const std::string& core_database_path,
                          const std::string& sql_init_path, const std::string& message_log_path,
                          const std::shared_ptr<EvseSecurity> evse_security, const Callbacks& callbacks) :
     ChargePoint(evse_connector_structure,
                 std::make_unique<DeviceModelStorageSqlite>(device_model_storage_address, device_model_migration_path,
-                                                           device_model_config_path, initialize_device_model),
+                                                           device_model_config_path),
                 ocpp_main_path, core_database_path, sql_init_path, message_log_path, evse_security, callbacks) {
 }
 

--- a/lib/ocpp/v2/functional_blocks/meter_values.cpp
+++ b/lib/ocpp/v2/functional_blocks/meter_values.cpp
@@ -93,7 +93,6 @@ void ocpp::v2::MeterValues::on_meter_value(const int32_t evse_id, const MeterVal
         this->aligned_data_evse0.set_values(meter_value);
     } else {
         this->context.evse_manager.get_evse(evse_id).on_meter_value(meter_value);
-        this->update_dm_evse_power(evse_id, meter_value);
     }
 }
 
@@ -116,22 +115,4 @@ void ocpp::v2::MeterValues::meter_values_req(const int32_t evse_id, const std::v
 
     ocpp::Call<MeterValuesRequest> call(req);
     this->context.message_dispatcher.dispatch_call(call, initiated_by_trigger_message);
-}
-
-void ocpp::v2::MeterValues::update_dm_evse_power(const int32_t evse_id, const MeterValue& meter_value) {
-    ComponentVariable evse_power_cv =
-        EvseComponentVariables::get_component_variable(evse_id, EvseComponentVariables::Power);
-
-    if (!evse_power_cv.variable.has_value()) {
-        return;
-    }
-
-    const auto power = utils::get_total_power_active_import(meter_value);
-    if (!power.has_value()) {
-        return;
-    }
-
-    this->context.device_model.set_read_only_value(evse_power_cv.component, evse_power_cv.variable.value(),
-                                                   AttributeEnum::Actual, std::to_string(power.value()),
-                                                   VARIABLE_ATTRIBUTE_VALUE_SOURCE_INTERNAL);
 }

--- a/lib/ocpp/v2/init_device_model_db.cpp
+++ b/lib/ocpp/v2/init_device_model_db.cpp
@@ -54,7 +54,8 @@ InitDeviceModelDb::~InitDeviceModelDb() {
     close_connection();
 }
 
-void InitDeviceModelDb::initialize_database(const std::filesystem::path& config_path, bool delete_db_if_exists = true) {
+void InitDeviceModelDb::initialize_database(
+    const std::map<ComponentKey, std::vector<DeviceModelVariable>> component_configs, bool delete_db_if_exists = true) {
     execute_init_sql(delete_db_if_exists);
 
     // Get existing components from the database.
@@ -63,9 +64,6 @@ void InitDeviceModelDb::initialize_database(const std::filesystem::path& config_
     if (this->database_exists) {
         existing_components = get_all_components_from_db();
     }
-
-    // Get component config files from the filesystem.
-    std::map<ComponentKey, std::vector<DeviceModelVariable>> component_configs = get_all_component_configs(config_path);
 
     // Check if the config is consistent.
     check_integrity(component_configs);
@@ -111,8 +109,7 @@ void InitDeviceModelDb::execute_init_sql(const bool delete_db_if_exists) {
     open_connection();
 }
 
-std::vector<std::filesystem::path>
-InitDeviceModelDb::get_component_config_from_directory(const std::filesystem::path& directory) {
+std::vector<std::filesystem::path> get_component_config_from_directory(const std::filesystem::path& directory) {
     std::vector<std::filesystem::path> component_config_files;
     for (const auto& p : std::filesystem::directory_iterator(directory)) {
         if (p.path().extension() == ".json") {
@@ -123,8 +120,55 @@ InitDeviceModelDb::get_component_config_from_directory(const std::filesystem::pa
     return component_config_files;
 }
 
+///
+/// \brief Get all component properties (variables) from the given (component) json.
+/// \param component_properties The json component properties
+/// \return A vector with all Variables belonging to this component.
+///
+std::vector<DeviceModelVariable> get_all_component_properties(const json& component_properties) {
+    std::vector<DeviceModelVariable> variables;
+
+    for (const auto& variable : component_properties.items()) {
+        DeviceModelVariable v = variable.value();
+        const std::string variable_key_name = variable.key();
+
+        variables.push_back(v);
+    }
+
+    return variables;
+}
+
+///
+/// \brief Read component config from given files.
+/// \param components_config_path   The paths to the component config files.
+/// \return A map holding the components with its variables, characteristics and attributes.
+///
 std::map<ComponentKey, std::vector<DeviceModelVariable>>
-InitDeviceModelDb::get_all_component_configs(const std::filesystem::path& directory) {
+read_component_config(const std::vector<std::filesystem::path>& components_config_path) {
+    std::map<ComponentKey, std::vector<DeviceModelVariable>> components;
+    for (const auto& path : components_config_path) {
+        std::ifstream config_file(path);
+        try {
+            json data = json::parse(config_file);
+            ComponentKey p = data;
+            if (data.contains("properties")) {
+                std::vector<DeviceModelVariable> variables = get_all_component_properties(data.at("properties"));
+                components.insert({p, variables});
+            } else {
+                EVLOG_warning << "Component " << data.at("name") << " does not contain any properties";
+                continue;
+            }
+        } catch (const json::parse_error& e) {
+            EVLOG_error << "Error while parsing config file: " << path;
+            throw;
+        }
+    }
+
+    return components;
+}
+
+std::map<ComponentKey, std::vector<DeviceModelVariable>>
+get_all_component_configs(const std::filesystem::path& directory) {
 
     const auto standardized_dir = directory / STANDARDIZED_COMPONENT_CONFIG_DIR;
     const auto custom_dir = directory / CUSTOM_COMPONENT_CONFIG_DIR;
@@ -214,43 +258,6 @@ void InitDeviceModelDb::insert_component(const ComponentKey& component_key,
         // Add variable
         insert_variable(variable, static_cast<uint64_t>(component_id));
     }
-}
-
-std::map<ComponentKey, std::vector<DeviceModelVariable>>
-InitDeviceModelDb::read_component_config(const std::vector<std::filesystem::path>& components_config_path) {
-    std::map<ComponentKey, std::vector<DeviceModelVariable>> components;
-    for (const auto& path : components_config_path) {
-        std::ifstream config_file(path);
-        try {
-            json data = json::parse(config_file);
-            ComponentKey p = data;
-            if (data.contains("properties")) {
-                std::vector<DeviceModelVariable> variables = get_all_component_properties(data.at("properties"));
-                components.insert({p, variables});
-            } else {
-                EVLOG_warning << "Component " << data.at("name") << " does not contain any properties";
-                continue;
-            }
-        } catch (const json::parse_error& e) {
-            EVLOG_error << "Error while parsing config file: " << path;
-            throw;
-        }
-    }
-
-    return components;
-}
-
-std::vector<DeviceModelVariable> InitDeviceModelDb::get_all_component_properties(const json& component_properties) {
-    std::vector<DeviceModelVariable> variables;
-
-    for (const auto& variable : component_properties.items()) {
-        DeviceModelVariable v = variable.value();
-        const std::string variable_key_name = variable.key();
-
-        variables.push_back(v);
-    }
-
-    return variables;
 }
 
 void InitDeviceModelDb::insert_variable_characteristics(const VariableCharacteristics& characteristics,

--- a/tests/lib/ocpp/v2/device_model_test_helper.cpp
+++ b/tests/lib/ocpp/v2/device_model_test_helper.cpp
@@ -212,7 +212,8 @@ bool DeviceModelTestHelper::set_variable_attribute_value_null(const std::string&
 
 void DeviceModelTestHelper::create_device_model_db() {
     InitDeviceModelDb db(this->database_path, this->migration_files_path);
-    db.initialize_database(this->config_path, true);
+    const auto component_configs = get_all_component_configs(this->config_path);
+    db.initialize_database(component_configs, true);
 }
 
 std::unique_ptr<DeviceModel> DeviceModelTestHelper::create_device_model(const bool init) {

--- a/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
+++ b/tests/lib/ocpp/v2/functional_blocks/test_reservation.cpp
@@ -54,7 +54,8 @@ protected: // Functions
     ///
     void create_device_model_db(const std::string& path) {
         InitDeviceModelDb db(path, MIGRATION_FILES_PATH);
-        db.initialize_database(CONFIG_PATH, true);
+        const auto component_configs = get_all_component_configs(CONFIG_PATH);
+        db.initialize_database(component_configs, true);
     }
 
     ///

--- a/tests/lib/ocpp/v2/test_charge_point.cpp
+++ b/tests/lib/ocpp/v2/test_charge_point.cpp
@@ -47,7 +47,8 @@ public:
 
     void create_device_model_db(const std::string& path) {
         InitDeviceModelDb db(path, MIGRATION_FILES_PATH);
-        db.initialize_database(CONFIG_PATH, true);
+        const auto component_configs = get_all_component_configs(CONFIG_PATH);
+        db.initialize_database(component_configs, true);
     }
 
     std::shared_ptr<DeviceModel>

--- a/tests/lib/ocpp/v2/test_device_model_storage_sqlite.cpp
+++ b/tests/lib/ocpp/v2/test_device_model_storage_sqlite.cpp
@@ -27,7 +27,7 @@ public:
 
 /// \brief Tests check_integrity does not raise error for valid database
 TEST_F(DeviceModelStorageSQLiteTest, test_check_integrity_valid) {
-    DeviceModelStorageSqlite dm(DATABASE_PATH, "", "", false);
+    DeviceModelStorageSqlite dm(DATABASE_PATH);
 
     EXPECT_NO_THROW(dm.check_integrity());
 }
@@ -38,7 +38,7 @@ TEST_F(DeviceModelStorageSQLiteTest, test_check_integrity_invalid) {
     device_model_test_helper.remove_variable_from_db("DisplayMessageCtrlr", std::nullopt, std::nullopt, std::nullopt,
                                                      "NumberOfDisplayMessages", std::nullopt);
 
-    DeviceModelStorageSqlite dm(DATABASE_PATH, "", "", false);
+    DeviceModelStorageSqlite dm(DATABASE_PATH);
 
     EXPECT_NO_THROW(dm.check_integrity());
 }


### PR DESCRIPTION

## Describe your changes
- Removed 'initialize_device_model' parameter from ChargePoint constructor
- Simplified DeviceModelStorageSqlite constructors
- Refactored InitDeviceModelDb to accept parsed component configs in order to make it reusable for non-json config based device models
- Moved config parsing logic (get_all_component_configs, etc.)
- Updated tests to reflect new initialization flow
- Removed update_dm_evse_power call, it is now expected to be set in the device model directly
- Bumped project version to 0.28.0

The changes have been implemented in order to integrate the `SqliteDeviceModelStorage` with EverestDeviceModel in everest-core . This is the companion PR: tbd

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

