### PR TITLE
Bugfix/typo in log messages raw

### DIFF
--- a/config/v2/component_config/standardized/InternalCtrlr.json
+++ b/config/v2/component_config/standardized/InternalCtrlr.json
@@ -267,7 +267,7 @@
           "type": "boolean"
       },
       "LogMessagesRaw": {
-          "variable_name": "LogMessages",
+          "variable_name": "LogMessagesRaw",
           "characteristics": {
               "supportsMonitoring": true,
               "dataType": "boolean"

--- a/lib/ocpp/common/ocpp_logging.cpp
+++ b/lib/ocpp/common/ocpp_logging.cpp
@@ -348,11 +348,13 @@ void MessageLogging::security(const std::string& msg) {
 }
 
 void MessageLogging::raw(const std::string& msg, LogType log_type) {
-    log_output(log_type, msg, "", true);
-    if (this->session_logging) {
-        std::scoped_lock lock(this->session_id_logging_mutex);
-        for (auto const& [session_id, logging] : this->session_id_logging) {
-            log_output(log_type, "", msg, true);
+    if (this->log_raw) {
+        log_output(log_type, msg, "", true);
+        if (this->session_logging) {
+            std::scoped_lock lock(this->session_id_logging_mutex);
+            for (auto const& [session_id, logging] : this->session_id_logging) {
+                log_output(log_type, "", msg, true);
+            }
         }
     }
 }


### PR DESCRIPTION
## Describe your changes
LogMessagesRaw variable was accidentally still called LogMessages in its variable name for OCPP 2.x

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

