### PR TITLE
fix(v21): Fix V2XChargingCtrlr variables

### DIFF
--- a/config/v2/component_config/standardized/ISO15118Ctrlr.json
+++ b/config/v2/component_config/standardized/ISO15118Ctrlr.json
@@ -4,6 +4,21 @@
   "name": "ISO15118Ctrlr",
   "type": "object",
   "properties": {
+    "ISO15118CtrlrAvailable": {
+      "variable_name": "Available",
+      "characteristics": {
+        "supportsMonitoring": true,
+        "dataType": "boolean"
+      },
+      "attributes": [
+        {
+          "type": "Actual",
+          "mutability": "ReadOnly",
+          "value": true
+        }
+      ],
+      "type": "boolean"
+    },
     "ISO15118CtrlrEnabled": {
       "variable_name": "Enabled",
       "characteristics": {

--- a/include/ocpp/v2/charge_point_callbacks.hpp
+++ b/include/ocpp/v2/charge_point_callbacks.hpp
@@ -31,10 +31,13 @@ struct Callbacks {
     /// \brief Function to check if the callback struct is completely filled. All std::functions should hold a function,
     ///       all std::optional<std::functions> should either be empty or hold a function.
     /// \param device_model The device model, to check if certain modules are enabled / available.
+    /// \param evse_connector_structure The evse_connector_structure is used to check variables for specific evse and/or
+    /// connector
     ///
     /// \retval false if any of the normal callbacks are nullptr or any of the optional ones are filled with a nullptr
     ///        true otherwise
-    bool all_callbacks_valid(std::shared_ptr<DeviceModel> device_model) const;
+    bool all_callbacks_valid(std::shared_ptr<DeviceModel> device_model,
+                             const std::map<int32_t, int32_t>& evse_connector_structure) const;
 
     ///
     /// \brief Callback if reset is allowed. If evse_id has a value, reset only applies to the given evse id. If it has

--- a/include/ocpp/v2/ctrlr_component_variables.hpp
+++ b/include/ocpp/v2/ctrlr_component_variables.hpp
@@ -62,6 +62,11 @@ extern const std::vector<Variable> required_evse_variables;
 ///
 extern const std::vector<Variable> required_connector_variables;
 
+///
+/// \brief Required variables of a V2X component.
+///
+extern const std::vector<Variable> required_v2x_variables;
+
 namespace ControllerComponents {
 extern const Component InternalCtrlr;
 extern const Component AlignedDataCtrlr;
@@ -303,24 +308,7 @@ extern const RequiredComponentVariable StopTxOnInvalidId;
 extern const ComponentVariable TxBeforeAcceptedEnabled;
 extern const RequiredComponentVariable TxStartPoint;
 extern const RequiredComponentVariable TxStopPoint;
-extern const ComponentVariable V2XChargingCtrlrAvailable;
-extern const RequiredComponentVariable V2XChargingCtrlrEnabled;
-extern const RequiredComponentVariable V2XChargingCtrlrSupportedEnergyTransferModes;
-extern const RequiredComponentVariable V2XChargingCtrlrSupportedOperationModes;
-extern const ComponentVariable V2XSampledDataTxStartedMeasurands;
-extern const ComponentVariable V2XSampledDataTxEndedMeasurands;
-extern const ComponentVariable V2XSampledDataTxEndedInterval;
-extern const ComponentVariable V2XSampledDataTxUpdatedMeasurands;
-extern const ComponentVariable V2XSampledDataTxUpdatedInterval;
 extern const ComponentVariable ISO15118CtrlrAvailable;
-extern const ComponentVariable ISO15118CtrlrEnabled;
-extern const ComponentVariable ISO15118CtrlrServiceRenegotiationSupport;
-extern const ComponentVariable ISO15118CtrlrProtocolSupported;
-ComponentVariable get_v2x_tx_started_measurands(const OperationModeEnum& mode);
-ComponentVariable get_v2x_tx_ended_measurands(const OperationModeEnum& mode);
-ComponentVariable get_v2x_tx_ended_interval(const OperationModeEnum& mode);
-ComponentVariable get_v2x_tx_updated_measurands(const OperationModeEnum& mode);
-ComponentVariable get_v2x_tx_updated_interval(const OperationModeEnum& mode);
 } // namespace ControllerComponentVariables
 
 namespace EvseComponentVariables {
@@ -341,6 +329,35 @@ extern const Variable Type;
 extern const Variable SupplyPhases;
 ComponentVariable get_component_variable(const int32_t evse_id, const int32_t connector_id, const Variable& variable);
 } // namespace ConnectorComponentVariables
+
+namespace V2xComponentVariables {
+extern const Variable Available;
+extern const Variable Enabled;
+extern const Variable SupportedEnergyTransferModes;
+extern const Variable SupportedOperationModes;
+extern const Variable TxStartedMeasurands;
+extern const Variable TxEndedMeasurands;
+extern const Variable TxEndedInterval;
+extern const Variable TxUpdatedMeasurands;
+extern const Variable TxUpdatedInterval;
+Variable get_v2x_tx_started_measurands(const OperationModeEnum& mode);
+Variable get_v2x_tx_ended_measurands(const OperationModeEnum& mode);
+Variable get_v2x_tx_ended_interval(const OperationModeEnum& mode);
+Variable get_v2x_tx_updated_measurands(const OperationModeEnum& mode);
+Variable get_v2x_tx_updated_interval(const OperationModeEnum& mode);
+ComponentVariable get_component_variable(const int32_t evse_id, const Variable& variable);
+} // namespace V2xComponentVariables
+
+namespace ISO15118ComponentVariables {
+extern const Variable Enabled;
+extern const Variable ServiceRenegotiationSupport;
+extern const Variable ProtocolSupported;
+// These variables are defined again here as it is possible to have either a global variable or evse specific
+extern const Variable SeccId;
+extern const Variable CountryName;
+extern const Variable OrganizationName;
+ComponentVariable get_component_variable(const int32_t evse_id, const Variable& variable);
+} // namespace ISO15118ComponentVariables
 
 namespace ConnectedEvComponentVariables {
 extern const Variable Available;

--- a/lib/ocpp/v2/charge_point_callbacks.cpp
+++ b/lib/ocpp/v2/charge_point_callbacks.cpp
@@ -4,7 +4,8 @@
 
 namespace ocpp::v2 {
 
-bool Callbacks::all_callbacks_valid(std::shared_ptr<DeviceModel> device_model) const {
+bool Callbacks::all_callbacks_valid(std::shared_ptr<DeviceModel> device_model,
+                                    const std::map<int32_t, int32_t>& evse_connector_structure) const {
     bool valid =
         this->is_reset_allowed_callback != nullptr and this->reset_callback != nullptr and
         this->stop_transaction_callback != nullptr and this->pause_charging_callback != nullptr and
@@ -87,8 +88,16 @@ bool Callbacks::all_callbacks_valid(std::shared_ptr<DeviceModel> device_model) c
             }
         }
 
-        if (device_model->get_optional_value<bool>(ControllerComponentVariables::V2XChargingCtrlrAvailable)
-                .value_or(false) and
+        bool v2x_available = std::any_of(
+            evse_connector_structure.begin(), evse_connector_structure.end(), [device_model](const auto& entry) {
+                const auto& [evse, connectors] = entry;
+                return device_model
+                    ->get_optional_value<bool>(
+                        V2xComponentVariables::get_component_variable(evse, V2xComponentVariables::Available))
+                    .value_or(false);
+            });
+
+        if (v2x_available and
             device_model->get_optional_value<bool>(ControllerComponentVariables::ISO15118CtrlrAvailable)
                 .value_or(false)) {
             if (!this->update_allowed_energy_transfer_modes_callback.has_value() or

--- a/lib/ocpp/v2/ctrlr_component_variables.cpp
+++ b/lib/ocpp/v2/ctrlr_component_variables.cpp
@@ -27,7 +27,6 @@ const Component SecurityCtrlr = {"SecurityCtrlr"};
 const Component SmartChargingCtrlr = {"SmartChargingCtrlr"};
 const Component TariffCostCtrlr = {"TariffCostCtrlr"};
 const Component TxCtrlr = {"TxCtrlr"};
-const Component V2XChargingCtrlr = {"V2XChargingCtrlr"};
 } // namespace ControllerComponents
 
 namespace StandardizedVariables {
@@ -1203,126 +1202,12 @@ const RequiredComponentVariable TxStopPoint = {
     }),
 };
 
-const ComponentVariable V2XChargingCtrlrAvailable = {
-    ControllerComponents::V2XChargingCtrlr,
-    std::optional<Variable>({
-        "Available",
-    }),
-};
-
-const RequiredComponentVariable V2XChargingCtrlrEnabled = {ControllerComponents::V2XChargingCtrlr,
-                                                           std::optional<Variable>({
-                                                               "Enabled",
-                                                           }),
-                                                           std::nullopt,
-                                                           {OcppProtocolVersion::v21}};
-
-const RequiredComponentVariable V2XChargingCtrlrSupportedEnergyTransferModes = {ControllerComponents::V2XChargingCtrlr,
-                                                                                std::optional<Variable>({
-                                                                                    "SupportedEnergyTransferModes",
-                                                                                }),
-                                                                                std::nullopt,
-                                                                                {OcppProtocolVersion::v21}};
-
-const RequiredComponentVariable V2XChargingCtrlrSupportedOperationModes = {ControllerComponents::V2XChargingCtrlr,
-                                                                           std::optional<Variable>({
-                                                                               "SupportedOperationModes",
-                                                                           }),
-                                                                           std::nullopt,
-                                                                           {OcppProtocolVersion::v21}};
-
-const ComponentVariable V2XSampledDataTxStartedMeasurands = {
-    ControllerComponents::V2XChargingCtrlr,
-    std::optional<Variable>({
-        "TxStartedMeasurands",
-    }),
-};
-
-const ComponentVariable V2XSampledDataTxEndedMeasurands = {
-    ControllerComponents::V2XChargingCtrlr,
-    std::optional<Variable>({
-        "TxEndedMeasurands",
-    }),
-};
-
-const ComponentVariable V2XSampledDataTxEndedInterval = {
-    ControllerComponents::V2XChargingCtrlr,
-    std::optional<Variable>({
-        "TxEndedInterval",
-    }),
-};
-
-const ComponentVariable V2XSampledDataTxUpdatedMeasurands = {
-    ControllerComponents::V2XChargingCtrlr,
-    std::optional<Variable>({
-        "TxUpdatedMeasurands",
-    }),
-};
-
-const ComponentVariable V2XSampledDataTxUpdatedInterval = {
-    ControllerComponents::V2XChargingCtrlr,
-    std::optional<Variable>({
-        "TxUpdatedInterval",
-    }),
-};
-
 const ComponentVariable ISO15118CtrlrAvailable = {
     ControllerComponents::ISO15118Ctrlr,
     std::optional<Variable>({
         "Available",
     }),
 };
-
-const ComponentVariable ISO15118CtrlrEnabled = {
-    ControllerComponents::ISO15118Ctrlr,
-    std::optional<Variable>({
-        "Enabled",
-    }),
-};
-
-const ComponentVariable ISO15118CtrlrServiceRenegotiationSupport = {
-    ControllerComponents::ISO15118Ctrlr,
-    std::optional<Variable>({
-        "ServiceRenegotiationSupport",
-    }),
-};
-
-const ComponentVariable ISO15118CtrlrProtocolSupported = {
-    ControllerComponents::ISO15118Ctrlr,
-    std::optional<Variable>({
-        "ProtocolSupported",
-    }),
-};
-
-ComponentVariable get_v2x_tx_started_measurands(const OperationModeEnum& mode) {
-    ComponentVariable cv = ControllerComponentVariables::V2XSampledDataTxStartedMeasurands;
-    cv.variable.value().instance = conversions::operation_mode_enum_to_string(mode);
-    return cv;
-}
-
-ComponentVariable get_v2x_tx_ended_measurands(const OperationModeEnum& mode) {
-    ComponentVariable cv = ControllerComponentVariables::V2XSampledDataTxEndedMeasurands;
-    cv.variable.value().instance = conversions::operation_mode_enum_to_string(mode);
-    return cv;
-}
-
-ComponentVariable get_v2x_tx_ended_interval(const OperationModeEnum& mode) {
-    ComponentVariable cv = ControllerComponentVariables::V2XSampledDataTxEndedInterval;
-    cv.variable.value().instance = conversions::operation_mode_enum_to_string(mode);
-    return cv;
-}
-
-ComponentVariable get_v2x_tx_updated_measurands(const OperationModeEnum& mode) {
-    ComponentVariable cv = ControllerComponentVariables::V2XSampledDataTxUpdatedMeasurands;
-    cv.variable.value().instance = conversions::operation_mode_enum_to_string(mode);
-    return cv;
-}
-
-ComponentVariable get_v2x_tx_updated_interval(const OperationModeEnum& mode) {
-    ComponentVariable cv = ControllerComponentVariables::V2XSampledDataTxUpdatedInterval;
-    cv.variable.value().instance = conversions::operation_mode_enum_to_string(mode);
-    return cv;
-}
 
 } // namespace ControllerComponentVariables
 
@@ -1362,6 +1247,78 @@ ComponentVariable get_component_variable(const int32_t evse_id, const int32_t co
     return component_variable;
 }
 } // namespace ConnectorComponentVariables
+
+namespace V2xComponentVariables {
+
+const Variable Available = {"Available"};
+const Variable Enabled = {"Enabled"};
+const Variable SupportedEnergyTransferModes = {"SupportedEnergyTransferModes"};
+const Variable SupportedOperationModes = {"SupportedOperationModes"};
+const Variable TxStartedMeasurands = {"TxStartedMeasurands"};
+const Variable TxEndedMeasurands = {"TxEndedMeasurands"};
+const Variable TxEndedInterval = {"TxEndedInterval"};
+const Variable TxUpdatedMeasurands = {"TxUpdatedMeasurands"};
+const Variable TxUpdatedInterval = {"TxUpdatedInterval"};
+
+Variable get_v2x_tx_started_measurands(const OperationModeEnum& mode) {
+    Variable cv = V2xComponentVariables::TxStartedMeasurands;
+    cv.instance = conversions::operation_mode_enum_to_string(mode);
+    return cv;
+}
+
+Variable get_v2x_tx_ended_measurands(const OperationModeEnum& mode) {
+    Variable cv = V2xComponentVariables::TxEndedMeasurands;
+    cv.instance = conversions::operation_mode_enum_to_string(mode);
+    return cv;
+}
+
+Variable get_v2x_tx_ended_interval(const OperationModeEnum& mode) {
+    Variable cv = V2xComponentVariables::TxEndedInterval;
+    cv.instance = conversions::operation_mode_enum_to_string(mode);
+    return cv;
+}
+
+Variable get_v2x_tx_updated_measurands(const OperationModeEnum& mode) {
+    Variable cv = V2xComponentVariables::TxUpdatedMeasurands;
+    cv.instance = conversions::operation_mode_enum_to_string(mode);
+    return cv;
+}
+
+Variable get_v2x_tx_updated_interval(const OperationModeEnum& mode) {
+    Variable cv = V2xComponentVariables::TxUpdatedInterval;
+    cv.instance = conversions::operation_mode_enum_to_string(mode);
+    return cv;
+}
+
+ComponentVariable get_component_variable(const int32_t evse_id, const Variable& variable) {
+    EVSE evse = {evse_id};
+    Component component = {"V2XChargingCtrlr", evse};
+    ComponentVariable component_variable;
+    component_variable.component = component;
+    component_variable.variable = variable;
+    return component_variable;
+}
+} // namespace V2xComponentVariables
+
+namespace ISO15118ComponentVariables {
+
+const Variable Available = {"Available"};
+const Variable Enabled = {"Enabled"};
+const Variable ServiceRenegotiationSupport = {"ServiceRenegotiationSupport"};
+const Variable ProtocolSupported = {"ProtocolSupported"};
+const Variable SeccId = {"SeccId"};
+const Variable CountryName = {"CountryName"};
+const Variable OrganizationName = {"OrganizationName"};
+
+ComponentVariable get_component_variable(const int32_t evse_id, const Variable& variable) {
+    EVSE evse = {evse_id};
+    Component component = {"ISO15118Ctrlr", evse};
+    ComponentVariable component_variable;
+    component_variable.component = component;
+    component_variable.variable = variable;
+    return component_variable;
+}
+} // namespace ISO15118ComponentVariables
 
 namespace ConnectedEvComponentVariables {
 
@@ -1415,11 +1372,7 @@ const std::vector<std::pair<ComponentVariable, std::vector<RequiredComponentVari
         {ControllerComponentVariables::DisplayMessageCtrlrAvailable,
          {ControllerComponentVariables::NumberOfDisplayMessages,
           ControllerComponentVariables::DisplayMessageSupportedFormats,
-          ControllerComponentVariables::DisplayMessageSupportedPriorities}},
-        {ControllerComponentVariables::V2XChargingCtrlrAvailable,
-         {ControllerComponentVariables::V2XChargingCtrlrEnabled,
-          ControllerComponentVariables::V2XChargingCtrlrSupportedEnergyTransferModes,
-          ControllerComponentVariables::V2XChargingCtrlrSupportedOperationModes}}};
+          ControllerComponentVariables::DisplayMessageSupportedPriorities}}};
 
 const std::vector<RequiredComponentVariable> required_variables{
     ControllerComponentVariables::AlignedDataInterval,
@@ -1490,5 +1443,8 @@ const std::vector<Variable> required_connector_variables{
     ConnectorComponentVariables::Available, ConnectorComponentVariables::AvailabilityState,
     ConnectorComponentVariables::SupplyPhases, ConnectorComponentVariables::Type};
 
+const std::vector<Variable> required_v2x_variables{V2xComponentVariables::Available, V2xComponentVariables::Enabled,
+                                                   V2xComponentVariables::SupportedEnergyTransferModes,
+                                                   V2xComponentVariables::SupportedOperationModes};
 } // namespace v2
 } // namespace ocpp

--- a/lib/ocpp/v2/device_model.cpp
+++ b/lib/ocpp/v2/device_model.cpp
@@ -575,6 +575,23 @@ void DeviceModel::check_integrity(const std::map<int32_t, int32_t>& evse_connect
                 throw DeviceModelError("maxLimit of 'Power' not set");
             }
 
+            Component v2x_component;
+            v2x_component.name = "V2XChargingCtrlr";
+            v2x_component.evse = evse;
+            if (this->device_model_map.count(v2x_component) and
+                std::any_of(evse_connector_structure.begin(), evse_connector_structure.end(),
+                            [this](const auto& entry) {
+                                const auto& [evse, connectors] = entry;
+                                return get_optional_value<bool>(V2xComponentVariables::get_component_variable(
+                                                                    evse, V2xComponentVariables::Available))
+                                    .value_or(false);
+                            })) {
+                for (const auto& required_variable : required_v2x_variables) {
+                    const auto& variable = V2xComponentVariables::get_component_variable(evse_id, required_variable);
+                    check_variable_has_value(variable);
+                }
+            }
+
             for (size_t connector_id = 1; connector_id <= nr_of_connectors; connector_id++) {
                 evse_component.name = "Connector";
                 evse_component.evse.value().connectorId = connector_id;

--- a/lib/ocpp/v21/functional_blocks/bidirectional.cpp
+++ b/lib/ocpp/v21/functional_blocks/bidirectional.cpp
@@ -57,6 +57,7 @@ void ocpp::v2::Bidirectional::handle_notify_allowed_energy_transfer(
         this->context.message_dispatcher.dispatch_call_result(call_result);
         return;
     }
+    // TODO(mlitre): Check if evse supports v2x
 
     const auto selected_protocol = this->context.device_model.get_optional_value<std::string>(
         ConnectedEvComponentVariables::get_component_variable(evse_id.value(),
@@ -67,7 +68,8 @@ void ocpp::v2::Bidirectional::handle_notify_allowed_energy_transfer(
 
     const bool service_renegotiation_supported =
         this->context.device_model
-            .get_optional_value<bool>(ControllerComponentVariables::ISO15118CtrlrServiceRenegotiationSupport)
+            .get_optional_value<bool>(ISO15118ComponentVariables::get_component_variable(
+                evse_id.value(), ISO15118ComponentVariables::ServiceRenegotiationSupport))
             .value_or(false);
 
     if (service_renegotiation_supported and is_15118_20 and this->notify_allowed_energy_transfer_callback.has_value()) {


### PR DESCRIPTION
## Describe your changes

V2X variables were set globally when they were supposed to be evse specific.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

