### PR TITLE
feat(ocpp16): add ISO15118CertificateManagementEnabled configuration option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.29.0
+    VERSION 0.30.0
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/config/v16/config-docker-tls.json
+++ b/config/v16/config-docker-tls.json
@@ -48,6 +48,7 @@
         "MaxChargingProfilesInstalled": 42
     },
     "PnC": {
+        "ISO15118CertificateManagementEnabled": true,
         "ISO15118PnCEnabled": true,
         "ContractValidationOffline": true
     },

--- a/config/v16/config-docker.json
+++ b/config/v16/config-docker.json
@@ -53,6 +53,7 @@
         "MaxChargingProfilesInstalled": 42
     },
     "PnC": {
+        "ISO15118CertificateManagementEnabled": true,
         "ISO15118PnCEnabled": true,
         "ContractValidationOffline": true
     },

--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -127,6 +127,7 @@
         "DisableSecurityEventNotifications": false
     },
     "PnC": {
+        "ISO15118CertificateManagementEnabled": true,
         "ISO15118PnCEnabled": true,
         "CentralContractValidationAllowed": true,
         "CertSigningWaitMinimum": 30,

--- a/config/v16/config.json
+++ b/config/v16/config.json
@@ -49,6 +49,7 @@
         "SecurityProfile": 0
     },
     "PnC": {
+        "ISO15118CertificateManagementEnabled": true,
         "ISO15118PnCEnabled": true,
         "ContractValidationOffline": true
     },

