### PR TITLE
Add ICCID and IMSI modem information to OCPP 2.0.1 BootNotificationRequest

### DIFF
--- a/lib/ocpp/v2/functional_blocks/provisioning.cpp
+++ b/lib/ocpp/v2/functional_blocks/provisioning.cpp
@@ -102,6 +102,20 @@ void Provisioning::boot_notification_req(const BootReasonEnum& reason, const boo
     charging_station.serialNumber.emplace(
         this->context.device_model.get_value<std::string>(ControllerComponentVariables::ChargeBoxSerialNumber));
 
+    auto iccid = this->context.device_model.get_optional_value<std::string>(ControllerComponentVariables::ICCID);
+    auto imsi = this->context.device_model.get_optional_value<std::string>(ControllerComponentVariables::IMSI);
+
+    if (iccid.has_value() || imsi.has_value()) {
+        Modem modem;
+        if (iccid.has_value()) {
+            modem.iccid.emplace(iccid.value());
+        }
+        if (imsi.has_value()) {
+            modem.imsi.emplace(imsi.value());
+        }
+        charging_station.modem.emplace(modem);
+    }
+
     req.reason = reason;
     req.chargingStation = charging_station;
 


### PR DESCRIPTION
## Describe your changes
Modify Provisioning::boot_notification_req() in lib/ocpp/v2/functional_blocks/provisioning.cpp to:

Read ICCID and IMSI values from the device model using get_optional_value<std::string>()
If either value is present, create a Modem object and populate the available fields
Attach the Modem object to charging_station.modem 

## Issue ticket number and link
EVerest/everest-core#1788 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] If OCPP 2.0.1 or OCPP2.1: I have updated the [OCPP 2.x status document](https://github.com/EVerest/libocpp/tree/main/doc/ocpp_2x_status.md)
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

