### PR TITLE
fix: Correct port when scheme is not provided

### DIFF
--- a/lib/ocpp/common/websocket/websocket_uri.cpp
+++ b/lib/ocpp/common/websocket/websocket_uri.cpp
@@ -46,7 +46,11 @@ Uri Uri::parse_and_validate(std::string uri, std::string chargepoint_id, int sec
     bool scheme_added_workaround = false;
     if (uri.find("://") == std::string::npos) {
         scheme_added_workaround = true;
-        uri = "ws://" + uri;
+        if (security_profile >= security::SecurityProfile::TLS_WITH_BASIC_AUTHENTICATION) {
+            uri = "wss://" + uri;
+        } else {
+            uri = "ws://" + uri;
+        }
     }
 
     auto uri_temp = ev_uri(uri);

--- a/tests/lib/ocpp/common/test_websocket_uri.cpp
+++ b/tests/lib/ocpp/common/test_websocket_uri.cpp
@@ -35,3 +35,13 @@ TEST(WebsocketUriTest, AppendingIdentity) {
     EXPECT_EQ(Uri::parse_and_validate("ws://test.uri.com/path/cp0001", "cp0001", 1).string(),
               "ws://test.uri.com/path/cp0001");
 }
+
+TEST(WebsocketUriTest, SetsCorrectPortForUri) {
+    auto uri_temp1 = Uri(Uri::parse_and_validate("test.uri.com/path/", "cp0001", 1));
+    EXPECT_EQ(uri_temp1.string(), "ws://test.uri.com/path/cp0001");
+    EXPECT_EQ(uri_temp1.get_port(), uri_default_port);
+
+    auto uri_temp2 = Uri(Uri::parse_and_validate("test.uri.com/path/", "cp0001", 2));
+    EXPECT_EQ(uri_temp2.string(), "wss://test.uri.com/path/cp0001");
+    EXPECT_EQ(uri_temp2.get_port(), uri_default_secure_port);
+}


### PR DESCRIPTION
provided

Signed-off-by: Christofer Gilje Skjæveland <christofer.skjaeveland@zaptec.com>

## Describe your changes
This change ensures that URLs without an explicit scheme are handled correctly for security profiles 2 and 3.

Previously, when a URL like **test.uri.com/path/** was provided under security profile 2, it would incorrectly resolve to **wss://test.uri.com:80/path/cp0001**. With this fix, it now falls back to the correct default secure port, resulting in **wss://test.uri.com:443/path/cp0001**.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

