### PR TITLE
fix(generator): Fix generator for required arrays of string enums

### DIFF
--- a/lib/ocpp/v21/messages/NotifyAllowedEnergyTransfer.cpp
+++ b/lib/ocpp/v21/messages/NotifyAllowedEnergyTransfer.cpp
@@ -21,8 +21,11 @@ void to_json(json& j, const NotifyAllowedEnergyTransferRequest& k) {
     // the required parts of the message
     j = json{
         {"transactionId", k.transactionId},
-        {"allowedEnergyTransfer", k.allowedEnergyTransfer},
+        {"allowedEnergyTransfer", json::array()},
     };
+    for (auto val : k.allowedEnergyTransfer) {
+        j["allowedEnergyTransfer"].push_back(ocpp::v2::conversions::energy_transfer_mode_enum_to_string(val));
+    }
     // the optional parts of the message
     if (k.customData) {
         j["customData"] = k.customData.value();
@@ -33,7 +36,7 @@ void from_json(const json& j, NotifyAllowedEnergyTransferRequest& k) {
     // the required parts of the message
     k.transactionId = j.at("transactionId");
     for (auto val : j.at("allowedEnergyTransfer")) {
-        k.allowedEnergyTransfer.push_back(val);
+        k.allowedEnergyTransfer.push_back(ocpp::v2::conversions::string_to_energy_transfer_mode_enum(val));
     }
 
     // the optional parts of the message

--- a/src/code_generator/common/templates/message.cpp.jinja
+++ b/src/code_generator/common/templates/message.cpp.jinja
@@ -37,6 +37,8 @@ namespace {{namespace}} {
     {%- else %}
         {%- if property.type == 'ocpp::DateTime' %}
 k.{{property.name}}.to_rfc3339()
+        {% elif property.type.startswith('std::vector<') and property.type.endswith('Enum>') %}
+            json::array()
         {%- else %}
 k.{{property.name}}
         {%- endif %}
@@ -48,6 +50,17 @@ k.{{property.name}}
 {%- else %}
 };
 {%- endif %}
+{%- for property in type.properties %}
+{%- if property.required and property.type.startswith('std::vector<') and property.type.endswith('Enum>')%}
+            for (auto val : k.{{property.name}}) {
+                {%- if property.type.endswith('Enum>') %}
+                j["{{property.name}}"].push_back({{ conversions_namespace_prefix }}conversions::{{- property.type.replace('std::vector<','').replace('>','') | snake_case}}_to_string(val));
+                {%- else%}
+                j["{{property.name}}"].push_back(val);
+                {%- endif%}
+            }
+{%- endif%}
+{%- endfor %}
 
         // the optional parts of the message
 {% for property in type.properties %}
@@ -97,7 +110,11 @@ j["{{property.name}}"] = k.{{property.name}}.value();
 {% if property.required %}
 {% if property.type.startswith('std::vector<') %}
         for (auto val : j.at("{{property.name}}")) {
+{%- if property.type.endswith('Enum>') %}
+            k.{{property.name}}.push_back({{ conversions_namespace_prefix }}conversions::string_to_{{- property.type.replace('std::vector<','').replace('>','') | snake_case}}(val));
+{% else %}
             k.{{property.name}}.push_back(val);
+{% endif %}
         }
 {% else %}
         k.{{property.name}} =
@@ -131,7 +148,7 @@ j["{{property.name}}"] = k.{{property.name}}.value();
             k.{{property.name}}.emplace(vec);
 {% else %}
 {% if property.enum %}
-            k.{{property.name}}.emplace({{ conversions_namespace_prefix }}conversions::string_to_{{- property.type | snake_case}}(j.at("{{property.name}}")));
+            k.{{property.name}}.emplace({{ conversions_namespace_prefix }}conversions::string_to_{{- property.type.replace('std::vector<','').replace('>','') | snake_case}}(j.at("{{property.name}}")));
 {% else %}
 {% if property.type == 'ocpp::DateTime' %}
             k.{{property.name}}.emplace(ocpp::DateTime(std::string(j.at("{{property.name}}"))));


### PR DESCRIPTION
## Describe your changes

Prior to this commit we could not handle arrays of string enums as we expected integers since we used the default assignment. This commit preserves the current implementation (not forcing array of objects to be constructed by "push back") and only force arrays of enums to be done more tediously.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

