### PR TITLE
fix(OCPP1.6): DefaultPrice text

### DIFF
--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -458,8 +458,7 @@ public:
     std::optional<KeyValue> getPriceNumberOfDecimalsForCostValuesKeyValue();
 
     std::optional<std::string> getDefaultPriceText(const std::string& language);
-    TariffMessage getTariffMessageWithDefaultPriceText();
-    TariffMessage getTariffMessageWithDefaultPriceTextOffline();
+    TariffMessage getDefaultTariffMessage(bool offline);
     ConfigurationStatus setDefaultPriceText(const CiString<50>& key, const CiString<500>& value);
     KeyValue getDefaultPriceTextKeyValue(const std::string& language);
     std::optional<std::vector<KeyValue>> getAllDefaultPriceTextKeyValues();

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2619,47 +2619,49 @@ std::optional<std::string> ChargePointConfiguration::getDefaultPriceText(const s
     return std::nullopt;
 }
 
-TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceText() {
+TariffMessage ChargePointConfiguration::getDefaultTariffMessage(bool offline) {
     TariffMessage tariff_message;
-    if (this->config.contains("CostAndPrice") and this->config.at("CostAndPrice").contains("DefaultPriceText")) {
-        json& default_tariff = this->config["CostAndPrice"]["DefaultPriceText"];
 
-        if (!default_tariff.contains("priceTexts")) {
+    if (!this->config.contains("CostAndPrice")) {
+        EVLOG_warning << "No CostAndPrice configuration found, returning empty TariffMessage.";
+        return tariff_message;
+    }
+
+    const auto& cost_and_price = this->config.at("CostAndPrice");
+    const std::string key = offline ? "priceTextOffline" : "priceText";
+
+    if (cost_and_price.contains("DefaultPrice")) {
+        const auto& default_price = cost_and_price.at("DefaultPrice");
+        if (default_price.contains(key)) {
+            DisplayMessageContent content;
+            content.message = default_price.at(key);
+            content.language = this->getLanguage();
+            tariff_message.message.push_back(content);
+        }
+    }
+
+    if (cost_and_price.contains("DefaultPriceText")) {
+        const auto& default_price_text = cost_and_price.at("DefaultPriceText");
+
+        if (!default_price_text.contains("priceTexts")) {
             return tariff_message;
         }
 
-        for (auto& item : default_tariff.at("priceTexts").items()) {
-            const auto tariff_message_item = item.value();
-            if (tariff_message_item.contains("priceText") and tariff_message_item.contains("language")) {
+        for (auto& item : default_price_text.at("priceTexts").items()) {
+            const auto& message_item = item.value();
+            if (message_item.contains(key) && message_item.contains("language")) {
                 DisplayMessageContent content;
-                content.message = tariff_message_item.at("priceText");
-                content.language = tariff_message_item.at("language");
+                content.message = message_item.at(key);
+                content.language = message_item.at("language");
                 tariff_message.message.push_back(content);
             }
         }
     }
-    return tariff_message;
-}
 
-TariffMessage ChargePointConfiguration::getTariffMessageWithDefaultPriceTextOffline() {
-    TariffMessage tariff_message;
-    if (this->config.contains("CostAndPrice") and this->config.at("CostAndPrice").contains("DefaultPriceText")) {
-        json& default_tariff = this->config["CostAndPrice"]["DefaultPriceText"];
-
-        if (!default_tariff.contains("priceTexts")) {
-            return tariff_message;
-        }
-
-        for (auto& item : default_tariff.at("priceTexts").items()) {
-            const auto tariff_message_item = item.value();
-            if (tariff_message_item.contains("priceTextOffline") and tariff_message_item.contains("language")) {
-                DisplayMessageContent content;
-                content.message = tariff_message_item.at("priceTextOffline");
-                content.language = tariff_message_item.at("language");
-                tariff_message.message.push_back(content);
-            }
-        }
+    if (tariff_message.message.empty()) {
+        EVLOG_warning << "No tariff message found in CostAndPrice configuration, returning empty TariffMessage.";
     }
+
     return tariff_message;
 }
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3409,10 +3409,9 @@ EnhancedIdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const 
         const auto update_tariff_message_if_eligible = [this](EnhancedIdTagInfo& enhanced_id_tag_info) {
             if (enhanced_id_tag_info.id_tag_info.status == AuthorizationStatus::Accepted &&
                 this->configuration->getCustomDisplayCostAndPriceEnabled()) {
-                enhanced_id_tag_info.tariff_message =
-                    this->websocket->is_connected()
-                        ? this->configuration->getTariffMessageWithDefaultPriceText()
-                        : this->configuration->getTariffMessageWithDefaultPriceTextOffline();
+                enhanced_id_tag_info.tariff_message = this->websocket->is_connected()
+                                                          ? this->configuration->getDefaultTariffMessage(false)
+                                                          : this->configuration->getDefaultTariffMessage(true);
             }
         };
 
@@ -3491,7 +3490,7 @@ EnhancedIdTagInfo ChargePointImpl::authorize_id_token(CiString<20> idTag, const 
                     this->tariff_messages_by_id_token.erase(tariff_it);
                 } else {
                     EVLOG_warning << "Tariff message was not received within timeout for idToken " << idTag.get();
-                    enhanced_id_tag_info.tariff_message = this->configuration->getTariffMessageWithDefaultPriceText();
+                    enhanced_id_tag_info.tariff_message = this->configuration->getDefaultTariffMessage(false);
                 }
                 this->user_price_cvs.erase(idTag.get());
             }


### PR DESCRIPTION

## Describe your changes
Using correct default price texts if online / offline. Before this change, the DefaultPriceText.priceTexts[n] was used, although this configuration key is only meant for the non default languages as a backup

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