--- a/config/v16/profile_schemas/PnC.json
+++ b/config/v16/profile_schemas/PnC.json
@@ -4,9 +4,15 @@
   "type": "object",
   "required": ["ISO15118PnCEnabled", "ContractValidationOffline"],
   "properties": {
+    "ISO15118CertificateManagementEnabled": {
+      "type": "boolean",
+      "description": "If this variable set to true, then the Charge Point supports ISO 15118 plug and charge messages via the DataTransfer mechanism as described in the application note. It also enables the mechanism to trigger SECC leaf certificate updates if the existing certificate is about to expire.",
+      "readOnly": false,
+      "default": false
+    },
     "ISO15118PnCEnabled": {
       "type": "boolean",
-      "description": "If this variable set to true, then the Charge Point supports ISO 15118 plug and charge messages via the DataTransfer mechanism as described in this application note.",
+      "description": "If this variable set to true, then the Charge Point supports ISO 15118 plug and charge authorization via contract certificates.",
       "readOnly": false
     },
     "CentralContractValidationAllowed": {

--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -418,6 +418,10 @@ public:
     KeyValue getSendLocalListMaxLengthKeyValue();
 
     // PnC
+    bool getISO15118CertificateManagementEnabled();
+    void setISO15118CertificateManagementEnabled(const bool iso15118_certificate_management_enabled);
+    KeyValue getISO15118CertificateManagementEnabledKeyValue();
+
     bool getISO15118PnCEnabled();
     void setISO15118PnCEnabled(const bool iso15118_pnc_enabled);
     KeyValue getISO15118PnCEnabledKeyValue();

--- a/include/ocpp/v16/charge_point_impl.hpp
+++ b/include/ocpp/v16/charge_point_impl.hpp
@@ -309,6 +309,7 @@ private:
     void handleClearChargingProfileRequest(Call<ClearChargingProfileRequest> call);
 
     // plug&charge for 1.6 whitepaper
+    bool is_iso15118_certificate_management_enabled();
     bool is_pnc_enabled();
     void data_transfer_pnc_sign_certificate();
     void data_transfer_pnc_get_certificate_status(const ocpp::v2::OCSPRequestData& ocsp_request_data);

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -69,7 +69,7 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
             EVLOG_debug << "Using a charge point configuration without default values.";
         } else {
             // extend config with default values
-            EVLOG_debug << "Adding the following default values to the charge point configuration: " << patch;
+            EVLOG_info << "Adding the following default values to the charge point configuration: " << patch;
             auto patched_config = this->config.patch(patch);
             this->config = patched_config;
         }
@@ -2354,6 +2354,25 @@ KeyValue ChargePointConfiguration::getSendLocalListMaxLengthKeyValue() {
     return kv;
 }
 
+// PnC Profile
+bool ChargePointConfiguration::getISO15118CertificateManagementEnabled() {
+    return this->config["PnC"]["ISO15118CertificateManagementEnabled"];
+}
+
+void ChargePointConfiguration::setISO15118CertificateManagementEnabled(
+    const bool iso15118_certificate_management_enabled) {
+    this->config["PnC"]["ISO15118CertificateManagementEnabled"] = iso15118_certificate_management_enabled;
+    this->setInUserConfig("PnC", "ISO15118CertificateManagementEnabled", iso15118_certificate_management_enabled);
+}
+
+KeyValue ChargePointConfiguration::getISO15118CertificateManagementEnabledKeyValue() {
+    KeyValue kv;
+    kv.key = "ISO15118CertificateManagementEnabled";
+    kv.readonly = false;
+    kv.value.emplace(ocpp::conversions::bool_to_string(this->getISO15118CertificateManagementEnabled()));
+    return kv;
+}
+
 bool ChargePointConfiguration::getISO15118PnCEnabled() {
     return this->config["PnC"]["ISO15118PnCEnabled"];
 }
@@ -3447,6 +3466,9 @@ std::optional<KeyValue> ChargePointConfiguration::get(CiString<50> key) {
 
     // PnC
     if (this->supported_feature_profiles.count(SupportedFeatureProfiles::PnC)) {
+        if (key == "ISO15118CertificateManagementEnabled") {
+            return this->getISO15118CertificateManagementEnabledKeyValue();
+        }
         if (key == "ISO15118PnCEnabled") {
             return this->getISO15118PnCEnabledKeyValue();
         }
@@ -3754,6 +3776,9 @@ ConfigurationStatus ChargePointConfiguration::set(CiString<50> key, CiString<500
         } catch (const std::out_of_range& e) {
             return ConfigurationStatus::Rejected;
         }
+    }
+    if (key == "ISO15118CertificateManagementEnabled") {
+        this->setISO15118CertificateManagementEnabled(ocpp::conversions::string_to_bool(value.get()));
     }
     if (key == "ISO15118PnCEnabled") {
         this->setISO15118PnCEnabled(ocpp::conversions::string_to_bool(value.get()));

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -1672,7 +1672,7 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
         // send initial StatusNotification.req
         this->status->trigger_status_notifications();
 
-        if (this->is_pnc_enabled()) {
+        if (this->is_iso15118_certificate_management_enabled()) {
             this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
             this->v2g_certificate_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
         }
@@ -1682,7 +1682,7 @@ void ChargePointImpl::handleBootNotificationResponse(ocpp::CallResult<BootNotifi
             this->client_certificate_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
         }
 
-        if (this->is_pnc_enabled()) {
+        if (this->is_iso15118_certificate_management_enabled()) {
             this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
         }
 
@@ -1926,7 +1926,7 @@ void ChargePointImpl::handleChangeConfigurationRequest(ocpp::Call<ChangeConfigur
 
                         this->websocket->set_websocket_ping_interval(websocket_ping_interval, websocket_pong_timeout);
                     }
-                } else if (call.msg.key == "ISO15118PnCEnabled") {
+                } else if (call.msg.key == "ISO15118CertificateManagementEnabled") {
                     if (ocpp::conversions::string_to_bool(call.msg.value.get())) {
                         this->ocsp_request_timer->stop();
                         this->ocsp_request_timer->timeout(INITIAL_CERTIFICATE_REQUESTS_DELAY);
@@ -1937,7 +1937,7 @@ void ChargePointImpl::handleChangeConfigurationRequest(ocpp::Call<ChangeConfigur
                         this->v2g_certificate_timer->stop();
                     }
                 } else if (call.msg.key == "OcspRequestInterval") {
-                    if (this->is_pnc_enabled()) {
+                    if (this->is_iso15118_certificate_management_enabled()) {
                         this->ocsp_request_timer->stop();
                         this->ocsp_request_timer->interval(
                             std::chrono::seconds(this->configuration->getOcspRequestInterval()));
@@ -2027,9 +2027,9 @@ void ChargePointImpl::handleDataTransferRequest(ocpp::Call<DataTransferRequest> 
     // first try the callbacks that are explicitly registered for a vendorId or messageId
     {
         std::lock_guard<std::mutex> lock(data_transfer_callbacks_mutex);
-        if (vendorId == ISO15118_PNC_VENDOR_ID and !this->is_pnc_enabled()) {
+        if (vendorId == ISO15118_PNC_VENDOR_ID and !this->is_iso15118_certificate_management_enabled()) {
             response.status = DataTransferStatus::UnknownVendorId;
-        } else if (vendorId == ISO15118_PNC_VENDOR_ID and this->is_pnc_enabled()) {
+        } else if (vendorId == ISO15118_PNC_VENDOR_ID and this->is_iso15118_certificate_management_enabled()) {
             if (this->data_transfer_pnc_callbacks.count(messageId)) {
                 // there is a ISO15118 PnC callback registered for this vendorId and messageId
                 const auto callback = this->data_transfer_pnc_callbacks[messageId];
@@ -3592,6 +3592,11 @@ ChargePointImpl::get_all_enhanced_composite_charging_schedules(const int32_t dur
 bool ChargePointImpl::is_pnc_enabled() {
     return this->configuration->getSupportedFeatureProfilesSet().count(SupportedFeatureProfiles::PnC) and
            this->configuration->getISO15118PnCEnabled();
+}
+
+bool ChargePointImpl::is_iso15118_certificate_management_enabled() {
+    return this->configuration->getSupportedFeatureProfilesSet().count(SupportedFeatureProfiles::PnC) and
+           this->configuration->getISO15118CertificateManagementEnabled();
 }
 
 ocpp::v2::AuthorizeResponse ChargePointImpl::data_transfer_pnc_authorize(

--- a/tests/config/v16/resources/config.json
+++ b/tests/config/v16/resources/config.json
@@ -50,6 +50,7 @@
         "SecurityProfile": 0
     },
     "PnC": {
+        "ISO15118CertificateManagementEnabled": true,
         "ISO15118PnCEnabled": true,
         "ContractValidationOffline": true
     },


### PR DESCRIPTION

## Describe your changes
* Introduces a new boolean config parameter  to enable ISO15118 certificate management for Plug and Charge via DataTransfer
* It replaces the ISO15118PnCEnabled behavior partly. ISO15118PnCEnabled now only controls if contract certificate service is enabled via ISO15118
* Updates include config files, schema definitions, charge point configuration handling, and related logic in the charge point implementation.

Note that this commit changes the application logic of the ISO15118PnCEnabled option. Care must me be taken when updating from an older version. The change of behavior was required for the Hubject Plug&Charge certification.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

