### PR TITLE
Revert "revert ChangeAvailability scheduled for reserved state"

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1719,7 +1719,8 @@ void ChargePointImpl::preprocess_change_availability_request(
     // should report an availability status of "Scheduled"
     auto should_be_scheduled_func = [this](int32_t connector) {
         return this->transaction_handler->transaction_active(connector) or
-               this->status->get_state(connector) == ChargePointStatus::Preparing;
+               this->status->get_state(connector) == ChargePointStatus::Preparing or
+               this->status->get_state(connector) == ChargePointStatus::Reserved;
     };
 
     // check if connector exists
@@ -4792,6 +4793,7 @@ void ChargePointImpl::on_reservation_start(int32_t connector) {
 }
 
 void ChargePointImpl::on_reservation_end(int32_t connector) {
+    this->execute_queued_availability_change(connector);
     this->status->submit_event(connector, FSMEvent::ReservationEnd, ocpp::DateTime());
 }
 


### PR DESCRIPTION
Reverts EVerest/libocpp#1024
Without this we just set the status to available even if there is a reservation in progress.