### PR TITLE
tls provider update

### DIFF
--- a/include/ocpp/common/websocket/websocket_libwebsockets.hpp
+++ b/include/ocpp/common/websocket/websocket_libwebsockets.hpp
@@ -56,7 +56,7 @@ private:
     /// \return True if it was successful, false otherwise
     bool initialize_connection_options(std::shared_ptr<ConnectionData>& new_connection_data);
 
-    bool tls_init(struct ssl_ctx_st* ctx, const std::string& path_chain, const std::string& path_key, bool custom_key,
+    bool tls_init(struct ssl_ctx_st* ctx, const std::string& path_chain, const std::string& path_key,
                   std::optional<std::string>& password);
 
     /// \brief Websocket processing thread loop

--- a/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
+++ b/lib/ocpp/common/websocket/websocket_libwebsockets.cpp
@@ -59,7 +59,6 @@ public:
 
 namespace ocpp {
 
-using evse_security::is_custom_private_key_file;
 using evse_security::OpenSSLProvider;
 
 enum class EConnectionState {
@@ -445,7 +444,7 @@ static const struct lws_protocols protocols[] = {{local_protocol_name, callback_
                                                  LWS_PROTOCOL_LIST_TERM};
 
 bool WebsocketLibwebsockets::tls_init(SSL_CTX* ctx, const std::string& path_chain, const std::string& path_key,
-                                      bool custom_key, std::optional<std::string>& password) {
+                                      std::optional<std::string>& password) {
     auto rc = SSL_CTX_set_cipher_list(ctx, this->connection_options.supported_ciphers_12.c_str());
     if (rc != 1) {
         EVLOG_debug << "SSL_CTX_set_cipher_list return value: " << rc;
@@ -653,22 +652,9 @@ bool WebsocketLibwebsockets::initialize_connection_options(std::shared_ptr<Conne
             private_key_password = certificate_info.password;
         }
 
-        bool custom_key = false;
-
-        if (!path_key.empty()) {
-            custom_key = is_custom_private_key_file(path_key);
-        }
-
         OpenSSLProvider provider;
-
-        if (custom_key) {
-            provider.set_tls_mode(OpenSSLProvider::mode_t::custom_provider);
-        } else {
-            provider.set_tls_mode(OpenSSLProvider::mode_t::default_provider);
-        }
-
         const SSL_METHOD* method = SSLv23_client_method();
-        ssl_ctx = SSL_CTX_new_ex(provider, provider.propquery_tls_str(), method);
+        ssl_ctx = SSL_CTX_new_ex(provider, provider.propquery_default(), method);
 
         if (ssl_ctx == nullptr) {
             ERR_print_errors_fp(stderr);
@@ -683,7 +669,7 @@ bool WebsocketLibwebsockets::initialize_connection_options(std::shared_ptr<Conne
         }
 
         // Init TLS data
-        if (!tls_init(ssl_ctx, path_chain, path_key, custom_key, private_key_password)) {
+        if (!tls_init(ssl_ctx, path_chain, path_key, private_key_password)) {
             EVLOG_error << "Unable to init tls security options for websocket";
             return false;
         }


### PR DESCRIPTION
## Describe your changes

OpenSSL/TLS provider update to match libevse-security and everest-core

To better support TPM2 there were updates to everest-core (PR#1486) and libevse-security (PR#120).
This brings libocpp up to date.

replaces PR https://github.com/EVerest/libocpp/pull/1154

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

