### PR TITLE
Add compatibility with Boost 1.89

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,13 @@ if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TEST
     append_coverage_compiler_flags()
 endif()
 
+# this policy allows us to continue using the removed FindBoost module for now
+if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 OLD)
+endif()
+
 # dependencies
-find_package(Boost COMPONENTS program_options regex system thread REQUIRED)
+find_package(Boost COMPONENTS program_options regex thread REQUIRED)
 find_package(SQLite3 REQUIRED)
 find_package(OpenSSL 3 REQUIRED)
 


### PR DESCRIPTION
remove unnecessary find_package for Boost system

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

