### PR TITLE
fix(ocpp16): Make UnlockConnectorOnEVSideDisconnect RO configurable

### DIFF
--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -20,6 +20,7 @@ private:
     json config;
     json custom_schema;
     json internal_schema;
+    bool core_schema_unlock_connector_on_ev_side_disconnect_ro_value;
     fs::path user_config_path;
 
     std::set<SupportedFeatureProfiles> supported_feature_profiles;


### PR DESCRIPTION
The read only attribute of UnlockConnectorOnEVSideDisconnect is now configurable based on the schema that is loaded with the software. By changing the value in schema, we can now have RO or RW for this key.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

