### PR TITLE
Fix json exceptions being thrown during handling of invalid messages

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1302,7 +1302,15 @@ void ChargePointImpl::message_callback(const std::string& message) {
         return;
     } catch (const json::exception& e) {
         EVLOG_error << "JSON exception during reception of message: " << e.what();
-        this->message_dispatcher->dispatch_call_error(CallError(MessageId("-1"), "GenericError", e.what(), json({})));
+        std::string error_message;
+        try {
+            error_message = json(e.what()).dump();
+        } catch (const json::exception& ex) {
+            error_message = "JSON exception during reception of message: ";
+            error_message += ex.what();
+        }
+        this->message_dispatcher->dispatch_call_error(
+            CallError(MessageId("-1"), "GenericError", error_message, json({})));
         return;
     } catch (const std::runtime_error& e) {
         EVLOG_error << "runtime_error during reception of message: " << e.what();


### PR DESCRIPTION
When certain malformed messages that during parsing result in a json exceptions are reported to the CSMS it was observed that secondary parsing exceptions can occur when the error message is sent to the CSMS as part of a CallError as well as when the incoming message in re-serialized in the security event to be sent.

This fixes #1104 by catching the secondary exception thrown during error message generation, and by not sending a truncated version of the problematic message but the error message instead.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

