### PR TITLE
fix(ocpp16): Set the correct websocket connection options after upgrade

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -303,6 +303,10 @@ void ChargePointImpl::init_websocket() {
             not this->configuration->getIgnoredProfilePurposesOffline().empty()) {
             this->signal_set_charging_profiles_callback();
         }
+        // Reupdate ws connection options once connected so that after upgrading security profile we use the real config
+        // values. Prior we would continue using only 1 connection attempt
+        auto connection_options = this->get_ws_connection_options();
+        this->websocket->set_connection_options(connection_options);
     });
     this->websocket->register_disconnected_callback([this]() {
         if (this->connection_state_changed_callback != nullptr) {


### PR DESCRIPTION
We would keep using only one connection attempt after a profile upgrade, even if the upgrade was successful.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

