### PR TITLE
fix(v16): use configured OcspRequestInterval instead of hardcoded 12h default

### DIFF
--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -205,8 +205,7 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
             };
         this->ocsp_request_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() {
             this->update_ocsp_cache();
-            this->ocsp_request_timer->interval(
-                std::chrono::seconds(this->configuration->getOcspRequestInterval()));
+            this->ocsp_request_timer->interval(std::chrono::seconds(this->configuration->getOcspRequestInterval()));
         });
     }
 

--- a/lib/ocpp/v16/charge_point_impl.cpp
+++ b/lib/ocpp/v16/charge_point_impl.cpp
@@ -28,7 +28,6 @@ const auto ISO15118_PNC_VENDOR_ID = "org.openchargealliance.iso15118pnc";
 const auto CALIFORNIA_PRICING_VENDOR_ID = "org.openchargealliance.costmsg";
 const auto CLIENT_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
 const auto V2G_CERTIFICATE_TIMER_INTERVAL = std::chrono::hours(12);
-const auto OCSP_REQUEST_TIMER_INTERVAL = std::chrono::hours(12);
 const auto INITIAL_CERTIFICATE_REQUESTS_DELAY = std::chrono::seconds(60);
 const auto WEBSOCKET_INIT_DELAY = std::chrono::seconds(2);
 const auto DEFAULT_MESSAGE_QUEUE_SIZE_THRESHOLD = 2E5;
@@ -206,7 +205,8 @@ ChargePointImpl::ChargePointImpl(const std::string& config, const fs::path& shar
             };
         this->ocsp_request_timer = std::make_unique<Everest::SteadyTimer>(&this->io_context, [this]() {
             this->update_ocsp_cache();
-            this->ocsp_request_timer->interval(OCSP_REQUEST_TIMER_INTERVAL);
+            this->ocsp_request_timer->interval(
+                std::chrono::seconds(this->configuration->getOcspRequestInterval()));
         });
     }
 


### PR DESCRIPTION
## Describe your changes

The OCSP request timer callback in `ChargePointImpl` constructor uses a hardcoded 12-hour interval (`OCSP_REQUEST_TIMER_INTERVAL`) for recurring OCSP cache updates. This means the user-configured `OcspRequestInterval` value (default: 604800s / 7 days, minimum: 86400 / 1 day) is ignored at startup.

When the CSMS later updates the interval via `ChangeConfiguration`, the correct config-based value is used (line ~1966), but the initial timer setup never reads from configuration.

### Changes

- Replace `OCSP_REQUEST_TIMER_INTERVAL` with `std::chrono::seconds(this->configuration->getOcspRequestInterval())` in the timer callback (consistent with the pattern already used in the `ChangeConfiguration` handler)
- - Remove the now-unused `OCSP_REQUEST_TIMER_INTERVAL` constant
## Issue ticket number and link

Fixes https://github.com/EVerest/EVerest/issues/1991

## Checklist

- [x] My changes follow the existing code style
- [ ] - [x] I have performed a self-review of my code
- [ ] - [x] New and existing tests pass locally with my changes