### PR TITLE
Fix: Reconnects on pong timeout

### DIFF
--- a/lib/ocpp/common/websocket/websocket_base.cpp
+++ b/lib/ocpp/common/websocket/websocket_base.cpp
@@ -220,7 +220,7 @@ void WebsocketBase::set_authorization_key(const std::string& authorization_key) 
 void WebsocketBase::on_pong_timeout(std::string msg) {
     EVLOG_info << "Reconnecting because of a pong timeout after " << this->connection_options.pong_timeout_s << "s"
                << " and with reason: " << msg;
-    reconnect(1000);
+    this->close(WebsocketCloseReason::ServiceRestart, "Pong timeout"); // application code will handle the reconnect
 }
 
 } // namespace ocpp

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1538,6 +1538,11 @@ void WebsocketLibwebsockets::on_conn_close(ConnectionData* conn_data) {
 
     this->m_is_connected = false;
 
+    // pong timeout should not trigger when we are not connected
+    if (this->ping_timer) {
+        this->ping_timer->stop();
+    }
+
     {
         std::lock_guard<std::mutex> lk(this->reconnect_mutex);
         this->reconnect_timer_tpm.stop();
@@ -1576,6 +1581,11 @@ void WebsocketLibwebsockets::on_conn_fail(ConnectionData* conn_data) {
                 EVLOG_error << "Disconnected callback not registered!";
             }
         });
+    }
+
+    // pong timeout should not trigger when we are not connected
+    if (this->ping_timer) {
+        this->ping_timer->stop();
     }
 
     this->m_is_connected = false;


### PR DESCRIPTION
## Describe your changes
The reconnect on pong timeouts were not working correctly when when the websocket connection was already closed or failed.

This change 
- stops the ping timer in case the ws connection is closed or failed, no need to trigger the `on_pong_timeout`.
- `on_pong_timeout` calls close instead of `reconnect`, leaving it to the higher level application logic to initiate potential reconnects

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

