### PR TITLE
fix: fetch readonly flag for AuthorizeRemoteTxRequests from Schema

### DIFF
--- a/include/ocpp/v16/charge_point_configuration.hpp
+++ b/include/ocpp/v16/charge_point_configuration.hpp
@@ -21,6 +21,7 @@ private:
     json custom_schema;
     json internal_schema;
     bool core_schema_unlock_connector_on_ev_side_disconnect_ro_value;
+    bool core_schema_authorize_remote_tx_requests_ro_value;
     fs::path user_config_path;
 
     std::set<SupportedFeatureProfiles> supported_feature_profiles;

--- a/lib/ocpp/v16/charge_point_configuration.cpp
+++ b/lib/ocpp/v16/charge_point_configuration.cpp
@@ -70,6 +70,8 @@ ChargePointConfiguration::ChargePointConfiguration(const std::string& config, co
             const auto core_schema = json::parse(core_schema_file);
             this->core_schema_unlock_connector_on_ev_side_disconnect_ro_value =
                 core_schema["properties"]["UnlockConnectorOnEVSideDisconnect"]["readOnly"];
+            this->core_schema_authorize_remote_tx_requests_ro_value =
+                core_schema["properties"]["AuthorizeRemoteTxRequests"]["readOnly"];
         }
     } catch (const json::parse_error& e) {
         EVLOG_error << "Error while parsing Core.json file.";
@@ -1280,7 +1282,7 @@ void ChargePointConfiguration::setAuthorizeRemoteTxRequests(bool enabled) {
 KeyValue ChargePointConfiguration::getAuthorizeRemoteTxRequestsKeyValue() {
     KeyValue kv;
     kv.key = "AuthorizeRemoteTxRequests";
-    kv.readonly = false;
+    kv.readonly = this->core_schema_authorize_remote_tx_requests_ro_value;
     kv.value.emplace(ocpp::conversions::bool_to_string(this->getAuthorizeRemoteTxRequests()));
     return kv;
 }


### PR DESCRIPTION
The OCPP 1.6 specs mention that the configuration key AuthorizeRemoteTxRequests can be ReadWrite or ReadOnly based on ChargingStation implementation. For our use case, we want it to be ReadOnly. With this fix the readonly flag for the concerned configuration key is fetched from Core schema profile.