### PR TITLE
fix(v16): correct drop_transaction_data to drop every second element

### DIFF
--- a/lib/ocpp/v16/utils.cpp
+++ b/lib/ocpp/v16/utils.cpp
@@ -15,7 +15,12 @@ size_t get_message_size(const ocpp::Call<StopTransactionRequest>& call) {
 void drop_transaction_data(size_t max_message_size, ocpp::Call<StopTransactionRequest>& call) {
     auto& transaction_data = call.msg.transactionData.value();
     while (get_message_size(call) > max_message_size && transaction_data.size() > 2) {
-        for (size_t i = 1; i < transaction_data.size() - 1; i = i + 2) {
+        // Drop every second message, keeping the first and last.
+        // Iterate backwards so that erase() does not shift the indices
+        // of elements we still need to remove.
+        int last = static_cast<int>(transaction_data.size()) - 2;
+        int start = (last % 2 == 0) ? last - 1 : last;
+        for (int i = start; i >= 1; i -= 2) {
             transaction_data.erase(transaction_data.begin() + i);
         }
     }

--- a/tests/lib/ocpp/v16/utils_tests.cpp
+++ b/tests/lib/ocpp/v16/utils_tests.cpp
@@ -39,8 +39,73 @@ TEST_F(UtilsTest, test_drop_transaction_data) {
     utils::drop_transaction_data(500, call);
     ASSERT_EQ(call.msg.transactionData.value().size(), 3);
     ASSERT_EQ(call.msg.transactionData.value().at(0).sampledValue.size(), 1);
-    ASSERT_EQ(call.msg.transactionData.value().at(1).sampledValue.size(), 4);
+    ASSERT_EQ(call.msg.transactionData.value().at(1).sampledValue.size(), 3);
     ASSERT_EQ(call.msg.transactionData.value().at(2).sampledValue.size(), 5);
+}
+
+TEST_F(UtilsTest, test_drop_transaction_data_six_elements) {
+    auto call = ocpp::Call<StopTransactionRequest>();
+
+    std::vector<TransactionData> transaction_data = {
+        {DateTime(), {{"1"}}},
+        {DateTime(), {{"1"}, {"2"}}},
+        {DateTime(), {{"1"}, {"2"}, {"3"}}},
+        {DateTime(), {{"1"}, {"2"}, {"3"}, {"4"}}},
+        {DateTime(), {{"1"}, {"2"}, {"3"}, {"4"}, {"5"}}},
+        {DateTime(), {{"1"}, {"2"}, {"3"}, {"4"}, {"5"}, {"6"}}},
+    };
+
+    call.msg.transactionData = transaction_data;
+    ASSERT_EQ(call.msg.transactionData.value().size(), 6);
+    utils::drop_transaction_data(500, call);
+    // Drop indices 1, 3 -> keep [0, 2, 4, 5]
+    ASSERT_EQ(call.msg.transactionData.value().size(), 4);
+    ASSERT_EQ(call.msg.transactionData.value().at(0).sampledValue.size(), 1);
+    ASSERT_EQ(call.msg.transactionData.value().at(1).sampledValue.size(), 3);
+    ASSERT_EQ(call.msg.transactionData.value().at(2).sampledValue.size(), 5);
+    ASSERT_EQ(call.msg.transactionData.value().at(3).sampledValue.size(), 6);
+}
+
+TEST_F(UtilsTest, test_drop_transaction_data_seven_elements) {
+    auto call = ocpp::Call<StopTransactionRequest>();
+
+    std::vector<TransactionData> transaction_data = {
+        {DateTime(), {{"a"}}},
+        {DateTime(), {{"a"}, {"b"}}},
+        {DateTime(), {{"a"}, {"b"}, {"c"}}},
+        {DateTime(), {{"a"}, {"b"}, {"c"}, {"d"}}},
+        {DateTime(), {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}}},
+        {DateTime(), {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}}},
+        {DateTime(), {{"a"}, {"b"}, {"c"}, {"d"}, {"e"}, {"f"}, {"g"}}},
+    };
+
+    call.msg.transactionData = transaction_data;
+    ASSERT_EQ(call.msg.transactionData.value().size(), 7);
+    utils::drop_transaction_data(500, call);
+    // Drop indices 1, 3, 5 -> keep [0, 2, 4, 6]
+    ASSERT_EQ(call.msg.transactionData.value().size(), 4);
+    ASSERT_EQ(call.msg.transactionData.value().at(0).sampledValue.size(), 1);
+    ASSERT_EQ(call.msg.transactionData.value().at(1).sampledValue.size(), 3);
+    ASSERT_EQ(call.msg.transactionData.value().at(2).sampledValue.size(), 5);
+    ASSERT_EQ(call.msg.transactionData.value().at(3).sampledValue.size(), 7);
+}
+
+TEST_F(UtilsTest, test_drop_transaction_data_preserves_minimum) {
+    auto call = ocpp::Call<StopTransactionRequest>();
+
+    std::vector<TransactionData> transaction_data = {
+        {DateTime(), {{"1"}}},
+        {DateTime(), {{"1"}, {"2"}}},
+        {DateTime(), {{"1"}, {"2"}, {"3"}}},
+    };
+
+    call.msg.transactionData = transaction_data;
+    ASSERT_EQ(call.msg.transactionData.value().size(), 3);
+    utils::drop_transaction_data(1, call);
+    // With 3 elements, drop index 1 -> keep [0, 2], then size == 2 so loop stops
+    ASSERT_EQ(call.msg.transactionData.value().size(), 2);
+    ASSERT_EQ(call.msg.transactionData.value().at(0).sampledValue.size(), 1);
+    ASSERT_EQ(call.msg.transactionData.value().at(1).sampledValue.size(), 3);
 }
 
 } // namespace v16


### PR DESCRIPTION
The `drop_transaction_data` function in `v16/utils.cpp` was supposed to drop every second MeterValue while keeping the first and last (per OCPP 1.6 Appendix). The implementation iterated forward with `erase()`, but each removal shifted subsequent indices down, causing the loop to skip elements.

With 5 messages `[0, 1, 2, 3, 4]` the old code kept `[0, 3, 4]` (after two while-loop passes) instead of `[0, 2, 4]` in a single pass. The middle message was lost unnecessarily.

I switched to backward iteration from the highest odd index so that removals never affect the positions of elements still to be processed. Also updated the existing test expectation and added three new test cases covering 6-element, 7-element, and minimum-preservation scenarios.

Fixes EVerest/EVerest#1990