### PR TITLE
[OCPP 1.6] StatusNotification timestamp is updated to represent the report time

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -3412,7 +3412,7 @@ void ChargePointImpl::status_notification(const int32_t connector, const ChargeP
     request.connectorId = connector;
     request.errorCode = errorCode;
     request.status = status;
-    request.timestamp = timestamp;
+    request.timestamp = ocpp::DateTime();
     request.info = info;
     request.vendorId = vendor_id;
     request.vendorErrorCode = vendor_error_code;


### PR DESCRIPTION
## Describe your changes

The OCPP 1.6 specification for StatusNotification.req states:

    timestamp
    Optional. The time for which the status is reported. If absent time
    of receipt of the message will be assumed.

The timestamp should represent the time the StatusNotification.req was sent and not the time the condition that triggered the message occurred. (i.e. when StatusNotification.req is sent and not when over voltage was detected).

One option would be to omit the timestamp completely. However that is useful information especially when offline queuing of messages is enabled.

The time of the original event (e.g. over voltage) should be available from the diagnostic logs if needed.

As a minimum (when offline queuing is not enabled) the StatusNotification.req messages on reconnect to the CSMS should represent the current time are they are indicating the current state of the charger.

This should also be the case when responding to a TriggerMessage.

### Reproduce
run the SIL (run-sil-ocpp.sh) and nodered (nodered-sil.sh)
make sure the CS is connected to the CSMS
activate an error condition via the nodered browser and ensure that the StatusNotification is received by the CSMS.
Stop and restart the CSMS and look at the StatusNotification messages on reconnect.
Send a TriggerMessage for StatusNotification and look at the StatusNotification (this has occasionally shown a previous time - on older versions of libocpp - doesn't not appear to be an issue on main)

e.g.
```
2025-08-13 14:33:29,316 Rx: [2,"8fccf790-cc8b-4c5c-8766-9ad6e00a4906","StatusNotification",{"connectorId":0,"errorCode":"NoError","status":"Available","timestamp":"2025-08-13T13:33:29.229Z"}]
2025-08-13 14:33:29,317 Tx: [3,"8fccf790-cc8b-4c5c-8766-9ad6e00a4906",{}]
2025-08-13 14:33:29,318 Rx: [2,"6004d084-81d5-47e1-823b-ce2f0e9da12c","StatusNotification",{"connectorId":1,"errorCode":"OtherError","info":"caused_by:evse_board_support/MREC5OverVoltage","status":"Faulted","timestamp":"2025-08-13T13:30:29.574Z","vendorErrorCode":"MREC5OverVoltage","vendorId":"EVerest"}]
2025-08-13 14:33:29,318 Tx: [3,"6004d084-81d5-47e1-823b-ce2f0e9da12c",{}]
2025-08-13 14:33:29,319 Rx: [2,"ab7dab58-da2a-4232-a47e-a3a3a2ed8a5e","StatusNotification",{"connectorId":2,"errorCode":"NoError","status":"Available","timestamp":"2025-08-13T13:33:29.229Z"}]
2025-08-13 14:33:29,320 Tx: [3,"ab7dab58-da2a-4232-a47e-a3a3a2ed8a5e",{}]
```
Note how the timestamp for connector 1 doesn't match the timestamps for connectors 0 and 2

connector|timestamp
---------------|---------------
0|2025-08-13T13:33:29.229Z
1|2025-08-13T13:30:29.574Z
2|2025-08-13T13:33:29.229Z

(localtime during the test was UTC+1)

## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

