### PR TITLE
fix(ocpp16): Replace existing language in DefaultPriceText

### DIFF
--- a/config/v16/config-full.json
+++ b/config/v16/config-full.json
@@ -172,7 +172,7 @@
         "NextTimeOffsetTransitionDateTime": "2024-01-01T00:00:00",
         "TimeOffsetNextTransition": "01:00",
         "CustomIdleFeeAfterStop": false,
-        "MultiLanguageSupportedLanguages": "en, nl, de, nb_NO",
+        "SupportedLanguages": "en, nl, de, nb_NO",
         "CustomMultiLanguageMessages": true,
         "Language": "en",
         "WaitForSetUserPriceTimeout": 5000

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -2859,7 +2859,25 @@ ConfigurationStatus ChargePointConfiguration::setDefaultPriceText(const CiString
         default_price["priceTexts"] = json::array();
     }
 
-    default_price["priceTexts"].push_back(j);
+    auto& price_texts = default_price.at("priceTexts");
+
+    if (!price_texts.is_array()) {
+        EVLOG_error << "Error while setting default price: 'priceTexts' is not an array";
+        return ConfigurationStatus::Rejected;
+    }
+
+    bool language_found = false;
+    for (auto& price_text : price_texts.items()) {
+        if (price_text.value().at("language").get<std::string>() == language) {
+            price_text.value() = j;
+            language_found = true;
+            break;
+        }
+    }
+
+    if (!language_found) {
+        default_price["priceTexts"].push_back(j);
+    }
 
     this->config["CostAndPrice"]["DefaultPriceText"] = default_price;
     this->setInUserConfig("CostAndPrice", "DefaultPriceText", default_price);


### PR DESCRIPTION
## Describe your changes
fix(ocpp16): This fixes the issue that an existing DefaultPriceText,<language> key could be set but did not replace an entry that already existed. If the entry for this language already exists, it is now overriden

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

