### PR TITLE
Fix: Composite schedule calculation for connector 0

### DIFF
--- a/lib/ocpp/v16/smart_charging.cpp
+++ b/lib/ocpp/v16/smart_charging.cpp
@@ -246,7 +246,7 @@ EnhancedChargingSchedule SmartChargingHandler::calculate_enhanced_composite_sche
         // Get the ChargingStationExternalConstraints and Combined Tx(Default)Profiles per evse
         std::vector<IntermediateProfile> evse_schedules{};
         for (int evse = 1; evse <= nr_of_evses; evse++) {
-
+            session_start.reset();
             auto transaction = this->connectors.at(evse)->transaction;
             if (transaction != nullptr) {
                 session_start = transaction->get_start_energy_wh()->timestamp;

--- a/lib/ocpp/v2/functional_blocks/smart_charging.cpp
+++ b/lib/ocpp/v2/functional_blocks/smart_charging.cpp
@@ -536,7 +536,7 @@ CompositeSchedule SmartCharging::calculate_composite_schedule(const ocpp::DateTi
         // Get the ChargingStationExternalConstraints and Combined Tx(Default)Profiles per evse
         std::vector<IntermediateProfile> evse_schedules{};
         for (int evse = 1; evse <= nr_of_evses; evse++) {
-
+            session_start.reset();
             auto& transaction = this->context.evse_manager.get_evse(evse).get_transaction();
             if (this->context.evse_manager.get_evse(evse).get_transaction() != nullptr) {
                 session_start = this->context.evse_manager.get_evse(evse).get_transaction()->start_time;

--- a/tests/lib/ocpp/v16/json/TxDefault_relative.json
+++ b/tests/lib/ocpp/v16/json/TxDefault_relative.json
@@ -1,0 +1,36 @@
+{
+    "chargingProfileId": 66,
+    "chargingProfileKind": "Relative",
+    "chargingProfilePurpose": "TxDefaultProfile",
+    "chargingSchedule": {
+        "chargingRateUnit": "W",
+        "chargingSchedulePeriod": [
+            {
+                "limit": 1000,
+                "startPeriod": 0
+            },
+            {
+                "limit": 7000,
+                "startPeriod": 70
+            },
+            {
+                "limit": 0,
+                "startPeriod": 140
+            },
+            {
+                "limit": 6000,
+                "startPeriod": 210
+            },
+            {
+                "limit": 1500,
+                "startPeriod": 280
+            },
+            {
+                "limit": 5000,
+                "startPeriod": 350
+            }
+        ],
+        "minChargingRate": 500
+    },
+    "stackLevel": 1
+}

--- a/tests/lib/ocpp/v2/json/relative/TxDefault_relative.json
+++ b/tests/lib/ocpp/v2/json/relative/TxDefault_relative.json
@@ -1,0 +1,39 @@
+{
+    "id": 66,
+    "chargingProfileKind": "Relative",
+    "chargingProfilePurpose": "TxDefaultProfile",
+    "chargingSchedule": [
+        {
+            "id": 0,
+            "chargingRateUnit": "W",
+            "chargingSchedulePeriod": [
+                {
+                    "limit": 1000,
+                    "startPeriod": 0
+                },
+                {
+                    "limit": 7000,
+                    "startPeriod": 70
+                },
+                {
+                    "limit": 0,
+                    "startPeriod": 140
+                },
+                {
+                    "limit": 6000,
+                    "startPeriod": 210
+                },
+                {
+                    "limit": 1500,
+                    "startPeriod": 280
+                },
+                {
+                    "limit": 5000,
+                    "startPeriod": 350
+                }
+            ],
+            "minChargingRate": 500
+        }
+    ],
+    "stackLevel": 1
+}

--- a/tests/lib/ocpp/v2/mocks/evse_manager_fake.hpp
+++ b/tests/lib/ocpp/v2/mocks/evse_manager_fake.hpp
@@ -92,10 +92,11 @@ public:
         return std::nullopt;
     }
 
-    void open_transaction(int evse_id, const std::string& transaction_id) {
+    void open_transaction(int evse_id, const std::string& transaction_id, const DateTime& start_time = DateTime()) {
         auto& transaction = this->transactions.at(evse_id - 1);
         transaction = std::make_unique<EnhancedTransaction>(db_handler, false);
         transaction->transactionId = transaction_id;
+        transaction->start_time = start_time;
 
         auto& mock = this->get_mock(evse_id);
         EXPECT_CALL(mock, get_transaction).WillRepeatedly(testing::ReturnRef(this->transactions.at(evse_id - 1)));

--- a/tests/lib/ocpp/v2/test_composite_schedule.cpp
+++ b/tests/lib/ocpp/v2/test_composite_schedule.cpp
@@ -1119,4 +1119,86 @@ TEST_F(CompositeScheduleTestFixtureV2, NoGapsWithSequentialProfiles) {
                 ));
     // clang-format on
 }
+
+TEST_F(CompositeScheduleTestFixtureV2, TxDefaultConnector0) {
+    this->load_charging_profiles_for_evse("relative/TxDefault_relative.json", STATION_WIDE_ID);
+
+    constexpr int32_t nr_of_evses = 2;
+    this->reconfigure_for_nr_of_evses(nr_of_evses);
+
+    const DateTime start_time = ocpp::DateTime("2024-01-02T08:00:00");
+    const DateTime end_time = ocpp::DateTime("2024-01-02T08:20:00");
+
+    CompositeSchedule result_con0 =
+        handler->calculate_composite_schedule(start_time, end_time, 0, ChargingRateUnitEnum::W, false, true);
+
+    EXPECT_EQ(result_con0.evseId, STATION_WIDE_ID);
+    EXPECT_EQ(result_con0.scheduleStart, start_time);
+    EXPECT_EQ(result_con0.duration, 1200);
+    EXPECT_EQ(result_con0.chargingRateUnit, ChargingRateUnitEnum::W);
+
+    EXPECT_THAT(result_con0.chargingSchedulePeriod,
+                testing::ElementsAre(PeriodEquals(0, 2000.0F), PeriodEquals(70, 14000.0F), PeriodEquals(140, 0.0F),
+                                     PeriodEquals(210, 12000.0F), PeriodEquals(280, 3000.0F),
+                                     PeriodEquals(350, 10000.0F)));
+
+    CompositeSchedule result_con1 =
+        handler->calculate_composite_schedule(start_time, end_time, 1, ChargingRateUnitEnum::W, false, true);
+
+    EXPECT_EQ(result_con1.evseId, 1);
+    EXPECT_EQ(result_con1.scheduleStart, start_time);
+    EXPECT_EQ(result_con1.duration, 1200);
+    EXPECT_EQ(result_con1.chargingRateUnit, ChargingRateUnitEnum::W);
+
+    EXPECT_THAT(result_con1.chargingSchedulePeriod,
+                testing::ElementsAre(PeriodEquals(0, 1000.0F), PeriodEquals(70, 7000.0F), PeriodEquals(140, 0.0F),
+                                     PeriodEquals(210, 6000.0F), PeriodEquals(280, 1500.0F),
+                                     PeriodEquals(350, 5000.0F)));
+
+    CompositeSchedule result_con2 =
+        handler->calculate_composite_schedule(start_time, end_time, 2, ChargingRateUnitEnum::W, false, true);
+
+    EXPECT_EQ(result_con2.evseId, 2);
+    EXPECT_EQ(result_con2.scheduleStart, start_time);
+    EXPECT_EQ(result_con2.duration, 1200);
+    EXPECT_EQ(result_con2.chargingRateUnit, ChargingRateUnitEnum::W);
+
+    EXPECT_THAT(result_con2.chargingSchedulePeriod,
+                testing::ElementsAre(PeriodEquals(0, 1000.0F), PeriodEquals(70, 7000.0F), PeriodEquals(140, 0.0F),
+                                     PeriodEquals(210, 6000.0F), PeriodEquals(280, 1500.0F),
+                                     PeriodEquals(350, 5000.0F)));
+
+    const DateTime tx_start_time = ocpp::DateTime("2024-01-02T08:00:00");
+    const DateTime request_time = ocpp::DateTime("2024-01-02T08:03:00");
+    auto timer = std::unique_ptr<Everest::SteadyTimer>();
+
+    this->evse_manager->open_transaction(1, "TX_ID_12345", tx_start_time);
+
+    CompositeSchedule result_con1_tx_active =
+        handler->calculate_composite_schedule(request_time, end_time, 1, ChargingRateUnitEnum::W, false, true);
+
+    EXPECT_EQ(result_con1_tx_active.evseId, 1);
+    EXPECT_EQ(result_con1_tx_active.scheduleStart, request_time);
+    EXPECT_EQ(result_con1_tx_active.duration, 1020);
+    EXPECT_EQ(result_con1_tx_active.chargingRateUnit, ChargingRateUnitEnum::W);
+
+    EXPECT_THAT(result_con1_tx_active.chargingSchedulePeriod,
+                testing::ElementsAre(PeriodEquals(0, 0.0F), PeriodEquals(30, 6000.0F), PeriodEquals(100, 1500.0F),
+                                     PeriodEquals(170, 5000.0F)));
+
+    result_con0 =
+        handler->calculate_composite_schedule(request_time, end_time, 0, ChargingRateUnitEnum::W, false, true);
+
+    EXPECT_EQ(result_con0.evseId, STATION_WIDE_ID);
+    EXPECT_EQ(result_con0.scheduleStart, request_time);
+    EXPECT_EQ(result_con0.duration, 1020);
+    EXPECT_EQ(result_con0.chargingRateUnit, ChargingRateUnitEnum::W);
+
+    EXPECT_THAT(result_con0.chargingSchedulePeriod,
+                testing::ElementsAre(PeriodEquals(0, 1000.0F), PeriodEquals(30, 7000.0F), PeriodEquals(70, 13000.0F),
+                                     PeriodEquals(100, 8500.0F), PeriodEquals(140, 1500.0F), PeriodEquals(170, 5000.0F),
+                                     PeriodEquals(210, 11000.0F), PeriodEquals(280, 6500.0F),
+                                     PeriodEquals(350, 10000.0F)));
+}
+
 } // namespace ocpp::v2


### PR DESCRIPTION
## Describe your changes
Changed composite schedule calculation for connector 0:
* When generating the EVSE intermediate profiles, the session start time was not calculated and passed to the generate_evse_intermediates function. This caused an invalid calculation of the IntermediateProfile for EVSEs with an active transaction, because the session_start time was not considered
* For composite schedule for connector 0, the summing limits were incorrectly included, even when no limits for setpoints or discharge limits had been set by the CSMS. This has been fixed by excluding setpoint calculation for connector 0 in general.
* A limit of 0A was not applied for composite schedules for connector 0. This has been fixed by changing a `> 0` to a `>= 0` 

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

