### PR TITLE
fix: expose reset_state_machine method to client

### DIFF
--- a/lib/ocpp/v16/charge_point.cpp
+++ b/lib/ocpp/v16/charge_point.cpp
@@ -53,6 +53,10 @@ bool ChargePoint::restart(const std::map<int, ChargePointStatus>& connector_stat
     return this->charge_point->restart(connector_status_map, bootreason);
 }
 
+void ChargePoint::reset_state_machine(const std::map<int, ChargePointStatus>& connector_status_map) {
+    return this->charge_point->reset_state_machine(connector_status_map);
+}
+
 bool ChargePoint::stop() {
     return this->charge_point->stop();
 }


### PR DESCRIPTION
The charge_point.hpp header for OCPP v16 implementation provides `reset_state_machine` that accepts a connector status map.  This function should be exposed to client to help update the state of the connectors.
