### PR TITLE
Fix #1042: Add explicit config setup to authorization unit tests

### DIFF
--- a/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
+++ b/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
@@ -543,8 +543,8 @@ TEST_F(AuthorizationTest, validate_token_local_auth_list_enabled_accepted) {
     this->set_local_auth_list_ctrlr_enabled(this->device_model, true);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
-    set_local_authorize_offline(false);
+    set_local_pre_authorize(this->device_model, false);
+    set_local_authorize_offline(this->device_model, false);
     ON_CALL(this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(true));
 
     IdTokenInfo id_token_info_result;
@@ -571,8 +571,8 @@ TEST_F(AuthorizationTest, validate_token_local_auth_list_enabled_unknown_no_remo
     this->disable_remote_authorization(this->device_model, true);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
-    set_local_authorize_offline(false);
+    set_local_pre_authorize(this->device_model, false);
+    set_local_authorize_offline(this->device_model, false);
     ON_CALL(this->connectivity_manager, is_websocket_connected()).WillByDefault(Return(true));
 
     IdTokenInfo id_token_info_result;
@@ -599,11 +599,12 @@ TEST_F(AuthorizationTest, validate_token_local_auth_list_enabled_unknown_websock
     this->disable_remote_authorization(this->device_model, false);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
-    set_local_authorize_offline(false);
+    set_local_pre_authorize(this->device_model, false);
+    set_local_authorize_offline(this->device_model, false);
 
     // WebSocket is disconnected for this test case
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(false));
+
 
     IdTokenInfo id_token_info_result;
     id_token_info_result.status = AuthorizationStatusEnum::Invalid;
@@ -705,9 +706,10 @@ TEST_F(
     this->set_local_authorize_offline(this->device_model, false);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
+    set_local_pre_authorize(this->device_model, false);
 
     ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
+
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
 
     IdToken id_token;
@@ -732,9 +734,10 @@ TEST_F(
     this->set_local_auth_list_ctrlr_enabled(this->device_model, true);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
+    set_local_pre_authorize(this->device_model, false);
 
     ON_CALL(this->evse_security, verify_certificate(_, DEFAULT_LEAF_CERT_TYPE))
+
         .WillByDefault(Return(ocpp::CertificateValidationResult::Valid));
 
     IdTokenInfo id_token_info_result;
@@ -762,7 +765,7 @@ TEST_F(AuthorizationTest,
     this->set_local_authorize_offline(this->device_model, false);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
+    set_local_pre_authorize(this->device_model, false);
 
     std::vector<ocpp::LeafCertificateType> types({ocpp::LeafCertificateType::MO, ocpp::LeafCertificateType::V2G});
     ON_CALL(this->evse_security, verify_certificate(_, types))
@@ -1083,8 +1086,9 @@ TEST_F(AuthorizationTest, validate_token_auth_cache_lifetime_expired) {
     this->disable_remote_authorization(this->device_model, false);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
-    set_local_authorize_offline(false);
+    set_local_pre_authorize(this->device_model, false);
+    set_local_authorize_offline(this->device_model, false);
+
 
     // The websocket is connected.
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(true));

--- a/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
+++ b/tests/lib/ocpp/v2/functional_blocks/test_authorization.cpp
@@ -605,7 +605,6 @@ TEST_F(AuthorizationTest, validate_token_local_auth_list_enabled_unknown_websock
     // WebSocket is disconnected for this test case
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(false));
 
-
     IdTokenInfo id_token_info_result;
     id_token_info_result.status = AuthorizationStatusEnum::Invalid;
 
@@ -630,8 +629,8 @@ TEST_F(AuthorizationTest, validate_token_local_auth_list_enabled_connectivity_ma
     this->disable_remote_authorization(this->device_model, false);
 
     // Explicit config setup for test isolation
-    set_local_pre_authorize(false);
-    set_local_authorize_offline(false);
+    set_local_pre_authorize(this->device_model, false);
+    set_local_authorize_offline(this->device_model, false);
 
     // WebSocket is connected
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(true));
@@ -1088,7 +1087,6 @@ TEST_F(AuthorizationTest, validate_token_auth_cache_lifetime_expired) {
     // Explicit config setup for test isolation
     set_local_pre_authorize(this->device_model, false);
     set_local_authorize_offline(this->device_model, false);
-
 
     // The websocket is connected.
     EXPECT_CALL(this->connectivity_manager, is_websocket_connected()).WillRepeatedly(Return(true));


### PR DESCRIPTION
## Describe your changes
This PR resolves inconsistent test behavior in test_authorization.cpp by explicitly setting key configuration values in all authorize_req-related unit tests. Specifically, each test now directly configures:

    local_pre_authorize

    local_authorize_offline

    WebSocket connection status via ON_CALL(...).WillByDefault(...)

These changes ensure that test results are deterministic and isolated from global or default state, as described in issue #1042.

## Issue ticket number and link
Fixes #1042
https://github.com/EVerest/libocpp/issues/1042

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

