### PR TITLE
Bugfix/websocket ping pong

### DIFF
--- a/include/ocpp/common/websocket/websocket.hpp
+++ b/include/ocpp/common/websocket/websocket.hpp
@@ -64,8 +64,9 @@ public:
     /// \returns true if the message was sent successfully
     bool send(const std::string& message);
 
-    /// \brief set the websocket ping interval \p interval_s in seconds
-    void set_websocket_ping_interval(int32_t interval_s);
+    /// \brief set the websocket ping interval \p ping_interval_s in seconds and pong timeout \p pong_interval_s in
+    /// seconds
+    void set_websocket_ping_interval(int32_t ping_interval_s, int32_t pong_interval_s);
 
     /// \brief set the \p authorization_key of the connection_options
     void set_authorization_key(const std::string& authorization_key);

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -54,12 +54,12 @@ protected:
     std::function<void(ConnectionFailedReason)> connection_failed_callback;
     std::shared_ptr<boost::asio::steady_timer> reconnect_timer;
     std::unique_ptr<Everest::SteadyTimer> ping_timer;
+    std::atomic_bool ping_cleared;
     std::mutex reconnect_mutex;
     std::mutex connection_mutex;
     std::atomic_int reconnect_backoff_ms;
     std::atomic_int connection_attempts;
     std::atomic_bool shutting_down;
-    std::atomic_bool reconnecting;
 
     /// \brief Indicates if the required callbacks are registered
     /// \returns true if the websocket is properly initialized

--- a/include/ocpp/common/websocket/websocket_base.hpp
+++ b/include/ocpp/common/websocket/websocket_base.hpp
@@ -55,6 +55,8 @@ protected:
     std::shared_ptr<boost::asio::steady_timer> reconnect_timer;
     std::unique_ptr<Everest::SteadyTimer> ping_timer;
     std::atomic_bool ping_cleared;
+    std::int32_t ping_elapsed_s;
+    std::int32_t pong_elapsed_s;
     std::mutex reconnect_mutex;
     std::mutex connection_mutex;
     std::atomic_int reconnect_backoff_ms;
@@ -131,8 +133,9 @@ public:
     /// \returns true if the message was sent successfully
     virtual bool send(const std::string& message) = 0;
 
-    /// \brief starts a timer that sends a websocket ping at the given \p interval_s
-    void set_websocket_ping_interval(int32_t interval_s);
+    /// \brief starts a timer that sends a websocket ping at the given \p ping_interval_s and
+    /// waits for a pong response in \p pong_timeout_s
+    void set_websocket_ping_interval(int32_t ping_interval_s, int32_t pong_timeout_s);
 
     /// \brief set the \p authorization_key of the connection_options
     void set_authorization_key(const std::string& authorization_key);

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -85,9 +85,9 @@ bool Websocket::send(const std::string& message) {
     return this->websocket->send(message);
 }
 
