### PR TITLE
Removed misleading TLS logging

### DIFF
--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -1090,7 +1090,7 @@ static bool send_internal(lws* wsi, WebsocketMessage* msg) {
 
     if (sent < 0) {
         // Fatal error, conn closed
-        EVLOG_error << "Error sending message over TLS websocket, conn closed.";
+        EVLOG_error << "Error sending message, conn closed.";
         msg->sent_bytes = 0;
         return false;
     }
@@ -1103,8 +1103,7 @@ static bool send_internal(lws* wsi, WebsocketMessage* msg) {
     msg->sent_bytes = sent;
 
     if (static_cast<size_t>(sent) < message_len) {
-        EVLOG_error << "Error sending message over TLS websocket. Sent bytes: " << sent
-                    << " Total to send: " << message_len;
+        EVLOG_error << "Error sending message. Sent bytes: " << sent << " Total to send: " << message_len;
         return false;
     }
 
@@ -1147,7 +1146,7 @@ void WebsocketLibwebsockets::poll_message(const std::shared_ptr<WebsocketMessage
         }
     }
 
-    EVLOG_debug << "Queueing message over TLS websocket: " << msg->payload;
+    EVLOG_debug << "Queueing message: " << msg->payload;
     message_queue.push(msg);
 
     // Request a write callback
@@ -1157,9 +1156,9 @@ void WebsocketLibwebsockets::poll_message(const std::shared_ptr<WebsocketMessage
                                        std::chrono::seconds(MESSAGE_SEND_TIMEOUT_S));
 
     if (msg->message_sent) {
-        EVLOG_debug << "Successfully sent last message over TLS websocket!";
+        EVLOG_debug << "Successfully sent last message!";
     } else {
-        EVLOG_warning << "Could not send last message over TLS websocket!";
+        EVLOG_warning << "Could not send last message!";
     }
 }
 


### PR DESCRIPTION
## Describe your changes
Some log statements incorrectly indicated that a TLS websocket connection was active, even when it was not. The information if it is a TLS or no TLS connection was not relevant for the log statements and therefore simply removed.

## Issue ticket number and link
https://github.com/EVerest/libocpp/issues/1136

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

