### PR TITLE
fix(ocpp16): Typo in WebSocketPintInterval config key name

### DIFF
--- a/config/v16/config-docker.json
+++ b/config/v16/config-docker.json
@@ -31,7 +31,7 @@
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true,
-        "WebsocketPingInterval": 10
+        "WebSocketPingInterval": 10
     },
     "FirmwareManagement": {
         "SupportedFileTransferProtocols": "FTP"

--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -129,10 +129,8 @@
     "PnC": {
         "ISO15118PnCEnabled": true,
         "CentralContractValidationAllowed": true,
-        "CertificateSignedMaxChainSize": 10000,
         "CertSigningWaitMinimum": 30,
         "CertSigningRepeatTimes": 2,
-        "CertificateStoreMaxLength": 1000,
         "ContractValidationOffline": true
     },
     "CostAndPrice": {

--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -97,7 +97,7 @@
         "TransactionMessageAttempts": 1,
         "TransactionMessageRetryInterval": 10,
         "UnlockConnectorOnEVSideDisconnect": true,
-        "WebsocketPingInterval": 10
+        "WebSocketPingInterval": 10
     },
     "LocalAuthListManagement": {
         "LocalAuthListEnabled": true,

--- a/config/v16/profile_schemas/Core.json
+++ b/config/v16/profile_schemas/Core.json
@@ -180,7 +180,7 @@
             "type": "boolean",
             "readOnly": false
         },
-        "WebsocketPingInterval": {
+        "WebSocketPingInterval": {
             "type": "integer",
             "readOnly": false,
             "minimum": 0

--- a/config/v16/profile_schemas/PnC.json
+++ b/config/v16/profile_schemas/PnC.json
@@ -14,13 +14,6 @@
       "description": "If this variable exists and has the value true, then the Charge Point can provide a contract certificate that it cannot validate to the Central System for validation as part of the Authorize.req.",
       "readOnly": false
     },
-    "CertificateSignedMaxChainSize": {
-      "type": "integer",
-      "description": "This configuration key can be used to limit the size of the 'certificateChain' field from the CertificateSigned.req PDU",
-      "maximum": 10000,
-      "minimum": 0,
-      "readOnly": true
-    },
     "CertSigningWaitMinimum": {
       "type": "integer",
       "description": "This configuration key defines how long the Charge Point has to wait (in seconds) before generating another CSR, in the case the Central System accepts the SignCertificate.req, but never returns the signed certificate back.",
@@ -32,12 +25,6 @@
       "description": "This configuration key can be used to configure the amount of times the Charge Point SHALL double the previous back-off time",
       "minimum": 0,
       "readOnly": false
-    },
-    "CertificateStoreMaxLength": {
-      "type": "integer",
-      "description": "Maximum number of Root/CA certificates that can be installed in the Charge Point.",
-      "minimum": 1,
-      "readOnly": true
     },
     "ContractValidationOffline": {
       "type": "boolean",

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -344,6 +344,11 @@ public:
 
     // Core Profile end
 
+    // Firmware Management Profile
+
+    std::optional<std::string> getSupportedFileTransferProtocols();
+    std::optional<KeyValue> getSupportedFileTransferProtocolsKeyValue();
+
     // SmartCharging Profile
     int32_t getChargeProfileMaxStackLevel();
     KeyValue getChargeProfileMaxStackLevelKeyValue();

--- a/lib/ocpp/common/websocket/websocket.cpp
+++ b/lib/ocpp/common/websocket/websocket.cpp
@@ -86,7 +86,7 @@ bool Websocket::send(const std::string& message) {
 }
 
 void Websocket::set_websocket_ping_interval(int32_t ping_interval_s, int32_t pong_interval_s) {
-    this->logging->sys("WebsocketPingInterval changed");
+    this->logging->sys("WebSocketPingInterval changed");
     this->websocket->set_websocket_ping_interval(ping_interval_s, pong_interval_s);
 }
 

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -1922,6 +1922,30 @@ std::optional<KeyValue> ChargePointConfiguration::getIFaceKeyValue() {
 
 // Core Profile end
 
+// Firmware Management Profile
+std::optional<std::string> ChargePointConfiguration::getSupportedFileTransferProtocols() {
+    std::optional<std::string> supported_file_transfer_protocols = std::nullopt;
+    if (this->config["FirmwareManagement"].contains("SupportedFileTransferProtocols")) {
+        supported_file_transfer_protocols.emplace(this->config["FirmwareManagement"]["SupportedFileTransferProtocols"]);
+    }
+    return supported_file_transfer_protocols;
+}
+
+std::optional<KeyValue> ChargePointConfiguration::getSupportedFileTransferProtocolsKeyValue() {
+    std::optional<KeyValue> supported_file_transfer_protocols_kv = std::nullopt;
+    auto supported_file_transfer_protocols = this->getSupportedFileTransferProtocols();
+    if (supported_file_transfer_protocols != std::nullopt) {
+        KeyValue kv;
+        kv.key = "SupportedFileTransferProtocols";
+        kv.readonly = true;
+        kv.value.emplace(supported_file_transfer_protocols.value());
+        supported_file_transfer_protocols_kv.emplace(kv);
+    }
+    return supported_file_transfer_protocols_kv;
+}
+
+// Firmware Managet Profile end
+
 int32_t ChargePointConfiguration::getChargeProfileMaxStackLevel() {
     return this->config["SmartCharging"]["ChargeProfileMaxStackLevel"];
 }
@@ -2179,8 +2203,8 @@ std::optional<KeyValue> ChargePointConfiguration::getAuthorizationKeyKeyValue() 
 // Security profile - optional
 std::optional<int32_t> ChargePointConfiguration::getCertificateSignedMaxChainSize() {
     std::optional<int32_t> certificate_max_chain_size = std::nullopt;
-    if (this->config["Core"].contains("CertificateMaxChainSize")) {
-        certificate_max_chain_size.emplace(this->config["Security"]["CertificateMaxChainSize"]);
+    if (this->config["Security"].contains("CertificateSignedMaxChainSize")) {
+        certificate_max_chain_size.emplace(this->config["Security"]["CertificateSignedMaxChainSize"]);
     }
     return certificate_max_chain_size;
 }
@@ -2190,7 +2214,7 @@ std::optional<KeyValue> ChargePointConfiguration::getCertificateSignedMaxChainSi
     auto certificate_max_chain_size = this->getCertificateSignedMaxChainSize();
     if (certificate_max_chain_size != std::nullopt) {
         KeyValue kv;
-        kv.key = "CertificateMaxChainSize";
+        kv.key = "CertificateSignedMaxChainSize";
         kv.readonly = true;
         kv.value.emplace(std::to_string(certificate_max_chain_size.value()));
         certificate_max_chain_size_kv.emplace(kv);
@@ -2201,7 +2225,7 @@ std::optional<KeyValue> ChargePointConfiguration::getCertificateSignedMaxChainSi
 // Security profile - optional
 std::optional<int32_t> ChargePointConfiguration::getCertificateStoreMaxLength() {
     std::optional<int32_t> certificate_store_max_length = std::nullopt;
-    if (this->config["Core"].contains("CertificateStoreMaxLength")) {
+    if (this->config["Security"].contains("CertificateStoreMaxLength")) {
         certificate_store_max_length.emplace(this->config["Security"]["CertificateStoreMaxLength"]);
     }
     return certificate_store_max_length;
@@ -3314,10 +3338,6 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     if (key == "AuthorizationCacheEnabled") {
         return this->getAuthorizationCacheEnabledKeyValue();
     }
-    // we should not return an AuthorizationKey because it's readonly
-    // if (key == "AuthorizationKey") {
-    //     return this->getAuthorizationKeyKeyValue();
-    // }
     if (key == "AuthorizeRemoteTxRequests") {
         return this->getAuthorizeRemoteTxRequestsKeyValue();
     }
@@ -3335,9 +3355,6 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     }
     if (key == "ConnectorPhaseRotationMaxLength") {
         return this->getConnectorPhaseRotationMaxLengthKeyValue();
-    }
-    if (key == "CpoName") {
-        return this->getCpoNameKeyValue();
     }
     if (key == "GetConfigurationMaxKeys") {
         return this->getGetConfigurationMaxKeysKeyValue();
@@ -3384,12 +3401,6 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     if (key == "ResetRetries") {
         return this->getResetRetriesKeyValue();
     }
-    if (key == "SecurityProfile") {
-        return this->getSecurityProfileKeyValue();
-    }
-    if (key == "DisableSecurityEventNotifications") {
-        return this->getDisableSecurityEventNotificationsKeyValue();
-    }
     if (key == "StopTransactionOnEVSideDisconnect") {
         return this->getStopTransactionOnEVSideDisconnectKeyValue();
     }
@@ -3427,6 +3438,13 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
         return this->getWebsocketPingIntervalKeyValue();
     }
 
+    // Firmware Management
+    if (this->supported_feature_profiles.count(SupportedFeatureProfiles::FirmwareManagement)) {
+        if (key == "SupportedFileTransferProtocols") {
+            return this->getSupportedFileTransferProtocolsKeyValue();
+        }
+    }
+
     // PnC
     if (this->supported_feature_profiles.count(SupportedFeatureProfiles::PnC)) {
         if (key == "ISO15118PnCEnabled") {
@@ -3462,6 +3480,32 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
         }
         if (key == "MaxChargingProfilesInstalled") {
             return this->getMaxChargingProfilesInstalledKeyValue();
+        }
+    }
+
+    // Security (always added as supported feature profile)
+    if (this->supported_feature_profiles.count(SupportedFeatureProfiles::Security)) {
+        if (key == "AdditionalRootCertificateCheck") {
+            return this->getAdditionalRootCertificateCheckKeyValue();
+        }
+        // we should not return an AuthorizationKey because it's readonly
+        // if (key == "AuthorizationKey") {
+        //     return this->getAuthorizationKeyKeyValue();
+        // }
+        if (key == "CertificateSignedMaxChainSize") {
+            return this->getCertificateSignedMaxChainSizeKeyValue();
+        }
+        if (key == "CertificateStoreMaxLength") {
+            return this->getCertificateStoreMaxLengthKeyValue();
+        }
+        if (key == "CpoName") {
+            return this->getCpoNameKeyValue();
+        }
+        if (key == "SecurityProfile") {
+            return this->getSecurityProfileKeyValue();
+        }
+        if (key == "DisableSecurityEventNotifications") {
+            return this->getDisableSecurityEventNotificationsKeyValue();
         }
     }
 

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -1870,15 +1870,15 @@ KeyValue ChargePointConfiguration::getUnlockConnectorOnEVSideDisconnectKeyValue(
 // Core Profile - optional
 std::optional<int32_t> ChargePointConfiguration::getWebsocketPingInterval() {
     std::optional<int32_t> websocket_ping_interval = std::nullopt;
-    if (this->config["Core"].contains("WebsocketPingInterval")) {
-        websocket_ping_interval.emplace(this->config["Core"]["WebsocketPingInterval"]);
+    if (this->config["Core"].contains("WebSocketPingInterval")) {
+        websocket_ping_interval.emplace(this->config["Core"]["WebSocketPingInterval"]);
     }
     return websocket_ping_interval;
 }
 void ChargePointConfiguration::setWebsocketPingInterval(int32_t websocket_ping_interval) {
     if (this->getWebsocketPingInterval() != std::nullopt) {
-        this->config["Core"]["WebsocketPingInterval"] = websocket_ping_interval;
-        this->setInUserConfig("Core", "WebsocketPingInterval", websocket_ping_interval);
+        this->config["Core"]["WebSocketPingInterval"] = websocket_ping_interval;
+        this->setInUserConfig("Core", "WebSocketPingInterval", websocket_ping_interval);
     }
 }
 std::optional<KeyValue> ChargePointConfiguration::getWebsocketPingIntervalKeyValue() {
@@ -1886,7 +1886,7 @@ std::optional<KeyValue> ChargePointConfiguration::getWebsocketPingIntervalKeyVal
     auto websocket_ping_interval = this->getWebsocketPingInterval();
     if (websocket_ping_interval != std::nullopt) {
         KeyValue kv;
-        kv.key = "WebsocketPingInterval";
+        kv.key = "WebSocketPingInterval";
         kv.readonly = false;
         kv.value.emplace(std::to_string(websocket_ping_interval.value()));
         websocket_ping_interval_kv.emplace(kv);
@@ -3423,7 +3423,7 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
     if (key == "UnlockConnectorOnEVSideDisconnect") {
         return this->getUnlockConnectorOnEVSideDisconnectKeyValue();
     }
-    if (key == "WebsocketPingInterval") {
+    if (key == "WebSocketPingInterval") {
         return this->getWebsocketPingIntervalKeyValue();
     }
 
@@ -3888,7 +3888,7 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
             return ConfigurationStatus::Rejected;
         }
     }
-    if (key == "WebsocketPingInterval") {
+    if (key == "WebSocketPingInterval") {
         if (this->getWebsocketPingInterval() == std::nullopt) {
             return ConfigurationStatus::NotSupported;
         }

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1917,7 +1917,7 @@ void ChargePointImpl::handleChangeConfigurationRequest(ocpp::Call<ChangeConfigur
                 } else if (call.msg.key == "TransactionMessageRetryInterval") {
                     this->message_queue->update_transaction_message_retry_interval(
                         this->configuration->getTransactionMessageRetryInterval());
-                } else if (call.msg.key == "WebsocketPingInterval") {
+                } else if (call.msg.key == "WebSocketPingInterval") {
                     auto websocket_ping_interval_option = this->configuration->getWebsocketPingInterval();
 
                     if (websocket_ping_interval_option.has_value()) {


### PR DESCRIPTION
## Describe your changes
* Removed `CertificateSignedMaxChainSize` and `CertificateStoreMaxLength` from PnC profile since those were present int the Security Profile already
* Some config keys were not properly reported and have been added: `CertificateSignedMaxChainSize`, `CertificateStoreMaxLength`, `SupportedFileTransferProtocols`
* A typo in the `WebSocketPingInterval` config key has been fixed

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