-void Websocket::set_websocket_ping_interval(int32_t interval_s) {
+void Websocket::set_websocket_ping_interval(int32_t ping_interval_s, int32_t pong_interval_s) {
     this->logging->sys("WebsocketPingInterval changed");
-    this->websocket->set_websocket_ping_interval(interval_s);
+    this->websocket->set_websocket_ping_interval(ping_interval_s, pong_interval_s);
 }
 
 void Websocket::set_authorization_key(const std::string& authorization_key) {

--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -15,6 +15,8 @@ WebsocketBase::WebsocketBase() :
     reconnect_timer(nullptr),
     connection_attempts(1),
     ping_cleared(true),
+    ping_elapsed_s(0),
+    pong_elapsed_s(0),
     reconnect_backoff_ms(0),
     shutting_down(false) {
 
@@ -159,34 +161,56 @@ void WebsocketBase::cancel_reconnect_timer() {
     this->reconnect_timer = nullptr;
 }
 
-void WebsocketBase::set_websocket_ping_interval(int32_t interval_s) {
+void WebsocketBase::set_websocket_ping_interval(int32_t ping_interval_s, int32_t pong_timeout_s) {
+    static constexpr int32_t PING_TIMER_INTERVAL = 1;
+
     if (this->ping_timer) {
         this->ping_timer->stop();
     }
 
-    if (interval_s > 0) {
+    if (ping_interval_s > 0) {
+        EVLOG_debug << "Started a ping interval of: " << ping_interval_s
+                    << " s with a pong timeout of: " << pong_timeout_s << " s";
+
         this->ping_timer->interval(
             [this]() {
-                if (false == ping_cleared.load()) {
-                    on_pong_timeout("Pong not received from server!");
+                if (false == ping_cleared.load()) { // We have a ping to which we require a response
+                    pong_elapsed_s += PING_TIMER_INTERVAL;
 
-                    // Always clear ping value on a fail
-                    ping_cleared.store(true);
+                    // We have waited more than we should for the pong response
+                    if (pong_elapsed_s > this->connection_options.pong_timeout_s) {
+                        on_pong_timeout("Pong not received from server!");
 
-                    // Clear the ping timer
-                    if (this->ping_timer) {
-                        this->ping_timer->stop();
+                        // Always clear ping value on a fail
+                        ping_cleared.store(true);
+
+                        // Reset the elapsed time
+                        ping_elapsed_s = pong_elapsed_s = 0;
+
+                        // Clear the ping timer
+                        if (this->ping_timer) {
+                            this->ping_timer->stop();
+                        }
                     }
-                } else {
-                    // Set the ping flag before sending it out
-                    ping_cleared.store(false);
-                    this->ping();
+                } else { // We need to see if we have to send the ping
+                    ping_elapsed_s += PING_TIMER_INTERVAL;
+
+                    if (ping_elapsed_s > this->connection_options.ping_interval_s) {
+                        // Set the ping flag before sending it out
+                        ping_cleared.store(false);
+                        this->ping();
+
+                        // Reset the elapsed time
+                        ping_elapsed_s = pong_elapsed_s = 0;
+                    }
                 }
             },
-            std::chrono::seconds(interval_s));
+            // Tick each second to see if we reached a timeout
+            std::chrono::seconds(PING_TIMER_INTERVAL));
     }
 
-    this->connection_options.ping_interval_s = interval_s;
+    this->connection_options.ping_interval_s = ping_interval_s;
+    this->connection_options.pong_timeout_s = pong_timeout_s;
 }
 
 void WebsocketBase::set_authorization_key(const std::string& authorization_key) {

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1356,6 +1356,9 @@ int WebsocketLibwebsockets::process_callback(void* wsi_ptr, int callback_reason,
         break;
 
     case LWS_CALLBACK_CLIENT_RECEIVE_PONG: {
+        // Clear the ping when we receive the pong
+        ping_cleared.store(true);
+
         if (false == message_queue.empty()) {
             lws_callback_on_writable(data->get_conn());
         }
@@ -1502,7 +1505,6 @@ void WebsocketLibwebsockets::on_conn_connected(ConnectionData* conn_data) {
 
     this->connection_attempts = 1; // reset connection attempts
     this->m_is_connected = true;
-    this->reconnecting = false;
 
     this->set_websocket_ping_interval(this->connection_options.ping_interval_s);
 

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -396,6 +396,11 @@ void WebsocketLibwebsockets::set_connection_options(const WebsocketConnectionOpt
         throw std::invalid_argument("Ocpp_versions may not contain 'Unknown'");
     }
 
+    if (connection_options.pong_timeout_s > connection_options.ping_interval_s) {
+        EVLOG_warning << "Pong timeout of " << connection_options.pong_timeout_s
+                      << " s is larger than the ping interval of " << connection_options.ping_interval_s << " s";
+    }
+
     set_connection_options_base(connection_options);
 
     // Set secure URI only if it is in TLS mode
@@ -1506,7 +1511,8 @@ void WebsocketLibwebsockets::on_conn_connected(ConnectionData* conn_data) {
     this->connection_attempts = 1; // reset connection attempts
     this->m_is_connected = true;
 
-    this->set_websocket_ping_interval(this->connection_options.ping_interval_s);
+    this->set_websocket_ping_interval(this->connection_options.ping_interval_s,
+                                      this->connection_options.pong_timeout_s);
 
     // Stop any dangling reconnect
     {

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1893,9 +1893,12 @@ void ChargePointImpl::handleChangeConfigurationRequest(ocpp::Call<ChangeConfigur
                         this->configuration->getTransactionMessageRetryInterval());
                 } else if (call.msg.key == "WebsocketPingInterval") {
                     auto websocket_ping_interval_option = this->configuration->getWebsocketPingInterval();
+
                     if (websocket_ping_interval_option.has_value()) {
                         auto websocket_ping_interval = websocket_ping_interval_option.value();
-                        this->websocket->set_websocket_ping_interval(websocket_ping_interval);
+                        auto websocket_pong_timeout = this->configuration->getWebsocketPongTimeout();
+
+                        this->websocket->set_websocket_ping_interval(websocket_ping_interval, websocket_pong_timeout);
                     }
                 } else if (call.msg.key == "ISO15118PnCEnabled") {
                     if (ocpp::conversions::string_to_bool(call.msg.value.get())) {


### PR DESCRIPTION
## Describe your changes

After we connect, we initiate a ping timer with an pre-determined interval. When the ping is sent, a flag is set, awaiting it to be cleared when the server's pong is received. If that flag is not cleared, the ping timer will force the websocket to reconnect.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

