### PR TITLE
Bump version to 0.30.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 project(ocpp
-    VERSION 0.30.2
+    VERSION 0.30.3
     DESCRIPTION "A C++ implementation of the Open Charge Point Protocol"
     LANGUAGES CXX
 )

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -19,7 +19,7 @@ liblog:
   options: ["BUILD_EXAMPLES OFF"]
 libtimer:
   git: https://github.com/EVerest/libtimer.git
-  git_tag: v0.1.2
+  git_tag: v0.1.3
   options: ["BUILD_EXAMPLES OFF"]
 date:
   git: https://github.com/HowardHinnant/date.git
@@ -27,7 +27,7 @@ date:
   options: ["BUILD_TZ_LIB ON", "HAS_REMOTE_API 0", "USE_AUTOLOAD 0", "USE_SYSTEM_TZ_DB ON"]
 libevse-security:
   git: https://github.com/EVerest/libevse-security.git
-  git_tag: v0.9.9
+  git_tag: 06db4b29e0a4ea4c6c40d77b6ecae7c153f4d9d7 # FIXME v0.10.0
 libwebsockets:
   git: https://github.com/warmcat/libwebsockets.git
   git_tag: v4.4.1


### PR DESCRIPTION
Update dependencies:
libtimer: v0.1.3 (Boost 1.89 compatibility fix)
libevse-security: v0.10.0 (bugfixes)

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

